### PR TITLE
update default logger to INFO

### DIFF
--- a/custom_components/ocpp/__init__.py
+++ b/custom_components/ocpp/__init__.py
@@ -28,7 +28,7 @@ from .const import (
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-logging.getLogger(DOMAIN).setLevel(logging.DEBUG)
+logging.getLogger(DOMAIN).setLevel(logging.INFO)
 
 AUTH_LIST_SCHEMA = vol.Schema(
     {

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -101,7 +101,7 @@ from .enums import (
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-logging.getLogger(DOMAIN).setLevel(logging.DEBUG)
+logging.getLogger(DOMAIN).setLevel(logging.INFO)
 # Uncomment these when Debugging
 # logging.getLogger("asyncio").setLevel(logging.DEBUG)
 # logging.getLogger("websockets").setLevel(logging.DEBUG)


### PR DESCRIPTION
I've notice my log contains a lot of information regarding OCPP
This PR suggest to reduce the amount of logs for a regular HA
environment.