### PR TITLE
Update current for 3 phase charger

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -716,10 +716,7 @@ class ChargePoint(cp):
                     + value[Phase.l2.value]
                     + value[Phase.l3.value]
                 )
-                if sum > 0:
-                    self._metrics[metric] = round(sum / 3, 1)
-                else:
-                    self._metrics[metric] = round(sum, 1)
+            self._metrics[metric] = round(sum, 1)
             self._extra_attr[metric] = value
 
     @on(Action.MeterValues)


### PR DESCRIPTION
Switched to presenting overall current,  rather than average phase current for consistency between single and 3 phase chargers, so that overall charger real power = power.factor x current.import x voltage.