### PR TITLE
Fix missing state class for reactive power sensors after #1417

### DIFF
--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -130,5 +130,6 @@ DEFAULT_CLASS_UNITS_HA = {
     SensorDeviceClass.FREQUENCY: ha.UnitOfFrequency.HERTZ,
     SensorDeviceClass.BATTERY: ha.PERCENTAGE,
     SensorDeviceClass.POWER: ha.UnitOfPower.KILO_WATT,
+    SensorDeviceClass.REACTIVE_POWER: ha.UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
     SensorDeviceClass.ENERGY: ha.UnitOfEnergy.KILO_WATT_HOUR,
 }

--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -113,7 +113,7 @@ UNITS_OCCP_TO_HA = {
     UnitOfMeasure.kw: ha.UnitOfPower.KILO_WATT,
     UnitOfMeasure.va: ha.UnitOfApparentPower.VOLT_AMPERE,
     UnitOfMeasure.kva: UnitOfMeasure.kva,
-    UnitOfMeasure.var: UnitOfMeasure.var,
+    UnitOfMeasure.var: ha.UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
     UnitOfMeasure.kvar: UnitOfMeasure.kvar,
     UnitOfMeasure.a: ha.UnitOfElectricCurrent.AMPERE,
     UnitOfMeasure.v: ha.UnitOfElectricPotential.VOLT,

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -137,6 +137,7 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
             SensorDeviceClass.CURRENT,
             SensorDeviceClass.VOLTAGE,
             SensorDeviceClass.POWER,
+            SensorDeviceClass.REACTIVE_POWER,
             SensorDeviceClass.TEMPERATURE,
             SensorDeviceClass.BATTERY,
             SensorDeviceClass.FREQUENCY,

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -268,6 +268,8 @@ async def test_cms_responses_v16(hass, socket_enabled):
     assert int(cs.get_metric("test_cpid", "Current.Import")) == 0
     assert int(cs.get_metric("test_cpid", "Voltage")) == 228
     assert cs.get_unit("test_cpid", "Energy.Active.Import.Register") == "kWh"
+    assert cs.get_ha_unit("test_cpid", "Power.Reactive.Import") == "var"
+    assert cs.get_unit("test_cpid", "Power.Reactive.Import") == "var"
     assert cs.get_metric("unknown_cpid", "Energy.Active.Import.Register") is None
     assert cs.get_unit("unknown_cpid", "Energy.Active.Import.Register") is None
     assert cs.get_extra_attr("unknown_cpid", "Energy.Active.Import.Register") is None
@@ -821,7 +823,7 @@ class ChargePoint(cpclass):
                             "value": "89.00",
                             "context": "Sample.Periodic",
                             "measurand": "Power.Reactive.Import",
-                            "unit": "W",
+                            "unit": "var",
                         },
                         {
                             "value": "0.010",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,12 +5,6 @@
 from collections.abc import AsyncGenerator
 
 from homeassistant.core import HomeAssistant
-from homeassistant.const import ATTR_DEVICE_CLASS
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorStateClass,
-    ATTR_STATE_CLASS,
-)
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ocpp import CentralSystem
@@ -43,17 +37,6 @@ async def test_setup_unload_and_reload_entry(
     assert DOMAIN in hass.data
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
-
-    # Test a random reactive power sensor to have correct device_class and state_class
-    reactive_power_sensor = hass.states.get("sensor.test_cpid_1_power_reactive_import")
-    assert (
-        reactive_power_sensor.attributes.get(ATTR_DEVICE_CLASS)
-        == SensorDeviceClass.REACTIVE_POWER
-    )
-    assert (
-        reactive_power_sensor.attributes.get(ATTR_STATE_CLASS)
-        == SensorStateClass.MEASUREMENT
-    )
 
     # Reload the entry and assert that the data from above is still there
     assert await hass.config_entries.async_reload(config_entry.entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,12 @@
 from collections.abc import AsyncGenerator
 
 from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorStateClass,
+    ATTR_STATE_CLASS,
+)
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ocpp import CentralSystem
@@ -37,6 +43,17 @@ async def test_setup_unload_and_reload_entry(
     assert DOMAIN in hass.data
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+
+    # Test a random reactive power sensor to have correct device_class and state_class
+    reactive_power_sensor = hass.states.get("sensor.test_cpid_1_power_reactive_import")
+    assert (
+        reactive_power_sensor.attributes.get(ATTR_DEVICE_CLASS)
+        == SensorDeviceClass.REACTIVE_POWER
+    )
+    assert (
+        reactive_power_sensor.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.MEASUREMENT
+    )
 
     # Reload the entry and assert that the data from above is still there
     assert await hass.config_entries.async_reload(config_entry.entry_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,35 @@
+"""Test sensor for ocpp integration."""
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ocpp.const import DOMAIN as OCPP_DOMAIN
+
+from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.components.sensor.const import (
+    SensorDeviceClass,
+    SensorStateClass,
+    ATTR_STATE_CLASS,
+)
+from .const import MOCK_CONFIG_DATA
+
+
+async def test_sensor(hass, socket_enabled):
+    """Test sensor."""
+    config_entry = MockConfigEntry(
+        domain=OCPP_DOMAIN,
+        data=MOCK_CONFIG_DATA,
+        entry_id="test_cms",
+        title="test_cms",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Test reactive power sensor
+    state = hass.states.get("sensor.test_cpid_power_reactive_import")
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.REACTIVE_POWER
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    # Test reactive energx sensor, not having own device class yet
+    state = hass.states.get("sensor.test_cpid_energy_reactive_import_register")
+    assert state.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert state.attributes.get(ATTR_STATE_CLASS) is None


### PR DESCRIPTION
After explicitly switching to reactive power device class I missed the state_class also depending on this device_class (#1417).

Should fix https://github.com/lbbrhzn/ocpp/issues/1449 (the raised repair regarding the changed unit of measurement is expected nevertheless)
