### PR TITLE
Add sampling config of meter when idle

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -50,6 +50,7 @@ from .const import (
     CONF_CPID,
     CONF_CSID,
     CONF_HOST,
+    CONF_IDLE_INTERVAL,
     CONF_METER_INTERVAL,
     CONF_MONITORED_VARIABLES,
     CONF_PORT,
@@ -372,6 +373,10 @@ class ChargePoint(cp):
             await self.configure(
                 ckey.meter_value_sample_interval.value,
                 str(self.entry.data[CONF_METER_INTERVAL]),
+            )
+            await self.configure(
+                ckey.clock_aligned_data_interval.value,
+                str(self.entry.data[CONF_IDLE_INTERVAL]),
             )
             #            await self.configure(
             #                "StopTxnSampledData", ",".join(self.entry.data[CONF_MONITORED_VARIABLES])

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -6,12 +6,14 @@ from .const import (
     CONF_CPID,
     CONF_CSID,
     CONF_HOST,
+    CONF_IDLE_INTERVAL,
     CONF_METER_INTERVAL,
     CONF_MONITORED_VARIABLES,
     CONF_PORT,
     DEFAULT_CPID,
     DEFAULT_CSID,
     DEFAULT_HOST,
+    DEFAULT_IDLE_INTERVAL,
     DEFAULT_MEASURAND,
     DEFAULT_METER_INTERVAL,
     DEFAULT_PORT,
@@ -26,6 +28,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_CSID, default=DEFAULT_CSID): str,
         vol.Required(CONF_CPID, default=DEFAULT_CPID): str,
         vol.Required(CONF_METER_INTERVAL, default=DEFAULT_METER_INTERVAL): int,
+        vol.Required(CONF_IDLE_INTERVAL, default=DEFAULT_IDLE_INTERVAL): int,
     }
 )
 STEP_USER_MEASURANDS_SCHEMA = vol.Schema(

--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -2,15 +2,14 @@
 import homeassistant.components.input_number as input_number
 import homeassistant.const as ha
 
-from ocpp.v16.enums import ChargePointStatus, Measurand, UnitOfMeasure
-
-from .enums import HAChargerServices, HAChargerStatuses
+from ocpp.v16.enums import Measurand, UnitOfMeasure
 
 CONF_CPI = "charge_point_identity"
 CONF_CPID = "cpid"
 CONF_CSID = "csid"
 CONF_HOST = ha.CONF_HOST
 CONF_ICON = ha.CONF_ICON
+CONF_IDLE_INTERVAL = "idle_interval"
 CONF_METER_INTERVAL = "meter_interval"
 CONF_MODE = ha.CONF_MODE
 CONF_MONITORED_VARIABLES = ha.CONF_MONITORED_VARIABLES
@@ -27,6 +26,7 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 9000
 DEFAULT_SUBPROTOCOL = "ocpp1.6"
 DEFAULT_METER_INTERVAL = 60
+DEFAULT_IDLE_INTERVAL = 900
 DOMAIN = "ocpp"
 ICON = "mdi:ev-station"
 SLEEP_TIME = 60
@@ -70,27 +70,6 @@ DEFAULT_ENERGY_UNIT = UnitOfMeasure.wh.value
 DEFAULT_POWER_UNIT = UnitOfMeasure.w.value
 HA_ENERGY_UNIT = UnitOfMeasure.kwh.value
 HA_POWER_UNIT = UnitOfMeasure.kw.value
-
-# Switch configuration definitions
-# At a minimum define switch name and on service call,
-# metric and condition combination can be used to drive switch state, use default to set initial state to True
-SWITCH_CHARGE = {
-    "name": "Charge_Control",
-    "on": HAChargerServices.service_charge_start.name,
-    "off": HAChargerServices.service_charge_stop.name,
-    "metric": HAChargerStatuses.status.value,
-    "condition": ChargePointStatus.charging.value,
-}
-SWITCH_AVAILABILITY = {
-    "name": "Availability",
-    "on": HAChargerServices.service_availability.name,
-    "off": HAChargerServices.service_availability.name,
-    "default": True,
-    "metric": HAChargerStatuses.status.value,
-    "condition": ChargePointStatus.available.value,
-}
-
-SWITCHES = [SWITCH_CHARGE, SWITCH_AVAILABILITY]
 
 # Where a HA unit does not exist use Ocpp unit
 UNITS_OCCP_TO_HA = {

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -9,7 +9,8 @@
                     "port": "Central system port number",
                     "csid": "Central system identity",
                     "cpid": "Charge point identity",
-                    "meter_interval": "Meter interval (seconds)"
+                    "meter_interval": "Charging sample interval (seconds)",
+                    "idle_interval": "Charger idle sampling interval (seconds)",
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -10,7 +10,7 @@
                     "csid": "Central system identity",
                     "cpid": "Charge point identity",
                     "meter_interval": "Charging sample interval (seconds)",
-                    "idle_interval": "Charger idle sampling interval (seconds)",
+                    "idle_interval": "Charger idle sampling interval (seconds)"
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -9,7 +9,8 @@
                     "port": "Central system port number",
                     "csid": "Central system identity",
                     "cpid": "Charge point identity",
-                    "meter_interval": "Meter interval (seconds)"
+                    "meter_interval": "Charging sample interval (seconds)",
+                    "idle_interval": "Charger idle sampling interval (seconds)",
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -10,7 +10,7 @@
                     "csid": "Central system identity",
                     "cpid": "Charge point identity",
                     "meter_interval": "Charging sample interval (seconds)",
-                    "idle_interval": "Charger idle sampling interval (seconds)",
+                    "idle_interval": "Charger idle sampling interval (seconds)"
                 }
             },
             "measurands": {


### PR DESCRIPTION
This PR adds regular sampling of the meter when it is not charging (ie idle) to the integration configuration. @lbbrhzn please add the Dutch translation 