### PR TITLE
Prevent reference sharing between entry and data

### DIFF
--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 from copy import deepcopy
-import logging
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -55,10 +54,6 @@ from .const import (
     DOMAIN,
     MEASURANDS,
 )
-
-
-_LOGGER: logging.Logger = logging.getLogger(__package__)
-logging.getLogger(DOMAIN).setLevel(logging.INFO)
 
 STEP_USER_CS_DATA_SCHEMA = vol.Schema(
     {
@@ -169,8 +164,6 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._data[CONF_CPIDS][-1][self._cp_id][CONF_MONITORED_VARIABLES] = (
                     DEFAULT_MONITORED_VARIABLES
                 )
-                _LOGGER.error(f"****updating entry {self._entry.data} with {self._data}")
-                # self.hass.config_entries._async_schedule_save()
                 return self.async_update_reload_and_abort(
                     self._entry,
                     data_updates=self._data,

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -10,8 +10,6 @@ from homeassistant.config_entries import (
 )
 import voluptuous as vol
 
-
-
 from .const import (
     CONF_CPID,
     CONF_CPIDS,
@@ -158,7 +156,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Don't allow duplicate cpids to be used
-            self._async_abort_entries_match({CONF_CPID: user_input[CONF_CPID]})            
+            self._async_abort_entries_match({CONF_CPID: user_input[CONF_CPID]})
             self._data[CONF_CPIDS].append({self._cp_id: user_input})
             if user_input[CONF_MONITORED_VARIABLES_AUTOCONFIG]:
                 self._data[CONF_CPIDS][-1][self._cp_id][CONF_MONITORED_VARIABLES] = (
@@ -167,8 +165,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_update_reload_and_abort(
                     self._entry,
                     data_updates=self._data,
-                )
-                
+                )                
             else:
                 return await self.async_step_measurands()
 

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -165,7 +165,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_update_reload_and_abort(
                     self._entry,
                     data_updates=self._data,
-                )                
+                )
             else:
                 return await self.async_step_measurands()
 


### PR DESCRIPTION
Change detection doesn't work when updating the self._data also updates self._entry.data because the reference to the cpid key is the same list. This prevents the data being persisted to disk.

Closes #1558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the configuration process for improved data integrity, ensuring changes are applied without unintended side effects.
- **Bug Fixes**
  - Minor formatting adjustments made for better readability in user input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->