### PR TITLE
add close_timeout

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -139,6 +139,7 @@ class CentralSystem:
             self.port,
             subprotocols=self.subprotocol,
             ping_timeout=None,
+            close_timeout=10,
         )
         self._server = server
         return self


### PR DESCRIPTION
to avoid a websocket half-close which results in the charger staying connected whilst the server thinks it is disconnected see https://www.excentis.com/blog/tcp-half-close-cool-feature-now-broken
https://github.com/eclipse/jetty.project/issues/3671