### PR TITLE
Fix voltage when L1 reported, and L2,L3 are 0

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -800,17 +800,16 @@ class ChargePoint(cp):
                     and (Phase.l2_n.value in phase_info)
                     and (Phase.l3_n.value in phase_info)
                 ):
-                    # Multiple line-neutral voltages are averaged.
-                    metric_value = (
-                        phase_info.get(Phase.l1_n.value, 0)
-                        + phase_info.get(Phase.l2_n.value, 0)
-                        + phase_info.get(Phase.l3_n.value, 0)
-                    ) / 3
-                elif (Phase.l1_n.value in phase_info) and (
-                    phase_info.get(Phase.l2_n.value, 0) == 0
-                ):
-                    # Single line-neutral voltages are copied
-                    metric_value = phase_info.get(Phase.l1_n.value, 0)
+                    if (phase_info.get(Phase.l2_n.value) == 0):
+                        # Single line-neutral voltages are copied
+                        metric_value = phase_info.get(Phase.l1_n.value, 0)
+                    else:
+                        # Multiple line-neutral voltages are averaged.
+                        metric_value = (
+                            phase_info.get(Phase.l1_n.value, 0)
+                            + phase_info.get(Phase.l2_n.value, 0)
+                            + phase_info.get(Phase.l3_n.value, 0)
+                        ) / 3
                 elif Phase.l1_l2.value in phase_info:
                     # Line-line voltages are converted to line-neutral and averaged.
                     metric_value = (

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -844,10 +844,10 @@ class ChargePoint(cp):
                     phase_info,
                     metric_value,
                 )
-                if unit == DEFAULT_POWER_UNIT:
+                if phase_info.get(om.unit.value) == DEFAULT_POWER_UNIT:
                     self._metrics[metric].value = float(metric_value) / 1000
                     self._metrics[metric].unit = HA_POWER_UNIT
-                elif unit == DEFAULT_ENERGY_UNIT:
+                elif phase_info.get(om.unit.value) == DEFAULT_ENERGY_UNIT:
                     self._metrics[metric].value = float(metric_value) / 1000
                     self._metrics[metric].unit = HA_ENERGY_UNIT
                 else:

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -806,9 +806,8 @@ class ChargePoint(cp):
                         + phase_info.get(Phase.l2_n.value, 0)
                         + phase_info.get(Phase.l3_n.value, 0)
                     ) / 3
-                elif (
-                    (Phase.l1_n.value in phase_info)
-                    and (phase_info.get(Phase.l2_n.value, 0) == 0)
+                elif (Phase.l1_n.value in phase_info) and (
+                    phase_info.get(Phase.l2_n.value, 0) == 0
                 ):
                     # Single line-neutral voltages are copied
                     metric_value = phase_info.get(Phase.l1_n.value, 0)

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -800,7 +800,7 @@ class ChargePoint(cp):
                     and (Phase.l2_n.value in phase_info)
                     and (Phase.l3_n.value in phase_info)
                 ):
-                    if (phase_info.get(Phase.l2_n.value) == 0):
+                    if phase_info.get(Phase.l2_n.value) == 0:
                         # Single line-neutral voltages are copied
                         metric_value = phase_info.get(Phase.l1_n.value, 0)
                     else:

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -806,13 +806,12 @@ class ChargePoint(cp):
                         + phase_info.get(Phase.l2_n.value, 0)
                         + phase_info.get(Phase.l3_n.value, 0)
                     ) / 3
-                elif Phase.l1_n.value in phase_info:
+                elif (
+                    (Phase.l1_n.value in phase_info)
+                    and (phase_info.get(Phase.l2_n.value, 0) == 0)
+                ):
                     # Single line-neutral voltages are copied
                     metric_value = phase_info.get(Phase.l1_n.value, 0)
-                elif Phase.l2_n.value in phase_info:
-                    metric_value = phase_info.get(Phase.l2_n.value, 0)
-                elif Phase.l3_n.value in phase_info:
-                    metric_value = phase_info.get(Phase.l3_n.value, 0)
                 elif Phase.l1_l2.value in phase_info:
                     # Line-line voltages are converted to line-neutral and averaged.
                     metric_value = (


### PR DESCRIPTION
I think a change in the voltage section is required also based on "MeterValues" log in #233