### PR TITLE
Upon Suspend events, energy flow is assumed to be 0 in both directions

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -964,6 +964,12 @@ class ChargePoint(cp):
                 self._metrics[Measurand.power_active_import.value].value = 0
             if Measurand.power_reactive_import.value in self._metrics:
                 self._metrics[Measurand.power_reactive_import.value].value = 0
+            if Measurand.current_export.value in self._metrics:
+                self._metrics[Measurand.current_export.value].value = 0
+            if Measurand.power_active_export.value in self._metrics:
+                self._metrics[Measurand.power_active_export.value].value = 0
+            if Measurand.power_reactive_export.value in self._metrics:
+                self._metrics[Measurand.power_reactive_export.value].value = 0
         self._metrics[cstat.error_code.value].value = error_code
         self.hass.async_create_task(self.central.update(self.central.cpid))
         return call_result.StatusNotificationPayload()
@@ -1018,6 +1024,12 @@ class ChargePoint(cp):
             self._metrics[Measurand.power_active_import.value].value = 0
         if Measurand.power_reactive_import.value in self._metrics:
             self._metrics[Measurand.power_reactive_import.value].value = 0
+        if Measurand.current_export.value in self._metrics:
+            self._metrics[Measurand.current_export.value].value = 0
+        if Measurand.power_active_export.value in self._metrics:
+            self._metrics[Measurand.power_active_export.value].value = 0
+        if Measurand.power_reactive_export.value in self._metrics:
+            self._metrics[Measurand.power_reactive_export.value].value = 0
         self.hass.async_create_task(self.central.update(self.central.cpid))
         return call_result.StopTransactionPayload(
             id_tag_info={om.status.value: AuthorizationStatus.accepted.value}


### PR DESCRIPTION
The OCPP reference guide specifies:
* Current.Export Instantaneous current flow from EV
* Current.Import Instantaneous current flow to EV

My Grizzl-E Smart EVSE actually sends the data points in the reverse direction (go figure, but the integration still works https://github.com/lbbrhzn/ocpp/issues/224 ) and does not send any additionnal Current.* samples after the EVSE reports the Suspend event.

``` 
[2,"4011002226dbd69865","MeterValues",{"connectorId":1,"meterValue":[{"timestamp":"2021-12-13T11:04:52.001Z","sampledValue":[{"measurand":"Current.Export","unit":"A","value":"28.00"}]}],"transactionId":1639405855}]
[2,"401100222689a1664a","MeterValues",{"connectorId":1,"meterValue":[{"timestamp":"2021-12-13T11:06:52.001Z","sampledValue":[{"measurand":"Current.Export","unit":"A","value":"27.79"}]}],"transactionId":1639405855}]
[2,"40110022262216ccd6","StatusNotification",{"errorCode":"NoError","status":"SuspendedEV","timestamp":"2021-12-13T11:07:36.001Z","info":"Charging->SuspendedEV on S2 open","connectorId":1}]
``` 

In theory I understand both metrics should be set to 0 if the current flow is suspended -- current code only covered for import values.

Without this patch, the last reported value is kept as the current energy flow and makes HA graphs incorrect.