### PR TITLE
Skip processing MeterValues when HA reports unavailable sensor values

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -1025,6 +1025,8 @@ class ChargePoint(cp):
 
             if st and st.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
                 return st.state
+            if st and st.state == STATE_UNAVAILABLE:
+                return STATE_UNAVAILABLE
 
         return None
 


### PR DESCRIPTION
This change stops the MeterValues handler from processing readings when Home Assistant reports an entity as `STATE_UNAVAILABLE`. This can happen during or right after an HA restart. Before this fix, the handler could receive `Unavailable` from HA during the restore phase and mistakenly treat it as the value is not available at all. That caused incorrect restoration of `energy_meter_start` and `transaction_id`, which in turn produced wrong `energy_session` and `energy_active_import` values.

#### Changes

* Adds a check: if `get_ha_metric(...)` returns `STATE_UNAVAILABLE`, the incoming MeterValues message is skipped.
* Processing resumes automatically once HA finishes reloading and valid OCPP values can be restored again.

#### Example

After an HA reboot, all `evcharger` entities may temporarily show `unavailable` while the charger keeps sending OCPP MeterValues. Previously, this led to `energy_meter_start` being possibly restored as `None`, which produced incorrect energy calculations (`energy_session`, `energy_active_import`). With this change, the handler returns early and waits for HA to provide real values again, avoiding using responses before data is available in HA to be restored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of unavailable metrics across charge point flows: the system now immediately treats unavailable sensor values as unavailable, logs the condition, schedules a refresh, and skips further processing for those meter/transaction updates to avoid incorrect state propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->