### PR TITLE
Update config_flow.py to permit capital letters in ocpp charger name

### DIFF
--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -79,7 +79,11 @@ STEP_USER_CS_DATA_SCHEMA = vol.Schema(
 
 STEP_USER_CP_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_CPID, default=DEFAULT_CPID): vol.All(str, str.lower().replace(" ","_")),
+        vol.Required(CONF_CPID, default=DEFAULT_CPID): vol.All(
+            str,
+            vol.Lower,
+            lambda v: v.replace(" ", "_"),
+        ),
         vol.Required(CONF_MAX_CURRENT, default=DEFAULT_MAX_CURRENT): int,
         vol.Required(
             CONF_MONITORED_VARIABLES_AUTOCONFIG,


### PR DESCRIPTION
Fix issue with the use of capital letters in the ocpp name of the charger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPID input validation: user-entered identifiers are now normalized by converting letters to lowercase and replacing spaces with underscores, reducing input errors and ensuring consistent handling of CPID entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->