### PR TITLE
Support for multiple connectors per charger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# HA Development
+config/
+**/.DS_Store

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import re
 import ssl
 
 from functools import partial
@@ -88,6 +89,10 @@ CUSTMSG_SERVICE_DATA_SCHEMA = vol.Schema(
         vol.Required("requested_message"): cv.string,
     }
 )
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(s).lower())
 
 
 class CentralSystem:
@@ -192,7 +197,7 @@ class CentralSystem:
 
     @staticmethod
     def _norm_conn(connector_id: int | None) -> int:
-        if connector_id in (None, 0):
+        if connector_id is None:
             return 0
         try:
             return int(connector_id)
@@ -293,19 +298,49 @@ class CentralSystem:
     def get_metric(self, id: str, measurand: str, connector_id: int | None = None):
         """Return last known value for given measurand."""
         # allow id to be either cpid or cp_id
-        cp_id, m = self._get_metrics(id)
-
-        if m is None:
+        cp_id = self.cpids.get(id, id)
+        if cp_id not in self.charge_points:
             return None
 
-        conn = self._norm_conn(connector_id)
-        try:
-            return m[(conn, measurand)].value
-        except Exception:
-            if conn == 0:
-                with contextlib.suppress(Exception):
-                    return m[measurand].value
+        cp = self.charge_points[cp_id]
+        m = cp._metrics
+        n_connectors = getattr(cp, "num_connectors", 1) or 1
+
+        def _try_val(key):
+            with contextlib.suppress(Exception):
+                val = m[key].value
+                return val
             return None
+
+        # 1) Explicit connector_id (including 0): just get it
+        if connector_id is not None:
+            conn = 0 if connector_id == 0 else connector_id
+            return _try_val((conn, measurand))
+
+        # 2) No connector_id: try CHARGER level (conn=0)
+        val = _try_val((0, measurand))
+        if val is not None:
+            return val
+
+        # 3) Legacy "flat" key (before the connector support)
+        with contextlib.suppress(Exception):
+            val = m[measurand].value
+            if val is not None:
+                return val
+
+        # 4) Fallback to connector 1 (old tests often expect this)
+        if n_connectors >= 1:
+            val = _try_val((1, measurand))
+            if val is not None:
+                return val
+
+        # 5) Last resort: find the first connector 2..N with value
+        for c in range(2, int(n_connectors) + 1):
+            val = _try_val((c, measurand))
+            if val is not None:
+                return val
+
+        return None
 
     def del_metric(self, id: str, measurand: str, connector_id: int | None = None):
         """Set given measurand to None."""
@@ -326,46 +361,124 @@ class CentralSystem:
     def get_unit(self, id: str, measurand: str, connector_id: int | None = None):
         """Return unit of given measurand."""
         # allow id to be either cpid or cp_id
-        cp_id, m = self._get_metrics(id)
-        if m is None:
+        cp_id = self.cpids.get(id, id)
+        if cp_id not in self.charge_points:
             return None
-        conn = self._norm_conn(connector_id)
-        try:
-            return m[(conn, measurand)].unit
-        except Exception:
-            if conn == 0:
-                with contextlib.suppress(Exception):
-                    return m[measurand].unit
+
+        cp = self.charge_points[cp_id]
+        m = cp._metrics
+        n_connectors = getattr(cp, "num_connectors", 1) or 1
+
+        def _try_unit(key):
+            with contextlib.suppress(Exception):
+                return m[key].unit
             return None
+
+        if connector_id is not None:
+            conn = 0 if connector_id == 0 else connector_id
+            return _try_unit((conn, measurand))
+
+        val = _try_unit((0, measurand))
+        if val is not None:
+            return val
+
+        with contextlib.suppress(Exception):
+            val = m[measurand].unit
+            if val is not None:
+                return val
+
+        if n_connectors >= 1:
+            val = _try_unit((1, measurand))
+            if val is not None:
+                return val
+
+        for c in range(2, int(n_connectors) + 1):
+            val = _try_unit((c, measurand))
+            if val is not None:
+                return val
+
+        return None
 
     def get_ha_unit(self, id: str, measurand: str, connector_id: int | None = None):
         """Return home assistant unit of given measurand."""
-        cp_id, m = self._get_metrics(id)
-        if m is None:
-            return None
-        conn = self._norm_conn(connector_id)
-        try:
-            return m[(conn, measurand)].ha_unit
-        except Exception:
-            if conn == 0:
-                with contextlib.suppress(Exception):
-                    return m[measurand].ha_unit
+        cp_id = self.cpids.get(id, id)
+        if cp_id not in self.charge_points:
             return None
 
+        cp = self.charge_points[cp_id]
+        m = cp._metrics
+        n_connectors = getattr(cp, "num_connectors", 1) or 1
+
+        def _try_ha_unit(key):
+            with contextlib.suppress(Exception):
+                return m[key].ha_unit
+            return None
+
+        if connector_id is not None:
+            conn = 0 if connector_id == 0 else connector_id
+            return _try_ha_unit((conn, measurand))
+
+        val = _try_ha_unit((0, measurand))
+        if val is not None:
+            return val
+
+        with contextlib.suppress(Exception):
+            val = m[measurand].ha_unit
+            if val is not None:
+                return val
+
+        if n_connectors >= 1:
+            val = _try_ha_unit((1, measurand))
+            if val is not None:
+                return val
+
+        for c in range(2, int(n_connectors) + 1):
+            val = _try_ha_unit((c, measurand))
+            if val is not None:
+                return val
+
+        return None
+
     def get_extra_attr(self, id: str, measurand: str, connector_id: int | None = None):
-        """Return last known extra attributes for given measurand."""
+        """Return extra attributes for given measurand."""
         # allow id to be either cpid or cp_id
-        cp_id, m = self._get_metrics(id)
-        if m is None:
+        cp_id = self.cpids.get(id, id)
+        if cp_id not in self.charge_points:
             return None
-        conn = self._norm_conn(connector_id)
-        try:
-            return m[(conn, measurand)].extra_attr
-        except Exception:
-            if conn == 0:
-                with contextlib.suppress(Exception):
-                    return m[measurand].extra_attr
+
+        cp = self.charge_points[cp_id]
+        m = cp._metrics
+        n_connectors = getattr(cp, "num_connectors", 1) or 1
+
+        def _try_extra(key):
+            with contextlib.suppress(Exception):
+                return m[key].extra_attr
             return None
+
+        if connector_id is not None:
+            conn = 0 if connector_id == 0 else connector_id
+            return _try_extra((conn, measurand))
+
+        val = _try_extra((0, measurand))
+        if val is not None:
+            return val
+
+        with contextlib.suppress(Exception):
+            val = m[measurand].extra_attr
+            if val is not None:
+                return val
+
+        if n_connectors >= 1:
+            val = _try_extra((1, measurand))
+            if val is not None:
+                return val
+
+        for c in range(2, int(n_connectors) + 1):
+            val = _try_extra((c, measurand))
+            if val is not None:
+                return val
+
+        return None
 
     def get_available(self, id: str, connector_id: int | None = None):
         """Return whether the charger (or a specific connector) is available."""
@@ -397,7 +510,7 @@ class CentralSystem:
         if not status_val:
             return cp.status == STATE_OK
 
-        ok_statuses = {
+        ok_statuses_norm = {
             "available",
             "preparing",
             "charging",
@@ -408,7 +521,7 @@ class CentralSystem:
             "reserved",
         }
 
-        ret = str(status_val).lower() in ok_statuses
+        ret = _norm(status_val) in ok_statuses_norm
         return ret
 
     def get_supported_features(self, id: str):
@@ -420,16 +533,26 @@ class CentralSystem:
             return self.charge_points[cp_id].supported_features
         return 0
 
-    async def set_max_charge_rate_amps(self, id: str, value: float):
+    async def set_max_charge_rate_amps(
+        self, id: str, value: float, connector_id: int = 0
+    ):
         """Set the maximum charge rate in amps."""
         # allow id to be either cpid or cp_id
         cp_id = self.cpids.get(id, id)
 
         if cp_id in self.charge_points:
-            return await self.charge_points[cp_id].set_charge_rate(limit_amps=value)
+            return await self.charge_points[cp_id].set_charge_rate(
+                limit_amps=value, conn_id=connector_id
+            )
         return False
 
-    async def set_charger_state(self, id: str, service_name: str, state: bool = True):
+    async def set_charger_state(
+        self,
+        id: str,
+        service_name: str,
+        state: bool = True,
+        connector_id: int | None = 1,
+    ):
         """Carry out requested service/state change on connected charger."""
         # allow id to be either cpid or cp_id
         cp_id = self.cpids.get(id, id)
@@ -437,15 +560,19 @@ class CentralSystem:
         resp = False
         if cp_id in self.charge_points:
             if service_name == csvcs.service_availability.name:
-                resp = await self.charge_points[cp_id].set_availability(state)
+                resp = await self.charge_points[cp_id].set_availability(
+                    state, connector_id=connector_id
+                )
             if service_name == csvcs.service_charge_start.name:
-                resp = await self.charge_points[cp_id].start_transaction()
+                resp = await self.charge_points[cp_id].start_transaction(
+                    connector_id=connector_id
+                )
             if service_name == csvcs.service_charge_stop.name:
                 resp = await self.charge_points[cp_id].stop_transaction()
             if service_name == csvcs.service_reset.name:
                 resp = await self.charge_points[cp_id].reset()
             if service_name == csvcs.service_unlock.name:
-                resp = await self.charge_points[cp_id].unlock()
+                resp = await self.charge_points[cp_id].unlock(connector_id=connector_id)
         return resp
 
     def device_info(self):

--- a/custom_components/ocpp/button.py
+++ b/custom_components/ocpp/button.py
@@ -14,7 +14,7 @@ from homeassistant.components.button import (
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .api import CentralSystem
-from .const import CONF_CPID, CONF_CPIDS, DOMAIN
+from .const import CONF_CPID, CONF_CPIDS, CONF_NUM_CONNECTORS, DOMAIN
 from .enums import HAChargerServices
 
 
@@ -23,6 +23,7 @@ class OcppButtonDescription(ButtonEntityDescription):
     """Class to describe a Button entity."""
 
     press_action: str | None = None
+    per_connector: bool = False
 
 
 BUTTONS: Final = [
@@ -32,6 +33,7 @@ BUTTONS: Final = [
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         press_action=HAChargerServices.service_reset.name,
+        per_connector=False,
     ),
     OcppButtonDescription(
         key="unlock",
@@ -39,22 +41,42 @@ BUTTONS: Final = [
         device_class=ButtonDeviceClass.UPDATE,
         entity_category=EntityCategory.CONFIG,
         press_action=HAChargerServices.service_unlock.name,
+        per_connector=True,
     ),
 ]
 
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Configure the Button platform."""
+    central_system: CentralSystem = hass.data[DOMAIN][entry.entry_id]
+    entities: list[ChargePointButton] = []
 
-    central_system = hass.data[DOMAIN][entry.entry_id]
-    entities = []
     for charger in entry.data[CONF_CPIDS]:
         cp_id_settings = list(charger.values())[0]
         cpid = cp_id_settings[CONF_CPID]
 
-        for ent in BUTTONS:
-            cpx = ChargePointButton(central_system, cpid, ent)
-            entities.append(cpx)
+        num_connectors = int(cp_id_settings.get(CONF_NUM_CONNECTORS, 1))
+
+        for desc in BUTTONS:
+            if desc.per_connector and num_connectors > 1:
+                for connector_id in range(1, num_connectors + 1):
+                    entities.append(
+                        ChargePointButton(
+                            central_system=central_system,
+                            cpid=cpid,
+                            description=desc,
+                            connector_id=connector_id,
+                        )
+                    )
+            else:
+                entities.append(
+                    ChargePointButton(
+                        central_system=central_system,
+                        cpid=cpid,
+                        description=desc,
+                        connector_id=None,
+                    )
+                )
 
     async_add_devices(entities, False)
 
@@ -70,23 +92,34 @@ class ChargePointButton(ButtonEntity):
         central_system: CentralSystem,
         cpid: str,
         description: OcppButtonDescription,
+        connector_id: int | None = None,
     ):
         """Instantiate instance of a ChargePointButton."""
         self.cpid = cpid
         self.central_system = central_system
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            [BUTTON_DOMAIN, DOMAIN, self.cpid, self.entity_description.key]
-        )
+        self.connector_id = connector_id
+        parts = [BUTTON_DOMAIN, DOMAIN, cpid, description.key]
+        if self.connector_id:
+            parts.insert(3, f"conn{self.connector_id}")
+        self._attr_unique_id = ".".join(parts)
         self._attr_name = self.entity_description.name
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.cpid)},
-        )
+        if self.connector_id:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, f"{cpid}-conn{self.connector_id}")},
+                name=f"{cpid} Connector {self.connector_id}",
+                via_device=(DOMAIN, cpid),
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, cpid)},
+                name=cpid,
+            )
 
     @property
     def available(self) -> bool:
         """Return charger availability."""
-        return self.central_system.get_available(self.cpid)  # type: ignore [no-any-return]
+        return self.central_system.get_available(self.cpid, self.connector_id)  # type: ignore[no-any-return]
 
     async def async_press(self) -> None:
         """Triggers the charger press action service."""

--- a/custom_components/ocpp/button.py
+++ b/custom_components/ocpp/button.py
@@ -119,7 +119,7 @@ class ChargePointButton(ButtonEntity):
     @property
     def available(self) -> bool:
         """Return charger availability."""
-        return self.central_system.get_available(self.cpid, self.connector_id)  # type: ignore[no-any-return]
+        return self.central_system.get_available(self.cpid, self.connector_id)
 
     async def async_press(self) -> None:
         """Triggers the charger press action service."""

--- a/custom_components/ocpp/button.py
+++ b/custom_components/ocpp/button.py
@@ -58,7 +58,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
         num_connectors = int(cp_id_settings.get(CONF_NUM_CONNECTORS, 1))
 
         for desc in BUTTONS:
-            if desc.per_connector and num_connectors > 1:
+            if desc.per_connector:
                 for connector_id in range(1, num_connectors + 1):
                     entities.append(
                         ChargePointButton(
@@ -124,5 +124,7 @@ class ChargePointButton(ButtonEntity):
     async def async_press(self) -> None:
         """Triggers the charger press action service."""
         await self.central_system.set_charger_state(
-            self.cpid, self.entity_description.press_action
+            self.cpid,
+            self.entity_description.press_action,
+            connector_id=self.connector_id,
         )

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -93,9 +93,7 @@ STEP_USER_CP_DATA_SCHEMA = vol.Schema(
         vol.Required(
             CONF_FORCE_SMART_CHARGING, default=DEFAULT_FORCE_SMART_CHARGING
         ): bool,
-        vol.Required(CONF_NUM_CONNECTORS, default=DEFAULT_NUM_CONNECTORS): vol.All(
-            int, vol.Range(min=1, max=16)
-        ),
+        vol.Required(CONF_NUM_CONNECTORS, default=DEFAULT_NUM_CONNECTORS): int,
     }
 )
 

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_METER_INTERVAL,
     CONF_MONITORED_VARIABLES,
     CONF_MONITORED_VARIABLES_AUTOCONFIG,
+    CONF_NUM_CONNECTORS,
     CONF_PORT,
     CONF_SKIP_SCHEMA_VALIDATION,
     CONF_SSL,
@@ -39,6 +40,7 @@ from .const import (
     DEFAULT_METER_INTERVAL,
     DEFAULT_MONITORED_VARIABLES,
     DEFAULT_MONITORED_VARIABLES_AUTOCONFIG,
+    DEFAULT_NUM_CONNECTORS,
     DEFAULT_PORT,
     DEFAULT_SKIP_SCHEMA_VALIDATION,
     DEFAULT_SSL,
@@ -91,6 +93,9 @@ STEP_USER_CP_DATA_SCHEMA = vol.Schema(
         vol.Required(
             CONF_FORCE_SMART_CHARGING, default=DEFAULT_FORCE_SMART_CHARGING
         ): bool,
+        vol.Required(CONF_NUM_CONNECTORS, default=DEFAULT_NUM_CONNECTORS): vol.All(
+            int, vol.Range(min=1, max=16)
+        ),
     }
 )
 
@@ -106,7 +111,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OCPP."""
 
     VERSION = 2
-    MINOR_VERSION = 0
+    MINOR_VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
 
     def __init__(self):

--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -25,6 +25,7 @@ CONF_MODE = ha.CONF_MODE
 CONF_MONITORED_VARIABLES = ha.CONF_MONITORED_VARIABLES
 CONF_MONITORED_VARIABLES_AUTOCONFIG = "monitored_variables_autoconfig"
 CONF_NAME = ha.CONF_NAME
+CONF_NUM_CONNECTORS = "num_connectors"
 CONF_PASSWORD = ha.CONF_PASSWORD
 CONF_PORT = ha.CONF_PORT
 CONF_SKIP_SCHEMA_VALIDATION = "skip_schema_validation"
@@ -45,6 +46,7 @@ DEFAULT_CSID = "central"
 DEFAULT_CPID = "charger"
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_MAX_CURRENT = 32
+DEFAULT_NUM_CONNECTORS = 1
 DEFAULT_PORT = 9000
 DEFAULT_SKIP_SCHEMA_VALIDATION = False
 DEFAULT_FORCE_SMART_CHARGING = False
@@ -151,6 +153,7 @@ class ChargerSystemSettings:
     skip_schema_validation: bool
     force_smart_charging: bool
     connection: int | None = None  # number of this connection in central server
+    num_connectors: int = 1
 
 
 @dataclass

--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -62,9 +62,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
         cp_id_settings = list(charger.values())[0]
         cpid = cp_id_settings[CONF_CPID]
         num_connectors = int(cp_id_settings.get(CONF_NUM_CONNECTORS, 1) or 1)
-        for connector_id in (
-            range(1, num_connectors + 1) if num_connectors > 1 else [None]
-        ):
+        for connector_id in range(1, num_connectors + 1):
             for ent in NUMBERS:
                 if ent.key == "maximum_current":
                     ent_initial = cp_id_settings[CONF_MAX_CURRENT]
@@ -163,7 +161,7 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
             self.cpid
         ) and Profiles.SMART & self.central_system.get_supported_features(self.cpid):
             resp = await self.central_system.set_max_charge_rate_amps(
-                self.cpid, num_value
+                self.cpid, num_value, self.connector_id
             )
             if resp is True:
                 self._attr_native_value = num_value

--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -72,7 +72,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 else:
                     ent_initial = ent.initial_value
                     ent_max = ent.native_max_value
-                name_suffix = f" Connector {connector_id}" if connector_id else ""
                 entities.append(
                     ChargePointNumber(
                         hass,
@@ -80,7 +79,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
                         cpid,
                         OcppNumberDescription(
                             key=ent.key,
-                            name=ent.name + name_suffix,
+                            name=ent.name,
                             icon=ent.icon,
                             initial_value=ent_initial,
                             native_min_value=ent.native_min_value,

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -116,6 +116,17 @@ async def async_setup_entry(hass, entry, async_add_devices):
                             connector_id=conn_id,
                         )
                     )
+
+            for metric in ["Energy.Active.Import.Register"]:
+                entities.append(
+                    ChargePointMetric(
+                        hass,
+                        central_system,
+                        cpid,
+                        _mk_desc(metric),
+                        connector_id=None,
+                    )
+                )
         else:
             for metric in CONNECTOR_ONLY:
                 entities.append(

--- a/custom_components/ocpp/switch.py
+++ b/custom_components/ocpp/switch.py
@@ -125,7 +125,7 @@ class ChargePointSwitch(SwitchEntity):
     @property
     def available(self) -> bool:
         """Return if switch is available."""
-        return self.central_system.get_available(self.cpid)  # type: ignore [no-any-return]
+        return self.central_system.get_available(self.cpid, self.connector_id)  # type: ignore [no-any-return]
 
     @property
     def is_on(self) -> bool:
@@ -133,7 +133,7 @@ class ChargePointSwitch(SwitchEntity):
         """Test metric state against condition if present"""
         if self.entity_description.metric_state is not None:
             resp = self.central_system.get_metric(
-                self.cpid, self.entity_description.metric_state
+                self.cpid, self.entity_description.metric_state, self.connector_id
             )
             if resp in self.entity_description.metric_condition:
                 self._state = True

--- a/custom_components/ocpp/translations/de.json
+++ b/custom_components/ocpp/translations/de.json
@@ -27,7 +27,8 @@
                     "idle_interval": "Abtastintervall Leerlauf (Sekunden)",
                     "skip_schema_validation": "Überspringe OCPP-Schemavalidierung",
                     "force_smart_charging": "Erzwinge Smart Charging Funktionsprofil",
-                    "monitored_variables_autoconfig": "Automatische Erkennung der OCPP-Messwerte"
+                    "monitored_variables_autoconfig": "Automatische Erkennung der OCPP-Messwerte",
+                    "num_connectors": "Anzahl der Anschlüsse pro Ladestation"
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -27,7 +27,8 @@
                     "monitored_variables_autoconfig": "Automatic detection of OCPP Measurands",
                     "idle_interval": "Charger idle sampling interval (seconds)",
                     "skip_schema_validation": "Skip OCPP schema validation",
-                    "force_smart_charging": "Force Smart Charging feature profile"
+                    "force_smart_charging": "Force Smart Charging feature profile",
+                    "num_connectors": "Number of connectors per charger"
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/es.json
+++ b/custom_components/ocpp/translations/es.json
@@ -22,7 +22,8 @@
                     "meter_interval": "Intervalo de mediciones (segundos)",
                     "idle_interval": "Intervalo de muestreo del cargador en reposo (segundos)",
                     "skip_schema_validation": "Omitir validación esquema OCPP",
-                    "force_smart_charging": "Forzar perfil de función Smart Charging"
+                    "force_smart_charging": "Forzar perfil de función Smart Charging",
+                    "num_connectors": "Número de conectores por punto de carga"
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -27,7 +27,8 @@
                     "monitored_variables_autoconfig": "Automatic detection of OCPP Measurands",
                     "idle_interval": "Charger idle sampling interval (seconds)",
                     "skip_schema_validation": "Skip OCPP schema validation",
-                    "force_smart_charging": "Force Smart Charging feature profile"
+                    "force_smart_charging": "Force Smart Charging feature profile",
+                    "num_connectors": "Number of connectors per charger"
                 }
             },
             "measurands": {

--- a/custom_components/ocpp/translations/nl.json
+++ b/custom_components/ocpp/translations/nl.json
@@ -22,7 +22,8 @@
                     "max_current": "Maximale laadstroom",
                     "meter_interval": "Meetinterval (secondes)",
                     "skip_schema_validation": "Skip OCPP schema validation",
-                    "force_smart_charging": "Functieprofiel Smart Charging forceren"
+                    "force_smart_charging": "Functieprofiel Smart Charging forceren",
+                    "num_connectors": "Aantal connectoren per Charge point"
                 }
             },
             "measurands": {

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -e
 
 cd "$(dirname "$0")/.."
@@ -7,18 +6,18 @@ cd "$(dirname "$0")/.."
 # Create config dir if not present
 if [[ ! -d "${PWD}/config" ]]; then
     mkdir -p "${PWD}/config"
-    hass --config "${PWD}/config" --script ensure_config
+    /home/vscode/.local/ha-venv/bin/python -m homeassistant --config "${PWD}/config" --script ensure_config
 fi
 
-# Create custom components dir if not present
-if [[ ! -d "${PWD}/config/custom_components" ]]; then
-    mkdir -p "${PWD}/config/custom_components"
-    hass --config "${PWD}/config" --script ensure_config
-fi
+# Ensure custom components dir exists
+mkdir -p "${PWD}/config/custom_components"
 
-# copy the ocpp integration
-rm -rf $PWD/config/custom_components/ocpp
-cp -r -l $PWD/custom_components/ocpp $PWD/config/custom_components/
+# Link the ocpp integration (overwrite if exists)
+ln -sfn "${PWD}/custom_components/ocpp" "${PWD}/config/custom_components/ocpp"
 
-# Start Home Assistant
-hass --config "${PWD}/config" --debug
+# Install debugpy if missing
+/home/vscode/.local/ha-venv/bin/python -m pip install --quiet debugpy || true
+
+# Start Home Assistant with debugger
+exec /home/vscode/.local/ha-venv/bin/python -m debugpy --listen 0.0.0.0:5678 \
+    -m homeassistant --config "${PWD}/config" --debug

--- a/tests/charge_point_test.py
+++ b/tests/charge_point_test.py
@@ -28,10 +28,11 @@ from websockets.asyncio.client import ClientConnection
 
 async def set_switch(hass: HomeAssistant, cpid: str, key: str, on: bool):
     """Toggle a switch."""
+    prefix = "_" if key == "availability" else "_connector_1_"
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON if on else SERVICE_TURN_OFF,
-        service_data={ATTR_ENTITY_ID: f"{SWITCH_DOMAIN}.{cpid}_{key}"},
+        service_data={ATTR_ENTITY_ID: f"{SWITCH_DOMAIN}.{cpid}{prefix}{key}"},
         blocking=True,
     )
 
@@ -43,7 +44,7 @@ async def set_number(hass: HomeAssistant, cpid: str, key: str, value: int):
         "set_value",
         service_data={"value": str(value)},
         blocking=True,
-        target={ATTR_ENTITY_ID: f"{NUMBER_DOMAIN}.{cpid}_{key}"},
+        target={ATTR_ENTITY_ID: f"{NUMBER_DOMAIN}.{cpid}_connector_1_{key}"},
     )
 
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -11,6 +11,7 @@ from custom_components.ocpp.const import (
     CONF_METER_INTERVAL,
     CONF_MONITORED_VARIABLES,
     CONF_MONITORED_VARIABLES_AUTOCONFIG,
+    CONF_NUM_CONNECTORS,
     CONF_PORT,
     CONF_SKIP_SCHEMA_VALIDATION,
     CONF_SSL,
@@ -115,6 +116,30 @@ MOCK_CONFIG_DATA_1 = {
                 CONF_METER_INTERVAL: 60,
                 CONF_MONITORED_VARIABLES: DEFAULT_MONITORED_VARIABLES,
                 CONF_MONITORED_VARIABLES_AUTOCONFIG: False,
+                CONF_NUM_CONNECTORS: 2,
+                CONF_SKIP_SCHEMA_VALIDATION: True,
+                CONF_FORCE_SMART_CHARGING: True,
+            }
+        },
+    ],
+}
+
+# different port with skip schema validation enabled, auto config false
+# and multiple connector support
+MOCK_CONFIG_DATA_1_MC = {
+    **MOCK_CONFIG_DATA,
+    CONF_CSID: "test_csid_1_mc",
+    CONF_PORT: 9001,
+    CONF_CPIDS: [
+        {
+            "CP_1_mc": {
+                CONF_CPID: "test_cpid_9001",
+                CONF_IDLE_INTERVAL: 900,
+                CONF_MAX_CURRENT: 32,
+                CONF_METER_INTERVAL: 60,
+                CONF_MONITORED_VARIABLES: DEFAULT_MONITORED_VARIABLES,
+                CONF_MONITORED_VARIABLES_AUTOCONFIG: False,
+                CONF_NUM_CONNECTORS: 2,
                 CONF_SKIP_SCHEMA_VALIDATION: True,
                 CONF_FORCE_SMART_CHARGING: True,
             }

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -640,14 +640,100 @@ async def test_cms_responses_errors_v16(
         )
 
 
+# @pytest.mark.skip(reason="skip")
+@pytest.mark.timeout(20)  # Set timeout for this test
+@pytest.mark.parametrize(
+    "setup_config_entry",
+    [{"port": 9007, "cp_id": "CP_1_norm_mc", "cms": "cms_norm", "num_connectors": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_1_norm_mc"])
+@pytest.mark.parametrize("port", [9007])
+async def test_cms_responses_normal_multiple_connectors_v16(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """Test central system responses to a charger under normal operation with multiple connectors."""
+
+    cs = setup_config_entry
+    num_connectors = 2
+
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}",
+        subprotocols=["ocpp1.5", "ocpp1.6"],
+    ) as ws:
+        cp = ChargePoint(f"{cp_id}_client", ws, no_connectors=num_connectors)
+
+        tasks = [
+            cp.start(),
+            cp.send_boot_notification(),
+            cp.send_authorize(),
+            cp.send_heartbeat(),
+            cp.send_security_event(),
+            cp.send_firmware_status(),
+            cp.send_data_transfer(),
+            cp.send_status_for_all_connectors(),
+            cp.send_start_transaction(12345),
+        ]
+
+        for conn_id in range(1, num_connectors + 1):
+            tasks.extend(
+                [
+                    cp.send_meter_err_phases(connector_id=conn_id),
+                    cp.send_meter_line_voltage(connector_id=conn_id),
+                    cp.send_meter_periodic_data(connector_id=conn_id),
+                ]
+            )
+
+        tasks.append(cp.send_stop_transaction(1))
+
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)
+
+        await ws.close()
+
+    cpid = cs.charge_points[cp_id].settings.cpid
+
+    assert int(
+        cs.get_metric(cpid, "Energy.Active.Import.Register", connector_id=1)
+    ) == int(1305570 / 1000)
+    assert int(cs.get_metric(cpid, "Energy.Session", connector_id=1)) == int(
+        (54321 - 12345) / 1000
+    )
+    assert int(cs.get_metric(cpid, "Current.Import", connector_id=1)) == 0
+    # assert int(cs.get_metric(cpid, "Voltage")) == 228
+    assert cs.get_unit(cpid, "Energy.Active.Import.Register", connector_id=1) == "kWh"
+    assert cs.get_ha_unit(cpid, "Power.Reactive.Import", connector_id=1) == "var"
+    assert cs.get_unit(cpid, "Power.Reactive.Import", connector_id=1) == "var"
+    assert cs.get_metric("unknown_cpid", "Energy.Active.Import.Register") is None
+    assert cs.get_unit("unknown_cpid", "Energy.Active.Import.Register") is None
+    assert cs.get_extra_attr("unknown_cpid", "Energy.Active.Import.Register") is None
+    assert int(cs.get_supported_features("unknown_cpid")) == 0
+    assert (
+        await asyncio.wait_for(
+            cs.set_max_charge_rate_amps("unknown_cpid", 0), timeout=1
+        )
+        is False
+    )
+    assert (
+        await asyncio.wait_for(
+            cs.set_charger_state("unknown_cpid", csvcs.service_clear_profile, False),
+            timeout=1,
+        )
+        is False
+    )
+
+
 class ChargePoint(cpclass):
     """Representation of real client Charge Point."""
 
-    def __init__(self, id, connection, response_timeout=30):
+    def __init__(self, id, connection, response_timeout=30, no_connectors=1):
         """Init extra variables for testing."""
         super().__init__(id, connection)
+        self.no_connectors = int(no_connectors)
         self.active_transactionId: int = 0
         self.accept: bool = True
+        self.task = None  # reused for background triggers
+        self._tasks: set[asyncio.Task] = set()
 
     @on(Action.get_configuration)
     def on_get_configuration(self, key, **kwargs):
@@ -672,7 +758,9 @@ class ChargePoint(cpclass):
             )
         if key[0] == ConfigurationKey.number_of_connectors.value:
             return call_result.GetConfiguration(
-                configuration_key=[{"key": key[0], "readonly": False, "value": "1"}]
+                configuration_key=[
+                    {"key": key[0], "readonly": False, "value": f"{self.no_connectors}"}
+                ]
             )
         if key[0] == ConfigurationKey.web_socket_ping_interval.value:
             if self.accept is True:
@@ -767,7 +855,7 @@ class ChargePoint(cpclass):
 
     @on(Action.reset)
     def on_reset(self, **kwargs):
-        """Handle change availability request."""
+        """Handle reset request."""
         if self.accept is True:
             return call_result.Reset(ResetStatus.accepted)
         else:
@@ -807,12 +895,34 @@ class ChargePoint(cpclass):
             return call_result.ClearChargingProfile(ClearChargingProfileStatus.unknown)
 
     @on(Action.trigger_message)
-    def on_trigger_message(self, **kwargs):
+    def on_trigger_message(self, requested_message, **kwargs):
         """Handle trigger message request."""
-        if self.accept is True:
-            return call_result.TriggerMessage(TriggerMessageStatus.accepted)
-        else:
+        if not self.accept:
             return call_result.TriggerMessage(TriggerMessageStatus.rejected)
+
+        resp = call_result.TriggerMessage(TriggerMessageStatus.accepted)
+
+        try:
+            from ocpp.v16.enums import (
+                MessageTrigger,
+            )
+
+            connector_id = kwargs.get("connector_id")
+            if requested_message == MessageTrigger.status_notification:
+                if connector_id in (None, 0):
+                    task = asyncio.create_task(self.send_status_for_all_connectors())
+                    self._tasks.add(task)
+                    task.add_done_callback(self._tasks.discard)
+                else:
+                    task = asyncio.create_task(
+                        self.send_status_notification(connector_id)
+                    )
+                    self._tasks.add(task)
+                    task.add_done_callback(self._tasks.discard)
+        except Exception:
+            pass
+
+        return resp
 
     @on(Action.update_firmware)
     def on_update_firmware(self, **kwargs):
@@ -886,49 +996,40 @@ class ChargePoint(cpclass):
         self.active_transactionId = resp.transaction_id
         assert resp.id_tag_info["status"] == AuthorizationStatus.accepted.value
 
-    async def send_status_notification(self):
-        """Send a status notification."""
+    async def send_status_notification(self, connector_id: int = 0):
+        """Send one StatusNotification for a specific connector."""
+        # Connector 0 = CP-level
+        if connector_id == 0:
+            status = ChargePointStatus.suspended_ev
+        elif connector_id == 1:
+            status = ChargePointStatus.charging
+        else:
+            status = ChargePointStatus.available
+
         request = call.StatusNotification(
-            connector_id=0,
+            connector_id=connector_id,
             error_code=ChargePointErrorCode.no_error,
-            status=ChargePointStatus.suspended_ev,
+            status=status,
             timestamp=datetime.now(tz=UTC).isoformat(),
             info="Test info",
             vendor_id="The Mobility House",
             vendor_error_code="Test error",
         )
-        resp = await self.call(request)
-        request = call.StatusNotification(
-            connector_id=1,
-            error_code=ChargePointErrorCode.no_error,
-            status=ChargePointStatus.charging,
-            timestamp=datetime.now(tz=UTC).isoformat(),
-            info="Test info",
-            vendor_id="The Mobility House",
-            vendor_error_code="Test error",
-        )
-        resp = await self.call(request)
-        request = call.StatusNotification(
-            connector_id=2,
-            error_code=ChargePointErrorCode.no_error,
-            status=ChargePointStatus.available,
-            timestamp=datetime.now(tz=UTC).isoformat(),
-            info="Test info",
-            vendor_id="The Mobility House",
-            vendor_error_code="Available",
-        )
-        resp = await self.call(request)
+        await self.call(request)
 
-        assert resp is not None
+    async def send_status_for_all_connectors(self):
+        """Send StatusNotification for 0..no_connectors."""
+        for cid in range(0, max(1, self.no_connectors) + 1):
+            await self.send_status_notification(cid)
 
-    async def send_meter_periodic_data(self):
-        """Send periodic meter data notification."""
+    async def send_meter_periodic_data(self, connector_id: int = 1):
+        """Send periodic meter data notification for a given connector."""
         n = 0
         while self.active_transactionId == 0 and n < 2:
             await asyncio.sleep(1)
             n += 1
         request = call.MeterValues(
-            connector_id=1,
+            connector_id=connector_id,
             transaction_id=self.active_transactionId,
             meter_value=[
                 {
@@ -1067,12 +1168,12 @@ class ChargePoint(cpclass):
         resp = await self.call(request)
         assert resp is not None
 
-    async def send_meter_line_voltage(self):
-        """Send line voltages."""
+    async def send_meter_line_voltage(self, connector_id: int = 1):
+        """Send line voltages for a given connector."""
         while self.active_transactionId == 0:
             await asyncio.sleep(1)
         request = call.MeterValues(
-            connector_id=1,
+            connector_id=connector_id,
             transaction_id=self.active_transactionId,
             meter_value=[
                 {
@@ -1109,12 +1210,12 @@ class ChargePoint(cpclass):
         resp = await self.call(request)
         assert resp is not None
 
-    async def send_meter_err_phases(self):
-        """Send erroneous voltage phase."""
+    async def send_meter_err_phases(self, connector_id: int = 1):
+        """Send erroneous voltage phase for a given connector."""
         while self.active_transactionId == 0:
             await asyncio.sleep(1)
         request = call.MeterValues(
-            connector_id=1,
+            connector_id=connector_id,
             transaction_id=self.active_transactionId,
             meter_value=[
                 {
@@ -1143,12 +1244,12 @@ class ChargePoint(cpclass):
         resp = await self.call(request)
         assert resp is not None
 
-    async def send_meter_energy_kwh(self):
-        """Send periodic energy meter value with kWh unit."""
+    async def send_meter_energy_kwh(self, connector_id: int = 1):
+        """Send periodic energy meter value with kWh unit for a given connector."""
         while self.active_transactionId == 0:
             await asyncio.sleep(1)
         request = call.MeterValues(
-            connector_id=1,
+            connector_id=connector_id,
             transaction_id=self.active_transactionId,
             meter_value=[
                 {
@@ -1168,12 +1269,12 @@ class ChargePoint(cpclass):
         resp = await self.call(request)
         assert resp is not None
 
-    async def send_main_meter_clock_data(self):
-        """Send periodic main meter value. Main meter values dont have transaction_id."""
+    async def send_main_meter_clock_data(self, connector_id: int = 1):
+        """Send periodic main meter value (no transaction_id) for a given connector."""
         while self.active_transactionId == 0:
             await asyncio.sleep(1)
         request = call.MeterValues(
-            connector_id=1,
+            connector_id=connector_id,
             meter_value=[
                 {
                     "timestamp": "2021-06-21T16:15:09Z",
@@ -1192,11 +1293,11 @@ class ChargePoint(cpclass):
         resp = await self.call(request)
         assert resp is not None
 
-    async def send_meter_clock_data(self):
-        """Send periodic meter data notification."""
+    async def send_meter_clock_data(self, connector_id: int = 1):
+        """Send periodic meter data (clock) for a given connector."""
         self.active_transactionId = 0
         request = call.MeterValues(
-            connector_id=1,
+            connector_id=connector_id,
             transaction_id=self.active_transactionId,
             meter_value=[
                 {

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1058,12 +1058,12 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
     # Junk report to be ignored
     await cp.call(call.NotifyReport(2, datetime.now(tz=UTC).isoformat(), 0))
 
-    assert cs.get_metric(cpid, cdet.serial.value) == "SERIAL"
-    assert cs.get_metric(cpid, cdet.model.value) == "MODEL"
-    assert cs.get_metric(cpid, cdet.vendor.value) == "VENDOR"
-    assert cs.get_metric(cpid, cdet.firmware_version.value) == "VERSION"
+    assert cs.get_metric(cpid, cdet.serial.value, connector_id=0) == "SERIAL"
+    assert cs.get_metric(cpid, cdet.model.value, connector_id=0) == "MODEL"
+    assert cs.get_metric(cpid, cdet.vendor.value, connector_id=0) == "VENDOR"
+    assert cs.get_metric(cpid, cdet.firmware_version.value, connector_id=0) == "VERSION"
     assert (
-        cs.get_metric(cpid, cdet.features.value)
+        cs.get_metric(cpid, cdet.features.value, connector_id=0)
         == Profiles.CORE | Profiles.SMART | Profiles.RES | Profiles.AUTH
     )
     assert (
@@ -1164,10 +1164,7 @@ async def _extra_features_test(
     await wait_ready(cs.charge_points[cp_id])
 
     assert (
-        cs.get_metric(
-            cpid,
-            cdet.features.value,
-        )
+        cs.get_metric(cpid, cdet.features.value, connector_id=0)
         == Profiles.CORE
         | Profiles.SMART
         | Profiles.RES
@@ -1219,10 +1216,7 @@ async def _unsupported_base_report_test(
     )
     await wait_ready(cs.charge_points[cp_id])
     assert (
-        cs.get_metric(
-            cpid,
-            cdet.features.value,
-        )
+        cs.get_metric(cpid, cdet.features.value, connector_id=0)
         == Profiles.CORE | Profiles.REM | Profiles.FW
     )
 

--- a/tests/test_charge_point_v201_multi.py
+++ b/tests/test_charge_point_v201_multi.py
@@ -1,0 +1,370 @@
+"""Implement a test by a simulating an OCPP 2.0.1 chargepoint."""
+
+import asyncio
+from datetime import datetime, UTC
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ocpp.const import CONF_CPIDS, CONF_CPID
+from custom_components.ocpp.const import (
+    DOMAIN as OCPP_DOMAIN,
+)
+from custom_components.ocpp.enums import (
+    HAChargerServices as csvcs,
+)
+import ocpp
+from ocpp.routing import on
+import ocpp.exceptions
+from ocpp.v201 import ChargePoint as cpclass, call, call_result
+from ocpp.v201.enums import (
+    Action,
+    BootReasonEnumType,
+    ChangeAvailabilityStatusEnumType,
+    ChargingStateEnumType,
+    ConnectorStatusEnumType,
+    DataEnumType,
+    GenericDeviceModelStatusEnumType,
+    MutabilityEnumType,
+    OperationalStatusEnumType,
+    RegistrationStatusEnumType,
+    ReportBaseEnumType,
+    SetVariableStatusEnumType,
+    TransactionEventEnumType,
+    TriggerMessageStatusEnumType,
+    TriggerReasonEnumType,
+    UpdateFirmwareStatusEnumType,
+)
+from ocpp.v201.datatypes import (
+    ComponentType,
+    EVSEType,
+    VariableType,
+    VariableAttributeType,
+    VariableCharacteristicsType,
+    ReportDataType,
+    SetVariableResultType,
+)
+
+from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_CP_APPEND
+
+from .charge_point_test import (
+    create_configuration,
+    run_charge_point_test,
+    remove_configuration,
+    wait_ready,
+)
+
+
+class MultiConnectorChargePoint(cpclass):
+    """Minimal OCPP 2.0.1 client som rapporterar 2 EVSE (1: två connectors, 2: en)."""
+
+    def __init__(self, cp_id, ws):
+        """Initialize."""
+        super().__init__(cp_id, ws)
+        self.inventory_done = asyncio.Event()
+        self.last_start_evse_id = None
+
+    @on(Action.get_base_report)
+    async def on_get_base_report(self, request_id: int, report_base: str, **kwargs):
+        """Get base report."""
+        assert report_base in (ReportBaseEnumType.full_inventory, "FullInventory")
+        asyncio.create_task(self._send_full_inventory(request_id))  # noqa: RUF006
+        return call_result.GetBaseReport(
+            GenericDeviceModelStatusEnumType.accepted.value
+        )
+
+    @on(Action.trigger_message)
+    async def on_trigger_message(self, requested_message: str, **kwargs):
+        """Handle trigger message."""
+        self.last_trigger = (requested_message, kwargs.get("evse"))
+        return call_result.TriggerMessage(TriggerMessageStatusEnumType.accepted.value)
+
+    @on(Action.update_firmware)
+    async def on_update_firmware(self, request_id: int, firmware: dict, **kwargs):
+        """Handle update firmware."""
+        return call_result.UpdateFirmware(UpdateFirmwareStatusEnumType.rejected.value)
+
+    @on(Action.set_variables)
+    async def on_set_variables(self, set_variable_data: list[dict], **kwargs):
+        """Handle SetVariables."""
+        results: list[SetVariableResultType] = []
+        for item in set_variable_data:
+            comp = item.get("component", {})
+            var = item.get("variable", {})
+            results.append(
+                SetVariableResultType(
+                    SetVariableStatusEnumType.accepted,
+                    ComponentType(
+                        comp.get("name"),
+                        instance=comp.get("instance"),
+                        evse=comp.get("evse"),
+                    ),
+                    VariableType(
+                        var.get("name"),
+                        instance=var.get("instance"),
+                    ),
+                )
+            )
+        return call_result.SetVariables(results)
+
+    async def _send_full_inventory(self, request_id: int):
+        ts = datetime.now(UTC).isoformat()
+        report_data = [
+            # EVSE 1
+            ReportDataType(
+                ComponentType("EVSE", evse=EVSEType(1)),
+                VariableType("Status"),
+                [VariableAttributeType(value="OK")],
+            ),
+            # EVSE 2
+            ReportDataType(
+                ComponentType("EVSE", evse=EVSEType(2)),
+                VariableType("Status"),
+                [VariableAttributeType(value="OK")],
+            ),
+            # Connector(1,1)
+            ReportDataType(
+                ComponentType("Connector", evse=EVSEType(1, connector_id=1)),
+                VariableType("Enabled"),
+                [
+                    VariableAttributeType(
+                        value="true", mutability=MutabilityEnumType.read_only
+                    )
+                ],
+            ),
+            # Connector(1,2)
+            ReportDataType(
+                ComponentType("Connector", evse=EVSEType(1, connector_id=2)),
+                VariableType("Enabled"),
+                [
+                    VariableAttributeType(
+                        value="true", mutability=MutabilityEnumType.read_only
+                    )
+                ],
+            ),
+            # Connector(2,1)
+            ReportDataType(
+                ComponentType("Connector", evse=EVSEType(2, connector_id=1)),
+                VariableType("Enabled"),
+                [
+                    VariableAttributeType(
+                        value="true", mutability=MutabilityEnumType.read_only
+                    )
+                ],
+            ),
+            # SmartChargingCtrlr.Available
+            ReportDataType(
+                ComponentType("SmartChargingCtrlr"),
+                VariableType("Available"),
+                [
+                    VariableAttributeType(
+                        value="true", mutability=MutabilityEnumType.read_only
+                    )
+                ],
+            ),
+            # SampledDataCtrlr.TxUpdatedMeasurands
+            ReportDataType(
+                ComponentType("SampledDataCtrlr"),
+                VariableType("TxUpdatedMeasurands"),
+                [VariableAttributeType(value="", persistent=True)],
+                VariableCharacteristicsType(
+                    DataEnumType.member_list,
+                    False,
+                    values_list="Energy.Active.Import.Register,Current.Import,Voltage",
+                ),
+            ),
+        ]
+
+        req = call.NotifyReport(
+            request_id=request_id,
+            generated_at=ts,
+            seq_no=0,
+            report_data=report_data,
+            tbc=False,
+        )
+        await self.call(req)
+        self.inventory_done.set()
+
+    @on(Action.change_availability)
+    async def on_change_availability(self, operational_status: str, **kwargs):
+        """Handle change availability."""
+        self.operative = operational_status == OperationalStatusEnumType.operative.value
+        return call_result.ChangeAvailability(
+            ChangeAvailabilityStatusEnumType.accepted.value
+        )
+
+    @on(Action.request_start_transaction)
+    async def on_request_start_transaction(
+        self, evse_id: int, id_token: dict, **kwargs
+    ):
+        """Handle request for start transaction."""
+        self.last_start_evse_id = evse_id
+        return call_result.RequestStartTransaction(status="Accepted")
+
+    @on(Action.request_stop_transaction)
+    async def on_request_stop_transaction(self, transaction_id: str, **kwargs):
+        """Handle request for stop transaction."""
+        return call_result.RequestStopTransaction(status="Accepted")
+
+    async def send_status(
+        self, evse_id: int, connector_id: int, status: ConnectorStatusEnumType
+    ):
+        """Send status."""
+        await self.call(
+            call.StatusNotification(
+                timestamp=datetime.now(UTC).isoformat(),
+                connector_status=status.value,
+                evse_id=evse_id,
+                connector_id=connector_id,
+            )
+        )
+
+    async def send_tx_started_eair_wh(
+        self, evse_id: int, connector_id: int, tx_id: str, eair_wh: int
+    ):
+        """Send EAIR on transaction started."""
+        await self.call(
+            call.TransactionEvent(
+                event_type=TransactionEventEnumType.started,
+                timestamp=datetime.now(UTC).isoformat(),
+                trigger_reason=TriggerReasonEnumType.authorized,
+                seq_no=0,
+                transaction_info={
+                    "transaction_id": tx_id,
+                    "charging_state": ChargingStateEnumType.charging,
+                },
+                evse={"id": evse_id, "connector_id": connector_id},
+                meter_value=[
+                    {
+                        "timestamp": datetime.now(UTC).isoformat(),
+                        "sampled_value": [
+                            {
+                                "measurand": "Energy.Active.Import.Register",
+                                "value": eair_wh,
+                                "unit_of_measure": {"unit": "Wh"},
+                            }
+                        ],
+                    }
+                ],
+            )
+        )
+
+    async def send_tx_updated_eair_wh(
+        self, evse_id: int, connector_id: int, tx_id: str, eair_wh: int
+    ):
+        """Send EAIR on transaction updated."""
+        await self.call(
+            call.TransactionEvent(
+                event_type=TransactionEventEnumType.updated,
+                timestamp=datetime.now(UTC).isoformat(),
+                trigger_reason=TriggerReasonEnumType.meter_value_periodic,
+                seq_no=1,
+                transaction_info={
+                    "transaction_id": tx_id,
+                    "charging_state": ChargingStateEnumType.charging,
+                },
+                evse={"id": evse_id, "connector_id": connector_id},
+                meter_value=[
+                    {
+                        "timestamp": datetime.now(UTC).isoformat(),
+                        "sampled_value": [
+                            {
+                                "measurand": "Energy.Active.Import.Register",
+                                "value": eair_wh,
+                                "unit_of_measure": {"unit": "Wh"},
+                            }
+                        ],
+                    }
+                ],
+            )
+        )
+
+
+@pytest.mark.timeout(150)
+async def test_v201_multi_connectors_per_evse(hass, socket_enabled):
+    """Test multi connector per EVSE functionality."""
+    cp_id = "CP_v201_multi"
+
+    config_data = MOCK_CONFIG_DATA.copy()
+    config_data[CONF_CPIDS].append({cp_id: MOCK_CONFIG_CP_APPEND.copy()})
+    config_data[CONF_CPIDS][-1][cp_id][CONF_CPID] = "test_v201_cpid"
+
+    config_entry = MockConfigEntry(
+        domain=OCPP_DOMAIN,
+        data=config_data,
+        entry_id="test_v201_multi",
+        title="test_v201_multi",
+        version=2,
+        minor_version=0,
+    )
+
+    cs = await create_configuration(hass, config_entry)
+    ocpp.messages.ASYNC_VALIDATION = False
+
+    async def _scenario(hass, cs, cp: MultiConnectorChargePoint):
+        boot = await cp.call(
+            call.BootNotification(
+                {
+                    "serial_number": "SERIAL",
+                    "model": "MODEL",
+                    "vendor_name": "VENDOR",
+                    "firmware_version": "VERSION",
+                },
+                BootReasonEnumType.power_up.value,
+            )
+        )
+        assert boot.status == RegistrationStatusEnumType.accepted.value
+
+        await wait_ready(cs.charge_points["CP_v201_multi"])
+
+        await asyncio.wait_for(cp.inventory_done.wait(), timeout=5)
+
+        cp_srv = cs.charge_points["CP_v201_multi"]
+        for _ in range(50):
+            if getattr(cp_srv, "num_connectors", 0) == 3:
+                break
+            await asyncio.sleep(0.1)
+        assert cp_srv.num_connectors == 3
+
+        cpid = cp_srv.settings.cpid
+
+        await cp.send_status(1, 1, ConnectorStatusEnumType.available)
+        await cp.send_status(1, 2, ConnectorStatusEnumType.occupied)
+        await cp.send_status(2, 1, ConnectorStatusEnumType.unavailable)
+        await asyncio.sleep(0.05)
+
+        assert cs.get_metric(cpid, "Status.Connector", connector_id=1) == "Available"
+        assert cs.get_metric(cpid, "Status.Connector", connector_id=2) == "Occupied"
+        assert cs.get_metric(cpid, "Status.Connector", connector_id=3) == "Unavailable"
+
+        await cp.send_tx_started_eair_wh(1, 2, "TX-1", 10_000)
+        await cp.send_tx_updated_eair_wh(1, 2, "TX-1", 10_500)
+        await asyncio.sleep(0.05)
+
+        assert cs.get_metric(
+            cpid, "Energy.Active.Import.Register", connector_id=2
+        ) == pytest.approx(10.5)
+        assert cs.get_metric(cpid, "Energy.Session", connector_id=2) == pytest.approx(
+            0.5
+        )
+        assert (
+            cs.get_unit(cpid, "Energy.Active.Import.Register", connector_id=2) == "kWh"
+        )
+        assert cs.get_unit(cpid, "Energy.Session", connector_id=2) == "kWh"
+
+        ok = await cs.set_charger_state(
+            cpid, csvcs.service_charge_start.name, True, connector_id=3
+        )
+        assert ok is True
+        await asyncio.sleep(0.05)
+        assert cp.last_start_evse_id == 2
+
+    await run_charge_point_test(
+        config_entry,
+        "CP_v201_multi",
+        ["ocpp2.0.1"],
+        lambda ws: MultiConnectorChargePoint("CP_v201_multi_client", ws),
+        [lambda cp: _scenario(hass, cs, cp)],
+    )
+
+    await remove_configuration(hass, config_entry)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -15,6 +15,7 @@ from .const import (
     MOCK_CONFIG_FLOW,
     CONF_CPIDS,
     CONF_MONITORED_VARIABLES_AUTOCONFIG,
+    CONF_NUM_CONNECTORS,
     DEFAULT_MONITORED_VARIABLES,
 )
 
@@ -116,6 +117,7 @@ async def test_successful_discovery_flow(hass, bypass_get_data):
     flow_output[CONF_CPIDS][-1]["test_cp_id"][CONF_MONITORED_VARIABLES_AUTOCONFIG] = (
         False
     )
+    flow_output[CONF_CPIDS][-1]["test_cp_id"][CONF_NUM_CONNECTORS] = 1
     assert result_meas["type"] == data_entry_flow.FlowResultType.ABORT
     entry = hass.config_entries._entries.get_entries_for_domain(DOMAIN)[0]
     assert entry.data == flow_output

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,7 +10,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.ocpp import CentralSystem
 from custom_components.ocpp.const import DOMAIN
 
-from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_DATA_1, MOCK_CONFIG_MIGRATION_FLOW
+from .const import (
+    MOCK_CONFIG_DATA,
+    MOCK_CONFIG_DATA_1,
+    MOCK_CONFIG_MIGRATION_FLOW,
+    MOCK_CONFIG_DATA_1_MC,
+)
 
 
 # We can pass fixtures as defined in conftest.py to tell pytest to use the fixture
@@ -30,6 +35,42 @@ async def test_setup_unload_and_reload_entry(
         title="test_cms1",
         version=2,
         minor_version=0,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
+
+    # Set up the entry and assert that the values set during setup are where we expect
+    # them to be. Because we have patched the ocppDataUpdateCoordinator.async_get_data
+    # call, no code from custom_components/ocpp/api.py actually runs.
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert DOMAIN in hass.data
+    assert config_entry.entry_id in hass.data[DOMAIN]
+    assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+
+    # Reload the entry and assert that the data from above is still there
+    assert await hass.config_entries.async_reload(config_entry.entry_id)
+    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+    assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+
+    # Unload the entry and verify that the data has been removed
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_setup_unload_and_reload_entry_multiple_connectors(
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+):
+    """Test entry setup and unload."""
+    # Create a mock entry so we don't have to go through config flow
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA_1_MC,
+        entry_id="test_cms1_mc",
+        title="test_cms1_mc",
+        version=2,
+        minor_version=1,
     )
     config_entry.add_to_hass(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
Add support for multiple connectors per charger. 

Breaking change is that Connector devices are now always added to a ChargePoint, even if there's only one outlet. I couldn't figure out a solid way of creating Connector devices/sensors after a charger has reported the number of connectors, so there is a new config entry **num_connectors** that defaults to 1.

Tested on a ChargeStorm Connected v1 (OCPP v 1.6) with two outlets.