### PR TITLE
Fix sensor data not updating for single-connector chargers (#1835)

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -924,7 +924,14 @@ class ChargePoint(cp):
                             # connector_id == 0 or missing → map based on topology
                             target_cid = 1 if single else 0
                     else:
-                        target_cid = connector_id
+                        # For single-connector chargers, remap connector 0 to connector 1
+                        # to match process_phases behavior and ensure consistent metric storage.
+                        # This prevents measurands sent on connectorId=0 (e.g., clock-aligned data)
+                        # from being stored in a different slot than periodic data on connectorId=1.
+                        if single and (connector_id is None or connector_id == 0):
+                            target_cid = 1
+                        else:
+                            target_cid = connector_id
 
                     # For EAIR: process only the best candidate in this bucket, skip others (incl. Transaction.Begin)
                     if is_eair and idx != best_eair_idx:

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -924,12 +924,12 @@ class ChargePoint(cp):
                             # connector_id == 0 or missing → map based on topology
                             target_cid = 1 if single else 0
                     else:
-                        # For single-connector chargers, remap connector 0 to connector 1
-                        # to match process_phases behavior and ensure consistent metric storage.
-                        # This prevents measurands sent on connectorId=0 (e.g., clock-aligned data)
-                        # from being stored in a different slot than periodic data on connectorId=1.
-                        if single and (connector_id is None or connector_id == 0):
-                            target_cid = 1
+                        # Remap connector_id=None/0 consistently, matching process_phases behavior.
+                        # Single-connector → slot 1; multi-connector → slot 0 (charger-wide).
+                        # Without this, connector_id=None would pass through as a dict key and
+                        # break _ConnectorAwareMetrics.__getitem__ on multi-connector chargers.
+                        if connector_id is None or connector_id == 0:
+                            target_cid = 1 if single else 0
                         else:
                             target_cid = connector_id
 

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -513,3 +513,41 @@ async def test_session_and_lifetime_eair_distinction(hass):
     main_after_life2 = srv2._metrics[(1, "Energy.Active.Import.Register")].value
     # Lifetime EAIR should be updated to 123.45 kWh.
     assert pytest.approx(main_after_life2, rel=1e-6) == 123.45
+
+
+@pytest.mark.timeout(5)
+async def test_process_measurands_non_eair_phase_none(hass):
+    """Non-EAIR measurand with phase=None uses the original connector_id."""
+    version = SimpleNamespace(value="1.6")
+    fake_hass = SimpleNamespace(
+        async_create_task=lambda c: asyncio.create_task(c),
+        helpers=SimpleNamespace(
+            entity_component=SimpleNamespace(async_update_entity=lambda eid: None)
+        ),
+    )
+    fake_entry = SimpleNamespace(entry_id="dummy")
+    fake_central = SimpleNamespace(
+        websocket_ping_interval=0,
+        websocket_ping_timeout=0,
+        websocket_ping_tries=0,
+    )
+    fake_settings = SimpleNamespace(cpid="cpid_dummy")
+    fake_conn = SimpleNamespace(state=State.CLOSED)
+
+    srv = BaseCP(
+        "cp_non_eair",
+        fake_conn,
+        version,
+        fake_hass,
+        fake_entry,
+        fake_central,
+        fake_settings,
+    )
+
+    # Send a non-EAIR measurand (Current.Offered) with phase=None and connector_id=1.
+    samples = [[MeasurandValue("Current.Offered", 32.0, None, "A", None, None)]]
+    srv.process_measurands(samples, is_transaction=False, connector_id=1)
+
+    metric = srv._metrics[(1, "Current.Offered")]
+    assert metric.value == 32.0
+    assert metric.unit == "A"


### PR DESCRIPTION
## Summary
- For single-connector chargers, non-phased measurands (like `Current.Offered`) sent with `connectorId=0` were stored at connector slot 0
- Meanwhile, `process_phases` correctly remaps phased values to connector 1
- This mismatch caused some sensors to intermittently fail to update, especially clock-aligned vs periodic data
- Fix: remap `connectorId=0` to `1` for non-EAIR measurands on single-connector chargers, matching the existing `process_phases` behavior

## Files changed
- `custom_components/ocpp/chargepoint.py` — added connector ID remapping for non-phased measurands

## Test plan
- [ ] Test with a single-connector Wallbox charger
- [ ] Verify `Current.Import` and `Current.Offered` both update on `Sample.Periodic`
- [ ] Verify `Sample.Clock` data also updates correctly
- [ ] Verify no regression for multi-connector chargers

Fixes #1835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed measurement allocation when connector identifiers are missing or zero: single-connector chargers now map readings to connector 1, and multi-connector chargers no longer use invalid connector keys. Metrics are now assigned to the correct connector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->