### PR TITLE
Correct custom component name for debuggging

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -65,7 +65,7 @@ ocpp:
 logger:
   default: info
   logs:
-    custom_components.cpps: debug
+    custom_components.ocpp: debug
 
 # If you need to debug uncomment the line below (doc: https://www.home-assistant.io/integrations/debugpy/)
 # debugpy:


### PR DESCRIPTION
Tried debugging with this config and realized it wasn't working because this wasn't correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected debug logging to target the OCPP component instead of the CPPS component, ensuring relevant diagnostics are captured where expected.
  * Improves clarity of logs during troubleshooting and reduces noise from unrelated components.
  * No impact on functionality or other settings; only logging behavior is adjusted for more accurate debugging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->