### PR TITLE
ProjectEV(Atess) chargers return empty responses to config messages b…

### DIFF
--- a/custom_components/ocpp/enums.py
+++ b/custom_components/ocpp/enums.py
@@ -34,6 +34,10 @@ class HAChargerStatuses(str, Enum):
     firmware_status = "Status.Firmware"
     reconnects = "Reconnects"
     id_tag = "Id.Tag"
+    current_import = "Current.Import"
+    voltage = "Voltage"
+    power_active_import = "Power.Active.Import"
+    temperature = "Temperature"
 
 
 class HAChargerDetails(str, Enum):


### PR DESCRIPTION
…ut are smart enabled chargers.  Support these by making the default type core plus smart in the case fo an empty message and protect the set_charging_rate calls against the empty responses that these chargers generate.