### PR TITLE
Grizzl-E doc updates for firmware 3.x.x on Mini / Ultimate models

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -131,7 +131,16 @@ Even though the device accepts all measurands, the working ones are
 If the devices loses connection to Home Assistant (due to Wi-Fi disconnection or update, for example) it doesn't seem to reconnect automatically. It is necessary to reboot the charger via Bluetooth for it to reconnect.
      
 ## [United Chargers Inc. - Grizzl-E](https://grizzl-e.com/about/)
-(has some defects in OCPP implementation, which can be worked around. See [User Guide](https://github.com/lbbrhzn/ocpp/blob/main/docs/user-guide.md) section in Documentation for details.)
+
+Grizzl-E chargers with firmware 3.x.x work mostly without issue, such as the following:
+* Grizzl-E Mini Connect 2024
+* Grizzl-E Ultimate
+
+Known issue: In firmware 03.09.0 amperage changes are accepted but not applied. This is due to the firmware accepting but not handling a value of `ChargePointMaxProfile` in `ChargerProfilePurpose`. United Chargers has stated that this will be addressed in firmware version 03.11.0.
+
+Supported OCPP requests for the 3.x.x firmware are documented in a PDF on their site in under https://grizzl-e.com/connect-to-third-party-ocpp-backend/
+
+Other Grizzl-E chargers on the 5.x.x firmware have some defects in OCPP implementation, which can be worked around. See [User Guide](https://github.com/lbbrhzn/ocpp/blob/main/docs/user-guide.md) section in Documentation for details.)
 
 ## [V2C Trydan](https://v2charge.com/trydan)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -132,7 +132,7 @@ ABB Terra AC firmware 1.8.21 and earlier versions fail to respond correctly when
 
 ### Grizzl-E
 
-Grizzl-E firmware has a few OCPP-compliance defects, including responding to certain OCPP server messages with invalid JSON. Symptoms of this problem include repeated reboots of the charger. By editing the OCPP server source code, one can avoid these problematic messages and obtain useful charger behaviour. ChargeLabs (the company working on the Grizzl-E firmware) expects to release version 6 of the firmware in early 2023, which may fix these problems.
+Grizzl-E firmware 5.x has a few OCPP-compliance defects, including responding to certain OCPP server messages with invalid JSON. Firmware 3.x.x on chargers such as the Mini Connect and Ultimate does not seem to have these issues. Symptoms of this problem include repeated reboots of the charger. By editing the OCPP server source code, one can avoid these problematic messages and obtain useful charger behaviour. ChargeLabs (the company working on the Grizzl-E firmware) expects to release version 6 of the firmware in early 2023, which may fix these problems.
 
 The workaround consists of:
 - checking the *Skip OCPP schema validation* checkbox during OCPP server configuration


### PR DESCRIPTION
Hi there!

I got a Grizzl-E Mini Connect 2024 and have been running it with the HA OCPP integration for a month or two with almost zero issues, despite the major issues and required workarounds reported in the documentation. It seems the Mini Connect and Ultimate models use a different firmware series (3.x.x vs 5.x) and they have resolve the majority of the issues.

This is my Mini Connect running on the latest version of the OCPP integration ([0.8.4](https://github.com/lbbrhzn/ocpp/releases/tag/v0.8.4)) with no modifications to the integration code. Not every sensor is provided but the ones that are provided work perfectly so far.

![Screenshot 2025-03-15 at 5 55 40 PM](https://github.com/user-attachments/assets/7c8b0e3f-b325-4fbd-8b38-c1dc5aed0e02)

The only issues I've had with the OCPP integration, so far, is amperage changes not being applied. After several discussions with United Chargers they acknowledged the issue and said it should be fixed in an upcoming firmware update.

Here is a copy of the relevant portion of the email thread with them.

![Screenshot 2025-03-15 at 5 42 10 PM](https://github.com/user-attachments/assets/7145c8a9-bf6f-408b-a7ff-84a183566332)

They have also setup a dedicated email address for working with them on OCPP implementation issues at integrations@unitedchargers.com. I decided not to include that email address in the documentation directly since it's intended more for developers to work with them on OCPP defects rather than be used as a setup support inbox for general users. But open to discussion on it.

![Screenshot 2025-03-15 at 5 43 48 PM](https://github.com/user-attachments/assets/475e2564-65c4-4b19-bcf5-1b75b177007c)

Anyway, I thought this was all really good and useful info for people considering Grizzl-E chargers, specifically the Mini and Ultimate who want to integrate into Home Assistant. With the current documentation they might be scared away thinking it won't work.

Happy to make any recommended changes!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced details on Grizzl-E charger support, specifying which models are compatible with firmware 3.x.x.
	- Clarified that OCPP compliance issues affect firmware version 5.x, while Mini Connect and Ultimate models running firmware 3.x.x remain issue‑free.
	- Noted a known firmware issue for version 03.09.0 with an upcoming fix in version 03.11.0 and provided references for further guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->