### PR TITLE
AvailabilityStatus scheduled is expected when charger transaction is in progress

### DIFF
--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -392,7 +392,10 @@ class ChargePoint(cp):
 
         req = call.ChangeAvailability(connector_id=0, type=typ)
         resp = await self.call(req)
-        if resp.status == AvailabilityStatus.accepted:
+        if resp.status in [
+            AvailabilityStatus.accepted,
+            AvailabilityStatus.scheduled,
+        ]:
             return True
         else:
             _LOGGER.warning("Failed with response: %s", resp.status)


### PR DESCRIPTION
When Home Assistant is restarted while car is connected you always get warning notification.

According to OCPP specification:
When a transaction is in progress Charge Point SHALL respond with availability status 'Scheduled' to indicate that it is scheduled to occur after the transaction has finished.

Closes #1457 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the handling of availability updates by accepting an additional valid status. This improvement leads to more robust status changes and reduces unnecessary failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->