### PR TITLE
Fix id_tag sensor not updated for local authorization (#1871)

### DIFF
--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1086,6 +1086,9 @@ class ChargePoint(cp):
             self._active_tx[connector_id] = tx_id
             self.active_transaction_id = tx_id
             self._metrics[(connector_id, cstat.id_tag.value)].value = id_tag
+            # StartTransaction is not always preceded by Authorize (local auth).
+            # Ensure charger-level id_tag (connector 0) is also updated.
+            self._metrics[0][cstat.id_tag.value].value = id_tag
             self._metrics[(connector_id, cstat.stop_reason.value)].value = ""
             self._metrics[(connector_id, csess.transaction_id.value)].value = tx_id
             try:
@@ -1138,6 +1141,7 @@ class ChargePoint(cp):
         self._active_tx[conn] = 0
         self.active_transaction_id = 0
         self._metrics[(conn, cstat.id_tag.value)].value = ""
+        self._metrics[0][cstat.id_tag.value].value = ""
         self._metrics[(conn, csess.transaction_id.value)].value = 0
         self._metrics[(conn, cstat.stop_reason.value)].value = kwargs.get(
             om.reason.name, None

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1141,7 +1141,21 @@ class ChargePoint(cp):
         self._active_tx[conn] = 0
         self.active_transaction_id = 0
         self._metrics[(conn, cstat.id_tag.value)].value = ""
-        self._metrics[0][cstat.id_tag.value].value = ""
+        # Only clear station-level id_tag if no other connector still has an active
+        # transaction.  Otherwise, keep connector 0 aligned to a remaining active
+        # connector's id_tag so the charger-level sensor stays accurate.
+        remaining_active = [
+            cid
+            for cid, tx in self._active_tx.items()
+            if cid != conn and int(tx or 0) > 0
+        ]
+        if not remaining_active:
+            self._metrics[0][cstat.id_tag.value].value = ""
+        else:
+            keep_cid = remaining_active[0]
+            self._metrics[0][cstat.id_tag.value].value = (
+                self._metrics[(keep_cid, cstat.id_tag.value)].value or ""
+            )
         self._metrics[(conn, csess.transaction_id.value)].value = 0
         self._metrics[(conn, cstat.stop_reason.value)].value = kwargs.get(
             om.reason.name, None

--- a/tests/test_additional_charge_point_v16.py
+++ b/tests/test_additional_charge_point_v16.py
@@ -1162,3 +1162,50 @@ async def test_stop_transaction_misc_paths(
             with contextlib.suppress(asyncio.CancelledError):
                 await task
             await ws.close()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize(
+    "setup_config_entry",
+    [{"port": 9334, "cp_id": "CP_cov_stop_tx_multi", "cms": "cms_services"}],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_cov_stop_tx_multi"])
+@pytest.mark.parametrize("port", [9334])
+async def test_stop_transaction_multi_connector_keeps_station_id_tag(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """Stop tx on one connector while another is active keeps station-level id_tag."""
+    cs = setup_config_entry
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
+    ) as ws:
+        cp = ChargePoint(f"{cp_id}_client", ws)
+        task = asyncio.create_task(cp.start())
+        try:
+            await cp.send_boot_notification()
+            await wait_ready(cs.charge_points[cp_id])
+            srv = cs.charge_points[cp_id]
+
+            # Simulate two running transactions on connectors 1 and 2
+            srv._active_tx[1] = 100
+            srv._active_tx[2] = 200
+            srv.active_transaction_id = 200
+            srv._metrics[(1, "Id.Tag")].value = "user_A"
+            srv._metrics[(2, "Id.Tag")].value = "user_B"
+            srv._metrics[0]["Id.Tag"].value = "user_B"
+
+            # Stop transaction on connector 2 — connector 1 still active
+            result = srv.on_stop_transaction(
+                meter_stop=0, timestamp=None, transaction_id=200
+            )
+            assert result is not None
+            # Station-level id_tag should reflect the still-active connector 1
+            assert srv._metrics[0]["Id.Tag"].value == "user_A"
+            # Connector 2 id_tag should be cleared
+            assert srv._metrics[(2, "Id.Tag")].value == ""
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await ws.close()


### PR DESCRIPTION
## Summary
- `sensor.<cpid>_id_tag` stays stale when charger performs local OCPP 1.6 authorization (skips Authorize, sends StartTransaction directly)
- Root cause: `on_start_transaction` sets connector-level id_tag but not charger-level (connector 0)
- Fix: also update `self._metrics[0][cstat.id_tag.value]` in `on_start_transaction`
- Also clear charger-level id_tag in `on_stop_transaction` for symmetry
- OCPP 2.0.1 handler already does this correctly

## Files changed
- `custom_components/ocpp/ocppv16.py` — update charger-level id_tag in `on_start_transaction` and clear it in `on_stop_transaction`

## Test plan
- [ ] Use RFID card authorized in charger's local list (no Authorize message sent)
- [ ] Verify `sensor.<cpid>_id_tag` updates on StartTransaction
- [ ] Verify `sensor.<cpid>_id_tag` still updates on normal Authorize -> StartTransaction flow
- [ ] Verify id_tag clears on StopTransaction

Fixes #1871

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Starting a connector session now also updates the station-level session ID. Stopping a connector clears or adjusts the station-level ID only when appropriate, preventing stale or conflicting session identifiers across multiple connectors.

* **Tests**
  * Added a test that verifies stopping one connector in a multi-connector scenario preserves or updates the station-level ID correctly and clears the stopped connector's ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->