### PR TITLE
Use enums for measurands

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -29,6 +29,7 @@ from ocpp.v16.enums import (
     ClearChargingProfileStatus,
     ConfigurationStatus,
     DataTransferStatus,
+    Measurand,
     RegistrationStatus,
     RemoteStartStopStatus,
     ResetStatus,
@@ -582,12 +583,12 @@ class ChargePoint(cp):
             status == ChargePointStatus.suspended_ev
             or status == ChargePointStatus.suspended_evse
         ):
-            if "Current.Import" in self._metrics:
-                self._metrics["Current.Import"] = 0
-            if "Power.Active.Import" in self._metrics:
-                self._metrics["Power.Active.Import"] = 0
-            if "Power.Reactive.Import" in self._metrics:
-                self._metrics["Power.Reactive.Import"] = 0
+            if Measurand.current_import in self._metrics:
+                self._metrics[Measurand.current_import] = 0
+            if Measurand.power_active_import in self._metrics:
+                self._metrics[Measurand.power_active_import] = 0
+            if Measurand.power_reactive_import in self._metrics:
+                self._metrics[Measurand.power_reactive_import] = 0
         self._metrics["Error.Code"] = error_code
         return call_result.StatusNotificationPayload()
 
@@ -625,12 +626,12 @@ class ChargePoint(cp):
             self._metrics["Session.Energy"] = round(
                 int(meter_stop) / 1000 - float(self._metrics["Meter.Start"]), 1
             )
-        if "Current.Import" in self._metrics:
-            self._metrics["Current.Import"] = 0
-        if "Power.Active.Import" in self._metrics:
-            self._metrics["Power.Active.Import"] = 0
-        if "Power.Reactive.Import" in self._metrics:
-            self._metrics["Power.Reactive.Import"] = 0
+        if Measurand.current_import in self._metrics:
+            self._metrics[Measurand.current_import] = 0
+        if Measurand.power_active_import in self._metrics:
+            self._metrics[Measurand.power_active_import] = 0
+        if Measurand.power_reactive_import in self._metrics:
+            self._metrics[Measurand.power_reactive_import] = 0
         return call_result.StopTransactionPayload(
             id_tag_info={"status": AuthorizationStatus.accepted}
         )

--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -1,7 +1,7 @@
 """Define constants for OCPP integration."""
 import homeassistant.const as ha
 
-from ocpp.v16.enums import UnitOfMeasure
+from ocpp.v16.enums import Measurand, UnitOfMeasure
 
 DOMAIN = "ocpp"
 CONF_METER_INTERVAL = "meter_interval"
@@ -49,30 +49,30 @@ SERVICE_UNLOCK = "unlock"
 
 # Ocpp supported measurands
 MEASURANDS = [
-    "Current.Export",
-    "Current.Import",
-    "Current.Offered",
-    "Energy.Active.Export.Register",
-    "Energy.Active.Import.Register",
-    "Energy.Reactive.Export.Register",
-    "Energy.Reactive.Import.Register",
-    "Energy.Active.Export.Interval",
-    "Energy.Active.Import.Interval",
-    "Energy.Reactive.Export.Interval",
-    "Energy.Reactive.Import.Interval",
-    "Frequency",
-    "Power.Active.Export",
-    "Power.Active.Import",
-    "Power.Factor",
-    "Power.Offered",
-    "Power.Reactive.Export",
-    "Power.Reactive.Import",
-    "RPM",
-    "SoC",
-    "Temperature",
-    "Voltage",
+    Measurand.current_export,
+    Measurand.current_import,
+    Measurand.current_offered,
+    Measurand.energy_active_export_register,
+    Measurand.energy_active_import_register,
+    Measurand.energy_reactive_export_register,
+    Measurand.energy_reactive_import_register,
+    Measurand.energy_active_export_interval,
+    Measurand.energy_active_import_interval,
+    Measurand.energy_reactive_export_interval,
+    Measurand.energy_reactive_import_interval,
+    Measurand.frequency,
+    Measurand.power_active_export,
+    Measurand.power_active_import,
+    Measurand.power_factor,
+    Measurand.power_offered,
+    Measurand.power_reactive_export,
+    Measurand.power_reactive_import,
+    Measurand.rpm,
+    Measurand.soc,
+    Measurand.temperature,
+    Measurand.voltage,
 ]
-DEFAULT_MEASURAND = "Energy.Active.Import.Register"
+DEFAULT_MEASURAND = Measurand.energy_active_import_register
 DEFAULT_MONITORED_VARIABLES = ",".join(MEASURANDS)
 DEFAULT_ENERGY_UNIT = UnitOfMeasure.wh
 DEFAULT_POWER_UNIT = UnitOfMeasure.w


### PR DESCRIPTION
I've replaced measurand names with the constants provided by ocpp.v16.enums.Measurand.
Ideally, I would like to make api.py string literal free, this will make linting much more effective.
Currently you can only detect runtime if you've make an error in one of the strings...
