### PR TITLE
Add support for Morek Smart AC Charger (#1574)

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -107,6 +107,11 @@ match transactions and it won't report some meter values such as session time.
 
 ## [Mennekes Amtron Charge Control](https://www.mennekes.de/emobility/produkte/charge-control/)
 
+## [Morek Smart AC Charger](https://ev.morek.eu/products-morek-quick-charge-11-22-kw/)
+Successful connection requires firmware version **A0-MEV-V2.0.9** or newer.
+
+The "Charger idle sampling interval" is not supported. Set this to **0** to avoid a "ClockAlignedDataInterval is read-only" warning.
+
 ## [Simpson & Partners](https://simpson-partners.com/home-ev-charger/)
 All basic functions work properly
 


### PR DESCRIPTION
Update supported-devices.md for Morek Smart AC Charger.

I have been successfully using the Morek 11kW Smart AC charger (model MEV11DREWN6T2) with this integration for over a year. Early firmware versions had connection exceptions, but these were resolved in firmware version **A0-MEV-V2.0.9**.

Closes #1574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added information about support for the "Morek Smart AC Charger," including firmware requirements and feature limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->