### PR TITLE
Fix EVPoint Statin Supported Features Separator

### DIFF
--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -261,7 +261,7 @@ class ChargePoint(cp):
         req = call.GetConfiguration(key=[ckey.supported_feature_profiles.value])
         resp = await self.call(req)
         try:
-            feature_list = (resp.configuration_key[0][om.value.value]).split(",")
+            feature_list = (resp.configuration_key[0][om.value.value]).replace(";", ",").split(",")
         except (IndexError, KeyError, TypeError):
             feature_list = [""]
         if feature_list[0] == "":


### PR DESCRIPTION
The EVPoint charging stations are responding to SupportedFeatureProfiles with the fallowing format:
```
Core;FirmwareManagement;LocalAuthListManagement;Reservation;SmartCharging;RemoteTrigger
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of feature/profile responses to normalize comma and semicolon separators, fixing cases where semicolon-delimited values were missed or misinterpreted. This yields more reliable detection and consistent behavior when devices return different separator formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->