### PR TITLE
Fix websockets 10 test error

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -138,7 +138,7 @@ class CentralSystem:
             self.on_connect,
             self.host,
             self.port,
-            subprotocols=self.subprotocol,
+            subprotocols=[self.subprotocol],
             ping_timeout=None,
             close_timeout=10,
         )


### PR DESCRIPTION
@lbbrhzn , suggest moving to 10 it improves handling of handshake and closing eg addresses a half close situation