### PR TITLE
add delay at start of monitor

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -800,11 +800,11 @@ class ChargePoint(cp):
                 latency_ping = timeout * 1000
                 pong_waiter = await asyncio.wait_for(connection.ping(), timeout=timeout)
                 time1 = time.perf_counter()
-                latency_ping = round(time1 - time0, 3)
+                latency_ping = round(time1 - time0, 3) * 1000
                 latency_pong = timeout * 1000
                 await asyncio.wait_for(pong_waiter, timeout=timeout)
                 time2 = time.perf_counter()
-                latency_pong = round(time2 - time1, 3)
+                latency_pong = round(time2 - time1, 3) * 1000
                 _LOGGER.debug(
                     f"Connection latency from '{self.central.csid}' to '{self.id}': ping={latency_ping} ms, pong={latency_pong} ms",
                 )

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -795,6 +795,7 @@ class ChargePoint(cp):
         connection = self._connection
         try:
             while connection.open:
+                await asyncio.sleep(timeout)
                 time0 = time.perf_counter()
                 latency_ping = timeout * 1000
                 pong_waiter = await asyncio.wait_for(connection.ping(), timeout=timeout)
@@ -809,7 +810,6 @@ class ChargePoint(cp):
                 )
                 self._metrics[cstat.latency_ping.value].value = latency_ping
                 self._metrics[cstat.latency_pong.value].value = latency_pong
-                await asyncio.sleep(timeout)
 
         except asyncio.TimeoutError as timeout_exception:
             self._metrics[cstat.latency_ping.value].value = latency_ping


### PR DESCRIPTION
my charger is not ready to respond/discards the first ping and so goes into a reconnect loop