### PR TITLE
new option flows & tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,16 @@
 {
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.pythonPath": "/usr/local/bin/python",
   "python.analysis.extraPaths": [
     "/usr/local/lib/python3.9/site-packages"
   ],
   "files.associations": {
     "*.yaml": "home-assistant"
+  },
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": true,
+      "source.organizeImports": true
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff"
   }
 }

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -46,21 +46,12 @@ frontend:
 #script: !include scripts.yaml
 #scene: !include scenes.yaml
 
-ocpp:
-  default_authorization_status: 'Invalid'
-  authorization_list:
-    - id_tag: 'pulsar'
-      name: 'My tag'
-      authorization_status : Accepted
-    - id_tag: 'CAFEBABE'
-      name: 'Some other tag'
-      authorization_status: Blocked
-    - id_tag: 'DEADBEEF'
-      name: 'Old tag'
-      status: Expired
-    - id_tag: '12341234'
-      name: 'Invalid tag'
-      authorization_status: Invalid
+# allow reverse proxy from local host
+http:
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 127.0.0.1
+    - ::1
 
 logger:
   default: info

--- a/custom_components/ocpp/button.py
+++ b/custom_components/ocpp/button.py
@@ -13,7 +13,16 @@ from homeassistant.components.button import (
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .api import CentralSystem
-from .const import CONF_CPID, DEFAULT_CPID, DOMAIN
+from .const import (
+    CONF_CP_ID,
+    CONF_CS_ID,
+    CONF_DEVICE_TYPE,
+    DEFAULT_CP_ID,
+    DEFAULT_CS_ID,
+    DEVICE_TYPE_CENTRAL_SYSTEM,
+    DEVICE_TYPE_CHARGE_POINT,
+    DOMAIN,
+)
 from .enums import HAChargerServices
 
 
@@ -44,16 +53,19 @@ BUTTONS: Final = [
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Configure the Button platform."""
+    device_type = entry.data.get(CONF_DEVICE_TYPE)
 
-    central_system = hass.data[DOMAIN][entry.entry_id]
-    cp_id = entry.data.get(CONF_CPID, DEFAULT_CPID)
+    if device_type == DEVICE_TYPE_CHARGE_POINT:
+        cp_id = entry.data.get(CONF_CP_ID, DEFAULT_CP_ID)
+        cs_id = entry.data.get(CONF_CS_ID, DEFAULT_CS_ID)
+        central_system = hass.data[DOMAIN][DEVICE_TYPE_CENTRAL_SYSTEM][cs_id]
 
-    entities = []
+        entities = []
 
-    for ent in BUTTONS:
-        entities.append(ChargePointButton(central_system, cp_id, ent))
+        for ent in BUTTONS:
+            entities.append(ChargePointButton(central_system, cp_id, ent))
 
-    async_add_devices(entities, False)
+        async_add_devices(entities, False)
 
 
 class ChargePointButton(ButtonEntity):
@@ -78,7 +90,7 @@ class ChargePointButton(ButtonEntity):
         self._attr_name = self.entity_description.name
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.cp_id)},
-            via_device=(DOMAIN, self.central_system.id),
+            via_device=(DOMAIN, self.central_system.cs_id),
         )
 
     @property

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -1,16 +1,24 @@
 """Adds config flow for ocpp."""
+import logging
+
 from homeassistant import config_entries
+from homeassistant.core import callback
 import voluptuous as vol
 
+from ocpp.v16.enums import AuthorizationStatus
+
 from .const import (
-    CONF_CPID,
-    CONF_CSID,
+    CONF_AUTH_STATUS,
+    CONF_CP_ID,
+    CONF_DEVICE_TYPE,
     CONF_FORCE_SMART_CHARGING,
     CONF_HOST,
+    CONF_ID_TAG,
     CONF_IDLE_INTERVAL,
     CONF_MAX_CURRENT,
     CONF_METER_INTERVAL,
-    CONF_MONITORED_VARIABLES,
+    CONF_NAME,
+    CONF_PASSWORD,
     CONF_PORT,
     CONF_SKIP_SCHEMA_VALIDATION,
     CONF_SSL,
@@ -20,61 +28,146 @@ from .const import (
     CONF_WEBSOCKET_PING_INTERVAL,
     CONF_WEBSOCKET_PING_TIMEOUT,
     CONF_WEBSOCKET_PING_TRIES,
-    DEFAULT_CPID,
-    DEFAULT_CSID,
+    DEFAULT_AUTH_STATUS,
+    DEFAULT_CP_ID,
+    DEFAULT_CP_NAME,
+    DEFAULT_CS_NAME,
+    DEFAULT_DEVICE_TYPE,
     DEFAULT_FORCE_SMART_CHARGING,
     DEFAULT_HOST,
+    DEFAULT_ID_TAG,
     DEFAULT_IDLE_INTERVAL,
     DEFAULT_MAX_CURRENT,
     DEFAULT_METER_INTERVAL,
-    DEFAULT_MONITORED_VARIABLES,
     DEFAULT_PORT,
     DEFAULT_SKIP_SCHEMA_VALIDATION,
     DEFAULT_SSL,
     DEFAULT_SSL_CERTFILE_PATH,
     DEFAULT_SSL_KEYFILE_PATH,
+    DEFAULT_TAG_NAME,
     DEFAULT_WEBSOCKET_CLOSE_TIMEOUT,
     DEFAULT_WEBSOCKET_PING_INTERVAL,
     DEFAULT_WEBSOCKET_PING_TIMEOUT,
     DEFAULT_WEBSOCKET_PING_TRIES,
+    DEVICE_TYPE_CENTRAL_SYSTEM,
+    DEVICE_TYPE_CHARGE_POINT,
+    DEVICE_TYPE_TAG,
+    DEVICE_TYPES,
     DOMAIN,
 )
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Required(CONF_SSL, default=DEFAULT_SSL): bool,
-        vol.Required(CONF_SSL_CERTFILE_PATH, default=DEFAULT_SSL_CERTFILE_PATH): str,
-        vol.Required(CONF_SSL_KEYFILE_PATH, default=DEFAULT_SSL_KEYFILE_PATH): str,
-        vol.Required(CONF_CSID, default=DEFAULT_CSID): str,
-        vol.Required(CONF_CPID, default=DEFAULT_CPID): str,
-        vol.Required(CONF_MAX_CURRENT, default=DEFAULT_MAX_CURRENT): int,
-        vol.Required(
-            CONF_MONITORED_VARIABLES, default=DEFAULT_MONITORED_VARIABLES
-        ): str,
-        vol.Required(CONF_METER_INTERVAL, default=DEFAULT_METER_INTERVAL): int,
-        vol.Required(CONF_IDLE_INTERVAL, default=DEFAULT_IDLE_INTERVAL): int,
-        vol.Required(
-            CONF_WEBSOCKET_CLOSE_TIMEOUT, default=DEFAULT_WEBSOCKET_CLOSE_TIMEOUT
-        ): int,
-        vol.Required(
-            CONF_WEBSOCKET_PING_TRIES, default=DEFAULT_WEBSOCKET_PING_TRIES
-        ): int,
-        vol.Required(
-            CONF_WEBSOCKET_PING_INTERVAL, default=DEFAULT_WEBSOCKET_PING_INTERVAL
-        ): int,
-        vol.Required(
-            CONF_WEBSOCKET_PING_TIMEOUT, default=DEFAULT_WEBSOCKET_PING_TIMEOUT
-        ): int,
-        vol.Required(
-            CONF_SKIP_SCHEMA_VALIDATION, default=DEFAULT_SKIP_SCHEMA_VALIDATION
-        ): bool,
-        vol.Required(
-            CONF_FORCE_SMART_CHARGING, default=DEFAULT_FORCE_SMART_CHARGING
-        ): bool,
-    }
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+CENTRAL_SYSTEM_SCHEMA_ITEMS: dict = {
+    vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    vol.Required(CONF_SSL, default=DEFAULT_SSL): bool,
+    vol.Required(
+        CONF_SSL_CERTFILE_PATH,
+        default=DEFAULT_SSL_CERTFILE_PATH,
+    ): str,
+    vol.Required(
+        CONF_SSL_KEYFILE_PATH,
+        default=DEFAULT_SSL_KEYFILE_PATH,
+    ): str,
+    vol.Required(
+        CONF_WEBSOCKET_CLOSE_TIMEOUT,
+        default=DEFAULT_WEBSOCKET_CLOSE_TIMEOUT,
+    ): int,
+    vol.Required(
+        CONF_WEBSOCKET_PING_TRIES,
+        default=DEFAULT_WEBSOCKET_PING_TRIES,
+    ): int,
+    vol.Required(
+        CONF_WEBSOCKET_PING_INTERVAL,
+        default=DEFAULT_WEBSOCKET_PING_INTERVAL,
+    ): int,
+    vol.Required(
+        CONF_WEBSOCKET_PING_TIMEOUT,
+        default=DEFAULT_WEBSOCKET_PING_TIMEOUT,
+    ): int,
+    vol.Required(
+        CONF_SKIP_SCHEMA_VALIDATION,
+        default=DEFAULT_SKIP_SCHEMA_VALIDATION,
+    ): bool,
+}
+CENTRAL_SYSTEM_SCHEMA: vol.Schema = vol.Schema(CENTRAL_SYSTEM_SCHEMA_ITEMS)
+
+CHARGE_POINT_SCHEMA_ITEMS: dict = {
+    vol.Required(CONF_CP_ID, default=DEFAULT_CP_ID): str,
+    vol.Optional(
+        CONF_PASSWORD,
+        description={"suggested_value": ""},
+    ): str,
+    vol.Required(
+        CONF_MAX_CURRENT,
+        default=DEFAULT_MAX_CURRENT,
+    ): int,
+    vol.Required(
+        CONF_IDLE_INTERVAL,
+        default=DEFAULT_IDLE_INTERVAL,
+    ): int,
+    vol.Required(
+        CONF_METER_INTERVAL,
+        default=DEFAULT_METER_INTERVAL,
+    ): int,
+    vol.Required(
+        CONF_FORCE_SMART_CHARGING,
+        default=DEFAULT_FORCE_SMART_CHARGING,
+    ): bool,
+}
+CHARGE_POINT_SCHEMA: vol.Schema = vol.Schema(CHARGE_POINT_SCHEMA_ITEMS)
+
+TAG_SCHEMA_ITEMS: dict = {
+    vol.Required(CONF_ID_TAG, default=DEFAULT_ID_TAG): str,
+    vol.Required(CONF_AUTH_STATUS, default=DEFAULT_AUTH_STATUS): vol.In(
+        [
+            AuthorizationStatus.accepted,
+            AuthorizationStatus.blocked,
+            AuthorizationStatus.expired,
+            AuthorizationStatus.invalid,
+        ]
+    ),
+}
+
+TAG_SCHEMA: vol.Schema = vol.Schema(TAG_SCHEMA_ITEMS)
+
+DEVICE_SCHEMA: vol.Schema = vol.Schema(
+    {vol.Required(CONF_DEVICE_TYPE, default=DEFAULT_DEVICE_TYPE): vol.In(DEVICE_TYPES)}
 )
+
+
+def charge_point_exists(
+    cp_id: str,
+    entries: config_entries.ConfigEntries,
+    skip_entry: config_entries.ConfigEntry = None,
+) -> bool:
+    """Check whether there is another entry with the specified charge point id."""
+    for entry in entries.async_entries(DOMAIN):
+        if (
+            (entry.data.get(CONF_DEVICE_TYPE, None) == DEVICE_TYPE_CHARGE_POINT)
+            and (entry.options.get(CONF_CP_ID, None) == cp_id)
+            and (entry is not skip_entry)
+        ):
+            return True
+    return False
+
+
+def tag_exists(
+    id_tag,
+    entries: config_entries.ConfigEntries,
+    skip_entry: config_entries.ConfigEntry = None,
+) -> bool:
+    """Check whether there is another entry with with the specified tag id."""
+    for entry in entries.async_entries(DOMAIN):
+        if (
+            (entry.data.get(CONF_DEVICE_TYPE, None) == DEVICE_TYPE_TAG)
+            and (entry.options.get(CONF_ID_TAG) == id_tag)
+            and (entry is not skip_entry)
+        ):
+            return True
+    return False
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -83,20 +176,187 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
-    def __init__(self):
-        """Initialize."""
-        self._data = {}
+    async def get_central_system_entry(self):
+        """Find central system entry, if present."""
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            if entry.data.get(CONF_DEVICE_TYPE, None) == DEVICE_TYPE_CENTRAL_SYSTEM:
+                return entry
+        return None
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: dict = None):
         """Handle user initiated configuration."""
-        errors: dict[str, str] = {}
+        # If there is no central system entity, we start configurating one
+        if await self.get_central_system_entry() is None:
+            return await self.async_step_central_system(user_input)
+        # Otherwise, we let the user select which type of device to add
+        return await self.async_step_select_device(user_input)
 
-        if user_input is not None:
-            # Todo: validate the user input
-            self._data = user_input
-            self._data[CONF_MONITORED_VARIABLES] = DEFAULT_MONITORED_VARIABLES
-            return self.async_create_entry(title=self._data[CONF_CSID], data=self._data)
-
+    async def async_step_select_device(self, user_input: dict = None):
+        """Handle device selection."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="select_device",
+                data_schema=DEVICE_SCHEMA,
+            )
+        device_type = user_input.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
+        if device_type == DEVICE_TYPE_CENTRAL_SYSTEM:
+            return await self.async_step_central_system()
+        if device_type == DEVICE_TYPE_CHARGE_POINT:
+            return await self.async_step_charge_point()
+        if device_type == DEVICE_TYPE_TAG:
+            return await self.async_step_tag()
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="select_device",
+            data_schema=DEVICE_SCHEMA,
+            errors={"CONF_DEVICE_TYPE": "not_supported"},
+        )
+
+    async def async_step_central_system(self, user_input: dict = None):
+        """Handle central system configuration."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="central_system",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_NAME, default=DEFAULT_CS_NAME): str}
+                ).extend(CENTRAL_SYSTEM_SCHEMA_ITEMS),
+            )
+        options = user_input.copy()
+        options.pop(CONF_NAME)
+        return self.async_create_entry(
+            title=user_input.get(CONF_NAME),
+            data={CONF_DEVICE_TYPE: DEVICE_TYPE_CENTRAL_SYSTEM},
+            options=options,
+        )
+
+    async def async_step_charge_point(self, user_input: dict = None):
+        """Handle charge point configuration."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if charge_point_exists(
+                user_input.get(CONF_CP_ID), self.hass.config_entries
+            ):
+                errors[CONF_CP_ID] = "charge_point_exists"
+            if not errors:
+                options = user_input.copy()
+                options.pop(CONF_NAME)
+                return self.async_create_entry(
+                    title=user_input.get(CONF_NAME),
+                    data={CONF_DEVICE_TYPE: DEVICE_TYPE_CHARGE_POINT},
+                    options=options,
+                )
+        return self.async_show_form(
+            step_id="charge_point",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_NAME, default=DEFAULT_CP_NAME): str}
+            ).extend(CHARGE_POINT_SCHEMA_ITEMS),
+            errors=errors,
+        )
+
+    async def async_step_tag(self, user_input: dict = None):
+        """Handle tag configuration."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            id_tag = user_input.get(CONF_ID_TAG, DEFAULT_ID_TAG)
+            if tag_exists(id_tag, self.hass.config_entries):
+                errors[CONF_ID_TAG] = "tag_exists"
+            if not errors:
+                options = user_input.copy()
+                options.pop(CONF_NAME)
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data={CONF_DEVICE_TYPE: DEVICE_TYPE_TAG},
+                    options=options,
+                )
+        return self.async_show_form(
+            step_id="tag",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_NAME, default=DEFAULT_TAG_NAME): str}
+            ).extend(TAG_SCHEMA_ITEMS),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
+    """Handles options flow for the component."""
+
+    async def async_step_init(self, user_input: dict = None):
+        """Handle initial step."""
+        if self._config_entry.data.get(CONF_DEVICE_TYPE) == DEVICE_TYPE_CENTRAL_SYSTEM:
+            return await self.async_step_central_system(user_input)
+        if self._config_entry.data.get(CONF_DEVICE_TYPE) == DEVICE_TYPE_CHARGE_POINT:
+            return await self.async_step_charge_point(user_input)
+        if self._config_entry.data.get(CONF_DEVICE_TYPE) == DEVICE_TYPE_TAG:
+            return await self.async_step_tag(user_input)
+        return self.async_abort(reason="not_supported")
+
+    async def async_step_central_system(self, user_input: dict = None):
+        """Handle Central System options."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if not errors:
+                return self.async_create_entry(
+                    title=self._config_entry.title,
+                    data=user_input,
+                )
+        return self.async_show_form(
+            step_id="central_system",
+            data_schema=self.add_suggested_values_to_schema(
+                CENTRAL_SYSTEM_SCHEMA, self._config_entry.options
+            ),
+            description_placeholders={
+                "name": self._config_entry.title,
+            },
+            errors=errors,
+        )
+
+    async def async_step_charge_point(self, user_input: dict = None):
+        """Handle Charge Point options."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if charge_point_exists(
+                user_input.get(CONF_CP_ID), self.hass.config_entries
+            ):
+                errors[CONF_CP_ID] = "charge_point_exists"
+            if not errors:
+                return self.async_create_entry(
+                    title=self._config_entry.title, data=user_input
+                )
+        return self.async_show_form(
+            step_id="charge_point",
+            data_schema=self.add_suggested_values_to_schema(
+                CHARGE_POINT_SCHEMA, self._config_entry.options
+            ),
+            description_placeholders={
+                "name": self._config_entry.title,
+            },
+            errors=errors,
+        )
+
+    async def async_step_tag(self, user_input: dict = None):
+        """Handle Tag options."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            id_tag = user_input.get(CONF_ID_TAG)
+            if tag_exists(id_tag, self.hass.config_entries, self._config_entry):
+                errors[CONF_ID_TAG] = "tag_exists"
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input.get(CONF_NAME), data=user_input
+                )
+        return self.async_show_form(
+            step_id="tag",
+            data_schema=self.add_suggested_values_to_schema(
+                TAG_SCHEMA, self._config_entry.options
+            ),
+            description_placeholders={
+                "name": self._config_entry.title,
+            },
+            errors=errors,
         )

--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -5,17 +5,19 @@ import homeassistant.components.input_number as input_number
 from homeassistant.components.sensor import SensorDeviceClass
 import homeassistant.const as ha
 
-from ocpp.v16.enums import Measurand, UnitOfMeasure
+from ocpp.v16.enums import AuthorizationStatus, Measurand, UnitOfMeasure
 
+# Configuration parameter names
 CONF_AUTH_LIST = "authorization_list"
 CONF_AUTH_STATUS = "authorization_status"
 CONF_CPI = "charge_point_identity"
-CONF_CPID = "cpid"
-CONF_CSID = "csid"
+CONF_CP_ID = "cpid"
+CONF_CS_ID = "csid"
 CONF_DEFAULT_AUTH_STATUS = "default_authorization_status"
+CONF_DEVICE_TYPE = "device_type"
 CONF_HOST = ha.CONF_HOST
-CONF_ID_TAG = "id_tag"
 CONF_ICON = ha.CONF_ICON
+CONF_ID_TAG = "id_tag"
 CONF_IDLE_INTERVAL = "idle_interval"
 CONF_MAX_CURRENT = "max_current"
 CONF_METER_INTERVAL = "meter_interval"
@@ -38,8 +40,19 @@ CONF_WEBSOCKET_PING_TRIES = "websocket_ping_tries"
 CONF_WEBSOCKET_PING_INTERVAL = "websocket_ping_interval"
 CONF_WEBSOCKET_PING_TIMEOUT = "websocket_ping_timeout"
 DATA_UPDATED = "ocpp_data_updated"
-DEFAULT_CSID = "central"
-DEFAULT_CPID = "charger"
+
+# Device types
+DEVICE_TYPE_CENTRAL_SYSTEM = "central_system"
+DEVICE_TYPE_CHARGE_POINT = "charge_point"
+DEVICE_TYPE_TAG = "tag"
+DEVICE_TYPES = [DEVICE_TYPE_CENTRAL_SYSTEM, DEVICE_TYPE_CHARGE_POINT, DEVICE_TYPE_TAG]
+
+# Default values
+DEFAULT_AUTH_STATUS = AuthorizationStatus.accepted
+DEFAULT_CS_ID = "central"
+DEFAULT_CP_ID = "charger"
+DEFAULT_ID_TAG = "00000000"
+DEFAULT_DEVICE_TYPE = DEVICE_TYPE_CENTRAL_SYSTEM
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_MAX_CURRENT = 32
 DEFAULT_PORT = 9000
@@ -49,12 +62,16 @@ DEFAULT_SSL = False
 DEFAULT_SSL_CERTFILE_PATH = pathlib.Path.cwd().joinpath("fullchain.pem")
 DEFAULT_SSL_KEYFILE_PATH = pathlib.Path.cwd().joinpath("privkey.pem")
 DEFAULT_SUBPROTOCOL = "ocpp1.6"
+DEFAULT_CS_NAME = "my central"
+DEFAULT_CP_NAME = "my charger"
+DEFAULT_TAG_NAME = "my tag"
 DEFAULT_METER_INTERVAL = 60
 DEFAULT_IDLE_INTERVAL = 900
 DEFAULT_WEBSOCKET_CLOSE_TIMEOUT = 10
 DEFAULT_WEBSOCKET_PING_TRIES = 2
 DEFAULT_WEBSOCKET_PING_INTERVAL = 20
 DEFAULT_WEBSOCKET_PING_TIMEOUT = 20
+
 DOMAIN = "ocpp"
 CONFIG = "config"
 ICON = "mdi:ev-station"
@@ -67,6 +84,7 @@ SWITCH = "switch"
 BUTTON = "button"
 
 PLATFORMS = [SENSOR, SWITCH, NUMBER, BUTTON]
+
 
 # Ocpp supported measurands
 MEASURANDS = [

--- a/custom_components/ocpp/manifest.json
+++ b/custom_components/ocpp/manifest.json
@@ -11,6 +11,7 @@
 	"config_flow": true,
 	"documentation": "https://github.com/lbbrhzn/ocpp/blob/main/README.md",
 	"iot_class": "local_push",
+	"integration_type": "device",
 	"issue_tracker": "https://github.com/lbbrhzn/ocpp/issues",
 	"requirements": [
 		"ocpp>=0.20.0",

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -1,63 +1,107 @@
 {
     "config": {
+        "error": {
+            "charge_point_exists": "There already is a charge point with the same identifier",
+            "tag_exists": "There already is a tag wih the same identifier"
+        },
         "step": {
-            "user": {
-                "title": "OCPP Configuration",
-                "description": "If you need help with the configuration have a look here: https://github.com/lbbrhzn/ocpp",
+            "select_device": {
+                "title": "Add device",
+                "data": {
+                    "device_type": "Select the device type:"
+                }
+            },
+            "central_system": {
+                "title": "Central System",
                 "data": {
                     "host": "Central system host address",
                     "port": "Central system port number",
                     "ssl": "Secure connection",
                     "ssl_certfile_path": "Path to SSL certificate or (None)",
                     "ssl_keyfile_path": "Path to SSL key or (None)",
-                    "csid": "Central system identity",
-                    "cpid": "Charge point identity",
+                    "websocket_close_timeout": "Websocket close timeout (seconds)",
+                    "websocket_ping_tries": "Websocket successive times to ping before closing",
+                    "websocket_ping_interval": "Websocket ping interval (seconds)",
+                    "websocket_ping_timeout": "Websocket ping timeout (seconds)",
+                    "skip_schema_validation": "Skip OCPP schema validation"
+                }
+            },
+            "charge_point": {
+                "title": "Charge Point",
+                "data": {
+                    "cpid": "Charge point identifier",
+                    "password": "Password",
                     "max_current": "Maximum charging current",
                     "meter_interval": "Charging sample interval (seconds)",
                     "idle_interval": "Charger idle sampling interval (seconds)",
+                    "force_smart_charging": "Force Smart Charging feature profile"
+                }
+            },
+            "tag": {
+                "title": "Tag",
+                "data": {
+                    "id": "Tag identifier",
+                    "authorization_status": "Tag authorization"
+                }
+            }
+        }
+    },
+    "options": {
+        "error": {
+            "charge_point_exists": "There already is a charge point with the same identifier",
+            "tag_exists": "There already is a tag wih the same identifier"
+        },
+        "step": {
+            "central_system": {
+                "title": "Options for {name}",
+                "data": {
+                    "host": "Central system host address",
+                    "port": "Central system port number",
+                    "ssl": "Secure connection",
+                    "ssl_certfile_path": "Path to SSL certificate or (None)",
+                    "ssl_keyfile_path": "Path to SSL key or (None)",
                     "websocket_close_timeout": "Websocket close timeout (seconds)",
                     "websocket_ping_tries": "Websocket successive times to try connection before closing",
                     "websocket_ping_interval": "Websocket ping interval (seconds)",
                     "websocket_ping_timeout": "Websocket ping timeout (seconds)",
-                    "skip_schema_validation": "Skip OCPP schema validation",
+                    "skip_schema_validation": "Skip OCPP schema validation"
+                }
+            },
+            "charge_point": {
+                "title": "Options for {name}",
+                "data": {
+                    "cpid": "Charge point identifier",
+                    "password": "Password",
+                    "max_current": "Maximum charging current",
+                    "meter_interval": "Charging sample interval (seconds)",
+                    "idle_interval": "Charger idle sampling interval (seconds)",
                     "force_smart_charging": "Force Smart Charging feature profile"
                 }
             },
-            "measurands": {
-                "title": "OCPP Measurands",
-                "description": "Select which measurand(s) should be shown in Home Assistant.",
+            "tag": {
+                "title": "Options for {name}",
                 "data": {
-                    "Current.Export": "Instantaneous current flow from EV",
-                    "Current.Import": "Instantaneous current flow to EV",
-                    "Current.Offered": "Maximum current offered to EV",
-                    "Energy.Active.Export.Register": "Active energy exported to the grid",
-                    "Energy.Active.Import.Register": "Active energy imported from the grid",
-                    "Energy.Reactive.Export.Register": "Reactive energy exported to the grid",
-                    "Energy.Reactive.Import.Register": "Reactive energy imported from the grid",
-                    "Energy.Active.Export.Interval": "Active energy exported to the grid during last interval",
-                    "Energy.Active.Import.Interval": "Active energy imported from the grid during last interval",
-                    "Energy.Reactive.Export.Interval": "Reactive energy exported to the grid during last interval",
-                    "Energy.Reactive.Import.Interval": "Reactive energy imported from the grid during last interval",
-                    "Frequency": "Powerline frequency",
-                    "Power.Active.Export": "Instantaneous active power exported by EV",
-                    "Power.Active.Import": "Instantaneous active power imported by EV",
-                    "Power.Factor": "Instantaneous power factor of total energy flow",
-                    "Power.Offered": "Maximum power offered to EV",
-                    "Power.Reactive.Export": "Instantaneous reactive power exported by EV",
-                    "Power.Reactive.Import": "Instantaneous reactive power imported by EV",
-                    "RPM": "Fan speed in RPM",
-                    "SoC": "State of charge of EV in percentage",
-                    "Temperature": "Temperature reading inside Charge Point",
-                    "Voltage": "Instantaneous AC RMS supply voltage"
+                    "id_tag": "Tag identifier",
+                    "authorization_status": "Tag authorization"
                 }
             }
+        }
+    },
+    "selector": {
+        "device_type": {
+            "options": {
+                "central_system": "Central System",
+                "charge_point": "Charge Point",
+                "tag": "Tag"
+            }
         },
-        "error": {
-            "auth": "Username/Password is wrong.",
-            "measurand": "Unknown measurand"
-        },
-        "abort": {
-            "single_instance_allowed": "Only a single instance is allowed."
+        "authorization_status": {
+            "options": {
+                "Accepted": "Accepted",
+                "Blocked": "Blocked",
+                "Expired": "Expired",
+                "Invalid": "Invalid"
+            }
         }
     }
 }

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -22,42 +22,33 @@
                     "skip_schema_validation": "Skip OCPP schema validation",
                     "force_smart_charging": "Force Smart Charging feature profile"
                 }
-            },
-            "measurands": {
-                "title": "OCPP Measurands",
-                "description": "Select which measurand(s) should be shown in Home Assistant.",
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "OCPP Configuration",
+                "description": "If you need help with the configuration have a look here: https://github.com/lbbrhzn/ocpp",
                 "data": {
-                    "Current.Export": "Instantaneous current flow from EV",
-                    "Current.Import": "Instantaneous current flow to EV",
-                    "Current.Offered": "Maximum current offered to EV",
-                    "Energy.Active.Export.Register": "Active energy exported to the grid",
-                    "Energy.Active.Import.Register": "Active energy imported from the grid",
-                    "Energy.Reactive.Export.Register": "Reactive energy exported to the grid",
-                    "Energy.Reactive.Import.Register": "Reactive energy imported from the grid",
-                    "Energy.Active.Export.Interval": "Active energy exported to the grid during last interval",
-                    "Energy.Active.Import.Interval": "Active energy imported from the grid during last interval",
-                    "Energy.Reactive.Export.Interval": "Reactive energy exported to the grid during last interval",
-                    "Energy.Reactive.Import.Interval": "Reactive energy imported from the grid during last interval",
-                    "Frequency": "Powerline frequency",
-                    "Power.Active.Export": "Instantaneous active power exported by EV",
-                    "Power.Active.Import": "Instantaneous active power imported by EV",
-                    "Power.Factor": "Instantaneous power factor of total energy flow",
-                    "Power.Offered": "Maximum power offered to EV",
-                    "Power.Reactive.Export": "Instantaneous reactive power exported by EV",
-                    "Power.Reactive.Import": "Instantaneous reactive power imported by EV",
-                    "RPM": "Fan speed in RPM",
-                    "SoC": "State of charge of EV in percentage",
-                    "Temperature": "Temperature reading inside Charge Point",
-                    "Voltage": "Instantaneous AC RMS supply voltage"
+                    "host": "Central system host address",
+                    "port": "Central system port number",
+                    "ssl": "Secure connection",
+                    "ssl_certfile_path": "Path to SSL certificate or (None)",
+                    "ssl_keyfile_path": "Path to SSL key or (None)",
+                    "csid": "Central system identity",
+                    "cpid": "Charge point identity",
+                    "max_current": "Maximum charging current",
+                    "meter_interval": "Charging sample interval (seconds)",
+                    "idle_interval": "Charger idle sampling interval (seconds)",
+                    "websocket_close_timeout": "Websocket close timeout (seconds)",
+                    "websocket_ping_tries": "Websocket successive times to try connection before closing",
+                    "websocket_ping_interval": "Websocket ping interval (seconds)",
+                    "websocket_ping_timeout": "Websocket ping timeout (seconds)",
+                    "skip_schema_validation": "Skip OCPP schema validation",
+                    "force_smart_charging": "Force Smart Charging feature profile"
                 }
             }
-        },
-        "error": {
-            "auth": "Username/Password is wrong.",
-            "measurand": "Unknown measurand"
-        },
-        "abort": {
-            "single_instance_allowed": "Only a single instance is allowed."
         }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def skip_notifications_fixture():
     """Skip notification calls."""
     with patch("homeassistant.components.persistent_notification.async_create"), patch(
         "homeassistant.components.persistent_notification.async_dismiss"
-    ), patch("custom_components.ocpp.api.ChargePoint.notify_ha"):
+    ), patch("custom_components.ocpp.ChargePoint.notify_ha"):
         yield
 
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,7 +1,8 @@
 """Constants for ocpp tests."""
 from custom_components.ocpp.const import (
-    CONF_CPID,
-    CONF_CSID,
+    CONF_CP_ID,
+    CONF_CS_ID,
+    CONF_DEVICE_TYPE,
     CONF_FORCE_SMART_CHARGING,
     CONF_HOST,
     CONF_IDLE_INTERVAL,
@@ -18,33 +19,36 @@ from custom_components.ocpp.const import (
     CONF_WEBSOCKET_PING_TIMEOUT,
     CONF_WEBSOCKET_PING_TRIES,
     DEFAULT_MONITORED_VARIABLES,
+    DEVICE_TYPE_CENTRAL_SYSTEM,
 )
 
-MOCK_CONFIG = {
+MOCK_CENTRAL_INPUT = {
     CONF_HOST: "127.0.0.1",
     CONF_PORT: 9000,
     CONF_SSL: False,
     CONF_SSL_CERTFILE_PATH: "/tests/fullchain.pem",
     CONF_SSL_KEYFILE_PATH: "/tests/privkey.pem",
-    CONF_CPID: "test_cpid",
-    CONF_CSID: "test_csid",
-    CONF_IDLE_INTERVAL: 900,
-    CONF_MAX_CURRENT: 32,
-    CONF_METER_INTERVAL: 60,
-    CONF_MONITORED_VARIABLES: DEFAULT_MONITORED_VARIABLES,
-    CONF_SKIP_SCHEMA_VALIDATION: False,
-    CONF_FORCE_SMART_CHARGING: True,
-    CONF_WEBSOCKET_CLOSE_TIMEOUT: 1,
-    CONF_WEBSOCKET_PING_TRIES: 0,
-    CONF_WEBSOCKET_PING_INTERVAL: 1,
-    CONF_WEBSOCKET_PING_TIMEOUT: 1,
+    CONF_CS_ID: "test_csid",
+}
+
+MOCK_CENTRAL_DATA = {
+    CONF_DEVICE_TYPE: DEVICE_TYPE_CENTRAL_SYSTEM,
+}
+
+MOCK_CENTRAL_OPTIONS = {
+    CONF_HOST: "127.0.0.1",
+    CONF_PORT: 9000,
+    CONF_SSL: False,
+    CONF_SSL_CERTFILE_PATH: "/tests/fullchain.pem",
+    CONF_SSL_KEYFILE_PATH: "/tests/privkey.pem",
+    CONF_CS_ID: "test_csid",
 }
 
 MOCK_CONFIG_DATA = {
     CONF_HOST: "127.0.0.1",
     CONF_PORT: 9000,
-    CONF_CPID: "test_cpid",
-    CONF_CSID: "test_csid",
+    CONF_CP_ID: "test_cpid",
+    CONF_CS_ID: "test_csid",
     CONF_IDLE_INTERVAL: 900,
     CONF_MAX_CURRENT: 32,
     CONF_METER_INTERVAL: 60,
@@ -64,14 +68,14 @@ MOCK_CONFIG_DATA = {
 MOCK_CONFIG_DATA_1 = {
     **MOCK_CONFIG_DATA,
     CONF_PORT: 9001,
-    CONF_CPID: "test_cpid_1",
+    CONF_CP_ID: "test_cpid_1",
 }
 
 # configuration with skip schema validation enabled
 MOCK_CONFIG_DATA_2 = {
     **MOCK_CONFIG_DATA,
     CONF_PORT: 9002,
-    CONF_CPID: "test_cpid_2",
+    CONF_CP_ID: "test_cpid_2",
     CONF_SKIP_SCHEMA_VALIDATION: True,
 }
 
@@ -79,8 +83,8 @@ MOCK_CONFIG_DATA_2 = {
 MOCK_CONFIG_SWITCH = {
     CONF_HOST: "127.0.0.1",
     CONF_PORT: 9001,
-    CONF_CPID: "test_cpid_2",
-    CONF_CSID: "test_csid_2",
+    CONF_CP_ID: "test_cpid_2",
+    CONF_CS_ID: "test_csid_2",
     CONF_MAX_CURRENT: 32,
     CONF_IDLE_INTERVAL: 900,
     CONF_METER_INTERVAL: 60,

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -324,13 +324,13 @@ async def test_cms_responses(hass, socket_enabled):
     assert int(cs.get_metric("test_cpid", "Energy.Session")) == int(
         (54321 - 12345) / 1000
     )
-    assert int(cs.get_metric("test_cpid", "Current.Import")) == int(0)
-    assert int(cs.get_metric("test_cpid", "Voltage")) == int(228)
+    assert int(cs.get_metric("test_cpid", "Current.Import")) == 0
+    assert int(cs.get_metric("test_cpid", "Voltage")) == 228
     assert cs.get_unit("test_cpid", "Energy.Active.Import.Register") == "kWh"
     assert cs.get_metric("unknown_cpid", "Energy.Active.Import.Register") is None
     assert cs.get_unit("unknown_cpid", "Energy.Active.Import.Register") is None
     assert cs.get_extra_attr("unknown_cpid", "Energy.Active.Import.Register") is None
-    assert int(cs.get_supported_features("unknown_cpid")) == int(0)
+    assert int(cs.get_supported_features("unknown_cpid")) == 0
     assert (
         await asyncio.wait_for(
             cs.set_max_charge_rate_amps("unknown_cpid", 0), timeout=1
@@ -370,9 +370,9 @@ async def test_cms_responses(hass, socket_enabled):
         except asyncio.TimeoutError:
             pass
         await ws.close()
-    assert int(cs.get_metric("test_cpid", "Frequency")) == int(50)
-    assert float(cs.get_metric("test_cpid", "Energy.Active.Import.Register")) == float(
-        1101.452
+    assert int(cs.get_metric("test_cpid", "Frequency")) == 50
+    assert (
+        float(cs.get_metric("test_cpid", "Energy.Active.Import.Register")) == 1101.452
     )
 
     await asyncio.sleep(1)
@@ -437,8 +437,8 @@ async def test_cms_responses(hass, socket_enabled):
             pass
         await ws.close()
 
-    assert int(cs.get_metric("test_cpid", "Energy.Active.Import.Register")) == int(1101)
-    assert int(cs.get_metric("test_cpid", "Energy.Session")) == int(11)
+    assert int(cs.get_metric("test_cpid", "Energy.Active.Import.Register")) == 1101
+    assert int(cs.get_metric("test_cpid", "Energy.Session")) == 11
     assert cs.get_unit("test_cpid", "Energy.Active.Import.Register") == "kWh"
 
     # test ocpp rejection messages sent from charger to cms

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,7 @@ from custom_components.ocpp.const import (  # BINARY_SENSOR,; PLATFORMS,; SENSOR
     DOMAIN,
 )
 
-from .const import MOCK_CONFIG, MOCK_CONFIG_DATA
+from .const import MOCK_CENTRAL_DATA, MOCK_CENTRAL_INPUT, MOCK_CENTRAL_OPTIONS
 
 # from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -46,14 +46,15 @@ async def test_successful_config_flow(hass, bypass_get_data):
     # If a user were to enter `test_username` for username and `test_password`
     # for password, it would result in this function call
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_CONFIG
+        result["flow_id"], user_input=MOCK_CENTRAL_INPUT
     )
 
     # Check that the config flow is complete and a new entry is created with
     # the input data
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "test_csid"
-    assert result["data"] == MOCK_CONFIG_DATA
+    assert result["data"] == MOCK_CENTRAL_DATA
+    assert result["options"] == MOCK_CENTRAL_OPTIONS
     assert result["result"]
 
 


### PR DESCRIPTION
- added new option flows to allow reconfiguration of central system and chargepoint point parameters.
- added config and option flow for tags
- added support multiple charge points per central system. 


NB. work in progress (TODO: get the tests working, add sensors for energy usage per tag)

@drc38  I am considering to allow only a single central system instance. Assuming we fully support multiple charge points per central system, do you see any reason to allow more than one central system instance?