### PR TITLE
Add notifications for charger errors

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -1112,7 +1112,7 @@ class ChargePoint(cp):
         """Notify user via HA web frontend."""
         await self.hass.services.async_call(
             PN_DOMAIN,
-            "persistent_notification.create",
+            "create",
             service_data={
                 "title": title,
                 "message": msg,

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -7,7 +7,7 @@ from math import sqrt
 import time
 from typing import Dict
 
-from homeassistant.component.persistent_notification import DOMAIN as PN_DOMAIN
+from homeassistant.components.persistent_notification import DOMAIN as PN_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OK, STATE_UNAVAILABLE, TIME_MINUTES
 from homeassistant.core import HomeAssistant

--- a/custom_components/ocpp/manifest.json
+++ b/custom_components/ocpp/manifest.json
@@ -6,6 +6,7 @@
   "issue_tracker": "https://github.com/lbbrhzn/ocpp/issues",
   "version": "0.3.26",
   "config_flow": true,
+  "after_dependencies": ["persistent_notification"]
   "codeowners": [
     "@lbbrhzn"
   ],

--- a/custom_components/ocpp/manifest.json
+++ b/custom_components/ocpp/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/lbbrhzn/ocpp/issues",
   "version": "0.3.26",
   "config_flow": true,
-  "after_dependencies": ["persistent_notification"]
+  "after_dependencies": ["persistent_notification"],
   "codeowners": [
     "@lbbrhzn"
   ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def skip_notifications_fixture():
     """Skip notification calls."""
     with patch("homeassistant.components.persistent_notification.async_create"), patch(
         "homeassistant.components.persistent_notification.async_dismiss"
-    ):
+    ), patch("custom_components.ocpp.api.ChargePoint.notify_ha"):
         yield
 
 


### PR DESCRIPTION
Charger errors reported as a persistent notification eg Unsupported, Rejected to alert users the request via the integration has failed. 