### PR TITLE
Add United Chargers Grizzl-E to documentation

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -12,6 +12,8 @@ All OCPP 1.6j compatible devices should be supported, but not every device offer
 ## [EVLink Wallbox Plus](https://www.se.com/ww/en/product/EVH3S22P0CK/evlink-wallbox-plus---t2-attached-cable---3-phase---32a-22kw/)
 ## [Evnex E Series & X Series Charging Stations](https://www.evnex.com/) 
 (Ability to configure a custom OCPP server such as HA is being discontinued)
+## [United Chargers Inc. - Grizzl-E](https://grizzl-e.com/about/)  
+(has some defects in OCPP implementation, which can be worked around. See [User Guide](https://github.com/lbbrhzn/ocpp/blob/main/docs/user-guide.md) section in Documentation for details.)
 ## [Wallbox Pulsar](https://wallbox.com/en_uk/wallbox-pulsar)
 ## [Vestel EVC04-AC22SW](https://www.vestel-echarger.com/EVC04_HomeSmart22kW.html)
 ## [V2C Trydan](https://v2charge.com/trydan)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -65,3 +65,35 @@ Measurands (according to OCPP terminology) are actually metrics provided by the 
 * `Availability` (OFF when something causes a problem or during a reboot etc)
 * `Maximum Current` (sets maximum charging current available)
 * `Reset`
+
+## Useful Entities and Workarounds for United Chargers Grizzl-E
+
+Comments below relate to Grizzl-E firmware version 5.633, tested Oct-Nov 2022. 
+
+### Metrics
+The Grizzl-E updates these metrics every 30s during charging sessions:
+* `Current Import` (current flowing into EV)
+* `Power Active Import` (power flowing into EV)
+* `Energy Active Import Register` (cumulative energy supplied to EV during charging session. Resets to zero at start of each session)
+* `Time Session` (elapsed time from start of charging session)
+
+### Diagnostics
+
+* `Status Connector` (current charger state: available/preparing/charging/finishing/suspended etc)
+* `Stop Reason` (reason the charging session was stopped)
+* `Latency Pong` (elapsed time for charger's response to internet ping. Good for diagnosing connectivity issues. Usually less than 1000ms)
+* `Version Firmware` (charger firmware version and build)
+
+### Controls
+
+* `Charge Control` (User switches to ON to start charging session, once charger is in Preparing state. Can be automated in HA - see this [comment in Issue #442](https://github.com/lbbrhzn/ocpp/issues/442#issuecomment-1295865797) for details)
+* `Availability` (ON when charger is idle. OFF during active charging session, or when something causes a problem)
+* `Maximum Current` (sets maximum charging current available. Reverts to value set by charger's internal DIP switch following reboots; tweak slider to reload)
+
+### OCPP Compatibility Issues
+
+Grizzl-E firmware has a few OCPP-compliance defects, including responding to certain OCPP server messages with invalid JSON. Symptoms of this problem include repeated reboots of the charger. By editing the OCPP server source code, one can avoid these problematic messages and obtain useful charger behaviour. ChargeLabs (the company working on the Grizzl-E firmware) expects to release version 6 of the firmware in early 2023, which may fix these problems.
+
+The workaround consists of:
+- checking the *Skip OCPP schema validation* checkbox during OCPP server configuration
+- commenting-out several lines in `/config/custom_components/ocpp/api.py` and adding a few default values to the OCPP server source code. Details are in this [comment in Issue #442](https://github.com/lbbrhzn/ocpp/issues/442#issuecomment-1237651231)


### PR DESCRIPTION
After testing the latest OCPP server (v 0.4.36) with my Grizzl-E charger, I'm happy to report that it substantially works. There are some quirks of the Grizzl-E charger and workarounds needed for it to play nice with the OCPP server.  I'm proposing some additions to the Documentation to record these details. 

Two files are affected: **supported-devices.md** and **user-guide.md**

Let me know if you'd like any changes to this PR.  For instance, do you prefer multiple commits to be rebased into one?  Thanks!