### PR TITLE
Pin ocpp to version 1.0.0

### DIFF
--- a/custom_components/ocpp/manifest.json
+++ b/custom_components/ocpp/manifest.json
@@ -13,7 +13,7 @@
 	"iot_class": "local_push",
 	"issue_tracker": "https://github.com/lbbrhzn/ocpp/issues",
 	"requirements": [
-		"ocpp>=1.0.0",
+		"ocpp==1.0.0",
 		"websockets>=14.1"
 	],
 	"version": "0.6.3"


### PR DESCRIPTION
Home Assistant now pip installs version 2.0.0 of ocpp, which breaks the integration. I think this is because 2.0.0 was released on pip today: https://pypi.org/project/ocpp/#history

I see you're working on a version that uses ocpp 2.0.0 - until then, I think it makes sense to have a version that pins to 1.0.0.