### PR TITLE
New metric added to track websocket Reconnects

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -702,6 +702,7 @@ class ChargePoint(cp):
     async def reconnect(self, connection):
         """Reconnect charge point."""
         self._connection = connection
+        self._metrics[cstat.reconnects.value].value += 1
         try:
             self.status = STATE_OK
             await super().start()

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -274,6 +274,7 @@ class ChargePoint(cp):
         self._metrics[csess.session_energy.value].unit = UnitOfMeasure.kwh.value
         self._metrics[csess.meter_start.value].unit = UnitOfMeasure.kwh.value
         self._attr_supported_features: int = 0
+        self._metrics[cstat.reconnects.value].value: int = 0
 
     async def post_connect(self):
         """Logic to be executed right after a charger connects."""

--- a/custom_components/ocpp/enums.py
+++ b/custom_components/ocpp/enums.py
@@ -28,6 +28,7 @@ class HAChargerStatuses(str, Enum):
     error_code = "Error.Code"
     stop_reason = "Stop.Reason"
     firmware_status = "FW.Status"
+    reconnects = "Reconnects"
 
 
 class HAChargerDetails(str, Enum):


### PR DESCRIPTION
This can be used to understand whether there may underlying network issues causing ocpp integration to become erratic/unstable