### PR TITLE
Set connection to None on disconnect

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -722,6 +722,7 @@ class ChargePoint(cp):
         except websockets.exceptions.WebSocketException as e:
             _LOGGER.debug("Websockets exception: %s", e)
         finally:
+            await self._connection.close()
             self._connection = None
             self.status = STATE_UNAVAILABLE
 
@@ -735,6 +736,7 @@ class ChargePoint(cp):
         except websockets.exceptions.WebSocketException as e:
             _LOGGER.debug("Websockets exception: %s", e)
         finally:
+            await self._connection.close()
             self._connection = None
             self.status = STATE_UNAVAILABLE
 

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -722,6 +722,7 @@ class ChargePoint(cp):
         except websockets.exceptions.WebSocketException as e:
             _LOGGER.debug("Websockets exception: %s", e)
         finally:
+            self._connection = None
             self.status = STATE_UNAVAILABLE
 
     async def reconnect(self, connection):
@@ -734,6 +735,7 @@ class ChargePoint(cp):
         except websockets.exceptions.WebSocketException as e:
             _LOGGER.debug("Websockets exception: %s", e)
         finally:
+            self._connection = None
             self.status = STATE_UNAVAILABLE
 
     async def async_update_device_info(self, boot_info: dict):


### PR DESCRIPTION
Hopefully stops integration responding to the charger when there has been a websocket half-close, allowing charger to timeout websocket and reconnect