### PR TITLE
Add support for spaces in returned profiles

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -494,7 +494,7 @@ class ChargePoint(cp):
             _LOGGER.warning("Force Smart Charging feature profile")
             self._attr_supported_features |= prof.SMART
         for item in feature_list:
-            item = item.strip()
+            item = item.strip().replace(" ", "")
             if item == om.feature_profile_core.value:
                 self._attr_supported_features |= prof.CORE
             elif item == om.feature_profile_firmware.value:


### PR DESCRIPTION
Some charges seem to add spaces in profiles name, instead of using CamelCase naming:

`2023-02-11 12:16:38.236 INFO (MainThread) [ocpp] 31457413209719: receive message [3,"521ee108-e7db-4e43-8288-422477c630cb",{"configurationKey":[{"key":"SupportedFeatureProfiles","value":"Core,Local Auth List Management,Reservation,Smart Charging,Remote Trigger","readonly":true}]}]`

This PR adds support for that