### PR TITLE
add ocpp versions supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![OCPP](https://github.com/home-assistant/brands/raw/master/custom_integrations/ocpp/icon.png)
 
-This is a Home Assistant integration for Electric Vehicle chargers that support the Open Charge Point Protocol.
+This is a Home Assistant integration for Electric Vehicle chargers that support the following Open Charge Point Protocols 1.6j, 2.0.1 and 2.1 (experimental).
 
 * based on the [Python OCPP Package](https://github.com/mobilityhouse/ocpp).
 * HACS compliant repository 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to specify supported versions of the Open Charge Point Protocol, including 1.6j, 2.0.1, and experimental 2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->