### PR TITLE
fix: round energy/power values to avoid total_increasing violations

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -67,6 +67,7 @@ from .const import (
 )
 
 TIME_MINUTES = UnitOfTime.MINUTES
+KILO_UNIT_PRECISION = 3  # decimal places when converting W→kW or Wh→kWh (1 Wh resolution)
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
@@ -811,12 +812,12 @@ class ChargePoint(cp):
 
                 if metric_unit == DEFAULT_POWER_UNIT:
                     self._metrics[(target_cid, metric)].value = round(
-                        metric_value / 1000, 3
+                        metric_value / 1000, KILO_UNIT_PRECISION
                     )
                     self._metrics[(target_cid, metric)].unit = HA_POWER_UNIT
                 elif metric_unit == DEFAULT_ENERGY_UNIT:
                     self._metrics[(target_cid, metric)].value = round(
-                        metric_value / 1000, 3
+                        metric_value / 1000, KILO_UNIT_PRECISION
                     )
                     self._metrics[(target_cid, metric)].unit = HA_ENERGY_UNIT
                 else:
@@ -832,8 +833,8 @@ class ChargePoint(cp):
         contract in Home Assistant (e.g. 0.066 → 0.0659999999998035).
         """
         if (measurand_value.unit == "Wh") or (measurand_value.unit is None):
-            return round(measurand_value.value / 1000, 3)
-        return round(measurand_value.value, 3)
+            return round(measurand_value.value / 1000, KILO_UNIT_PRECISION)
+        return round(measurand_value.value, KILO_UNIT_PRECISION)
 
     def process_measurands(
         self,
@@ -913,7 +914,7 @@ class ChargePoint(cp):
                     unit = HA_ENERGY_UNIT
 
                 if unit == DEFAULT_POWER_UNIT:
-                    value = round(value / 1000, 3)
+                    value = round(value / 1000, KILO_UNIT_PRECISION)
                     unit = HA_POWER_UNIT
 
                 if self._metrics[(connector_id, csess.meter_start.value)].value == 0:

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -810,10 +810,10 @@ class ChargePoint(cp):
                 metric_unit = phase_info.get(om.unit.value)
 
                 if metric_unit == DEFAULT_POWER_UNIT:
-                    self._metrics[(target_cid, metric)].value = metric_value / 1000
+                    self._metrics[(target_cid, metric)].value = round(metric_value / 1000, 3)
                     self._metrics[(target_cid, metric)].unit = HA_POWER_UNIT
                 elif metric_unit == DEFAULT_ENERGY_UNIT:
-                    self._metrics[(target_cid, metric)].value = metric_value / 1000
+                    self._metrics[(target_cid, metric)].value = round(metric_value / 1000, 3)
                     self._metrics[(target_cid, metric)].unit = HA_ENERGY_UNIT
                 else:
                     self._metrics[(target_cid, metric)].value = metric_value
@@ -821,10 +821,15 @@ class ChargePoint(cp):
 
     @staticmethod
     def get_energy_kwh(measurand_value: MeasurandValue) -> float:
-        """Convert energy value from charger to kWh."""
+        """Convert energy value from charger to kWh.
+
+        Rounds to 3 decimal places (1 Wh precision) to avoid floating-point
+        artefacts that would violate the ``total_increasing`` state-class
+        contract in Home Assistant (e.g. 0.066 → 0.0659999999998035).
+        """
         if (measurand_value.unit == "Wh") or (measurand_value.unit is None):
-            return measurand_value.value / 1000
-        return measurand_value.value
+            return round(measurand_value.value / 1000, 3)
+        return round(measurand_value.value, 3)
 
     def process_measurands(
         self,
@@ -904,7 +909,7 @@ class ChargePoint(cp):
                     unit = HA_ENERGY_UNIT
 
                 if unit == DEFAULT_POWER_UNIT:
-                    value = value / 1000
+                    value = round(value / 1000, 3)
                     unit = HA_POWER_UNIT
 
                 if self._metrics[(connector_id, csess.meter_start.value)].value == 0:

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -810,10 +810,14 @@ class ChargePoint(cp):
                 metric_unit = phase_info.get(om.unit.value)
 
                 if metric_unit == DEFAULT_POWER_UNIT:
-                    self._metrics[(target_cid, metric)].value = round(metric_value / 1000, 3)
+                    self._metrics[(target_cid, metric)].value = round(
+                        metric_value / 1000, 3
+                    )
                     self._metrics[(target_cid, metric)].unit = HA_POWER_UNIT
                 elif metric_unit == DEFAULT_ENERGY_UNIT:
-                    self._metrics[(target_cid, metric)].value = round(metric_value / 1000, 3)
+                    self._metrics[(target_cid, metric)].value = round(
+                        metric_value / 1000, 3
+                    )
                     self._metrics[(target_cid, metric)].unit = HA_ENERGY_UNIT
                 else:
                     self._metrics[(target_cid, metric)].value = metric_value


### PR DESCRIPTION
Some chargers report energy readings with floating-point noise (e.g. 65.9999999998035 Wh instead of 66 Wh). After the Wh-to-kWh division this produces values like 0.0659999999998035 instead of 0.066, which can appear to decrease slightly and triggers the HA recorder warning:

> Entity sensor.charger_energy_session from integration ocpp has state class total_increasing, but its state is not strictly increasing

I've added `round(..., 3)` (1 Wh / 1 W precision) to all the Wh-to-kWh and W-to-kW conversion paths in `chargepoint.py`. This is consistent with the rounding already used for the session-energy derivation on the meter_start path (line 998).

Fixes #1916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision of energy and power readings by rounding values to three decimal places for display.
  * Standardized unit conversions so reported kWh and kW values are consistent across the app.
  * Reduced floating-point artifacts, yielding more stable and predictable energy/power values in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->