### PR TITLE
Correct reactive power device class

### DIFF
--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -163,8 +163,10 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
             Measurand.rpm,
         ] or self.metric.lower().startswith("frequency"):
             device_class = SensorDeviceClass.FREQUENCY
-        elif self.metric.lower().startswith(("power.a", "power.o", "power.r")):
+        elif self.metric.lower().startswith("power.a", "power.o"):
             device_class = SensorDeviceClass.POWER
+        elif self.metric.lower().startswith("power.r"):
+            device_class = SensorDeviceClass.REACTIVE_POWER
         elif self.metric.lower().startswith("temperature."):
             device_class = SensorDeviceClass.TEMPERATURE
         elif self.metric.lower().startswith("timestamp.") or self.metric in [

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -163,7 +163,7 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
             Measurand.rpm,
         ] or self.metric.lower().startswith("frequency"):
             device_class = SensorDeviceClass.FREQUENCY
-        elif self.metric.lower().startswith("power.a", "power.o"):
+        elif self.metric.lower().startswith(("power.a", "power.o")):
             device_class = SensorDeviceClass.POWER
         elif self.metric.lower().startswith("power.r"):
             device_class = SensorDeviceClass.REACTIVE_POWER

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -156,6 +156,8 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
             device_class = SensorDeviceClass.CURRENT
         elif self.metric.lower().startswith("voltage"):
             device_class = SensorDeviceClass.VOLTAGE
+        elif self.metric.lower().startswith("energy.r"):
+            device_class = None
         elif self.metric.lower().startswith("energy."):
             device_class = SensorDeviceClass.ENERGY
         elif self.metric in [


### PR DESCRIPTION
fixes #1403 partially by giving a device class for reactive power sensors.

There is no device class for reactive energy so far, means this cannot be fixed and does not have a device class assigned on purpose: https://developers.home-assistant.io/docs/core/entity/sensor/
Once HA provides a device class for it it can be added here...