### PR TITLE
improve reconnect and trigger boot notification

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -3,7 +3,7 @@ default_config:
 logger:
   default: info
   logs:
-    custom_components.occp: debug
+    custom_components.ocpp: debug
 
 # If you need to debug uncomment the line below (doc: https://www.home-assistant.io/integrations/debugpy/)
 # debugpy:

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -153,7 +153,7 @@ class CentralSystem:
         self._server = server
         return self
 
-    async def on_connect(self, websocket: websockets.connection, path: str):
+    async def on_connect(self, websocket, path: str):
         """Request handler executed for every new OCPP connection."""
 
         try:
@@ -300,6 +300,8 @@ class ChargePoint(cp):
         self._requires_reboot = False
         self.preparing = asyncio.Event()
         self._transactionId = 0
+        self.triggered_boot_notification = False
+        self.received_boot_notification = False
         self._metrics = defaultdict(lambda: Metric(None, None))
         self._metrics[cdet.identifier.value].value = id
         self._metrics[csess.session_time.value].unit = TIME_MINUTES
@@ -367,7 +369,8 @@ class ChargePoint(cp):
             await asyncio.sleep(2)
             await self.get_supported_features()
             if prof.REM in self._attr_supported_features:
-                await self.trigger_boot_notification()
+                if self.received_boot_notification is False:
+                    await self.trigger_boot_notification()
                 await self.trigger_status_notification()
             await self.become_operative()
             await self.get_configuration(ckey.heartbeat_interval.value)
@@ -457,8 +460,10 @@ class ChargePoint(cp):
         )
         resp = await self.call(req)
         if resp.status == TriggerMessageStatus.accepted:
+            self.triggered_boot_notification = True
             return True
         else:
+            self.triggered_boot_notification = False
             _LOGGER.warning("Failed with response: %s", resp.status)
             return False
 
@@ -778,27 +783,23 @@ class ChargePoint(cp):
 
         return resp
 
-    async def monitor_connection(self):
+    async def monitor_connection(self, connection):
         """Monitor the connection, by measuring the connection latency."""
         timeout = 20
         self._metrics[cstat.latency_ping.value].unit = "ms"
         self._metrics[cstat.latency_pong.value].unit = "ms"
 
         try:
-            while True:
-                if self._connection.open is False:
-                    _LOGGER.debug(f"Connection not open '{self.id}'")
-                    await asyncio.sleep(timeout)
-                    continue
-                t0 = time.perf_counter()
-                pong_waiter = await asyncio.wait_for(
-                    self._connection.ping(), timeout=timeout
-                )
-                t1 = time.perf_counter()
+            while connection.open:
+                time0 = time.perf_counter()
+                latency_ping = timeout * 1000
+                pong_waiter = await asyncio.wait_for(connection.ping(), timeout=timeout)
+                time1 = time.perf_counter()
+                latency_ping = round(time1 - time0, 3)
+                latency_pong = timeout * 1000
                 await asyncio.wait_for(pong_waiter, timeout=timeout)
-                t2 = time.perf_counter()
-                latency_ping = round(1000 * (t1 - t0))
-                latency_pong = round(1000 * (t2 - t1))
+                time2 = time.perf_counter()
+                latency_pong = round(time2 - time1, 3)
                 _LOGGER.debug(
                     f"Connection latency from '{self.central.csid}' to '{self.id}': ping={latency_ping} ms, pong={latency_pong} ms",
                 )
@@ -808,16 +809,18 @@ class ChargePoint(cp):
 
         except asyncio.TimeoutError:
             _LOGGER.debug(f"Timeout in connection '{self.id}'")
-            self._connection.close()
-        except websockets.exceptions.ConnectionClosed as connection_closed_exception:
-            _LOGGER.debug(
-                f"Connection closed to '{self.id}': {connection_closed_exception}"
-            )
+            self._metrics[cstat.latency_ping.value].value = latency_ping
+            self._metrics[cstat.latency_pong.value].value = latency_pong
+        except websockets.exceptions.ConnectionClosed:
+            pass
         except Exception as other_exception:
             _LOGGER.error(
                 f"Unexpected exception in connection to '{self.id}': {other_exception}",
                 exc_info=True,
             )
+        if connection.open:
+            await connection.close()
+        _LOGGER.debug(f"Stopped monitoring connection to '{self.id}'")
 
     async def _handle_call(self, msg):
         try:
@@ -828,31 +831,35 @@ class ChargePoint(cp):
 
     async def start(self):
         """Start charge point."""
+        connection = self._connection
         try:
             await asyncio.gather(
-                super().start(), self.monitor_connection(), self.post_connect()
+                super().start(),
+                self.monitor_connection(connection),
+                self.post_connect(),
             )
         except websockets.exceptions.WebSocketException as e:
             _LOGGER.debug("Websockets exception: %s", e)
         finally:
-            await self._connection.close()
+            await connection.close()
             self.status = STATE_UNAVAILABLE
 
-    async def reconnect(self, connection: websockets.connection):
+    async def reconnect(self, connection):
         """Reconnect charge point."""
         # close old connection, if needed
-        if self._connection is not None:
+        if self._connection.open:
             await self._connection.close()
+            await asyncio.sleep(1)
         # use the new connection
         self._connection = connection
         self._metrics[cstat.reconnects.value].value += 1
         try:
             self.status = STATE_OK
-            await asyncio.gather(super().start(), self.monitor_connection())
-        except websockets.exceptions.WebSocketException as e:
-            _LOGGER.debug("Websockets exception: %s", e)
+            await asyncio.gather(super().start(), self.monitor_connection(connection))
+        except websockets.exceptions.WebSocketException as websocket_exception:
+            _LOGGER.debug("Websockets exception: %s", websocket_exception)
         finally:
-            await self._connection.close()
+            await connection.close()
             self.status = STATE_UNAVAILABLE
 
     async def async_update_device_info(self, boot_info: dict):
@@ -887,13 +894,13 @@ class ChargePoint(cp):
             return average
 
         measurand_data = {}
-        for sv in data:
+        for item in data:
             # create ordered Dict for each measurand, eg {"voltage":{"unit":"V","L1":"230"...}}
-            measurand = sv.get(om.measurand.value, None)
-            phase = sv.get(om.phase.value, None)
-            value = sv.get(om.value.value, None)
-            unit = sv.get(om.unit.value, None)
-            context = sv.get(om.context.value, None)
+            measurand = item.get(om.measurand.value, None)
+            phase = item.get(om.phase.value, None)
+            value = item.get(om.value.value, None)
+            unit = item.get(om.unit.value, None)
+            context = item.get(om.context.value, None)
             if measurand is not None and phase is not None:
                 if measurand not in measurand_data:
                     measurand_data[measurand] = {}
@@ -1036,8 +1043,8 @@ class ChargePoint(cp):
             interval=3600,
             status=RegistrationStatus.accepted.value,
         )
+        self.received_boot_notification = True
         _LOGGER.debug("Received boot notification for %s: %s", self.id, kwargs)
-        self.hass.async_create_task(self.notify_ha(f"Charger {self.id} booted"))
         # update metrics
         self._metrics[cdet.model.value].value = kwargs.get(
             om.charge_point_model.name, None
@@ -1054,7 +1061,9 @@ class ChargePoint(cp):
 
         self.hass.async_create_task(self.async_update_device_info(kwargs))
         self.hass.async_create_task(self.central.update(self.central.cpid))
-        self.hass.async_create_task(self.post_connect())
+        if self.triggered_boot_notification is False:
+            self.hass.async_create_task(self.notify_ha(f"Charger {self.id} rebooted"))
+            self.hass.async_create_task(self.post_connect())
         return resp
 
     @on(Action.StatusNotification)


### PR DESCRIPTION
after adding trigger_boot_notification to post_connect, we could get into an infinite loop because the boot notification handler would create a new post_connect. This makes sense in case of a spontaneous reboot, but not if the boot notification was triggered. So we check for this, and only only re-do post connect if the boot notification was not triggered.