### PR TITLE
Cleaned PR#1920 - Fix Session Energy bug for chargers that send phase-specific readings

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -810,14 +810,58 @@ class ChargePoint(cp):
                 metric_unit = phase_info.get(om.unit.value)
 
                 if metric_unit == DEFAULT_POWER_UNIT:
-                    self._metrics[(target_cid, metric)].value = metric_value / 1000
-                    self._metrics[(target_cid, metric)].unit = HA_POWER_UNIT
+                    final_value = metric_value / 1000
+                    final_unit = HA_POWER_UNIT
                 elif metric_unit == DEFAULT_ENERGY_UNIT:
-                    self._metrics[(target_cid, metric)].value = metric_value / 1000
-                    self._metrics[(target_cid, metric)].unit = HA_ENERGY_UNIT
+                    final_value = metric_value / 1000
+                    final_unit = HA_ENERGY_UNIT
                 else:
-                    self._metrics[(target_cid, metric)].value = metric_value
-                    self._metrics[(target_cid, metric)].unit = metric_unit
+                    final_value = metric_value
+                    final_unit = metric_unit
+
+                self._metrics[(target_cid, metric)].value = final_value
+                self._metrics[(target_cid, metric)].unit = final_unit
+
+                # Amend session energy based on incoming Energy.Active.Import.Register values if the charger does not report session energy directly.
+                if metric == DEFAULT_MEASURAND and not getattr(
+                    self, "_charger_reports_session_energy", False
+                ):
+                    # Verify we are in an active transaction
+                    tx_metric = self._metrics.get(
+                        (
+                            target_cid,
+                            csess.transaction_id.value,
+                        )
+                    )
+
+                    if tx_metric and tx_metric.value:
+                        # Get meter start and session energy metrics
+                        ms_metric = self._metrics.get(
+                            (
+                                target_cid,
+                                csess.meter_start.value,
+                            )
+                        )
+                        se_metric = self._metrics.get(
+                            (
+                                target_cid,
+                                csess.session_energy.value,
+                            )
+                        )
+
+                        if ms_metric and se_metric:
+                            # Initialize baseline if missing
+                            if ms_metric.value is None:
+                                ms_metric.value = final_value
+                                ms_metric.unit = final_unit
+                                se_metric.value = 0.0
+                                se_metric.unit = final_unit
+                            # Session Energy Math: Current Total - Start Total
+                            elif ms_metric.unit == final_unit:
+                                se_metric.value = (
+                                    round(1000 * (final_value - ms_metric.value)) / 1000
+                                )
+                                se_metric.unit = final_unit
 
     @staticmethod
     def get_energy_kwh(measurand_value: MeasurandValue) -> float:
@@ -982,7 +1026,9 @@ class ChargePoint(cp):
                                 ].value
                         else:
                             # Initialize baseline on first tx-bound EAIR; then derive Session = EAIR - meter_start.
-                            ms_metric = self._metrics[(target_cid, csess.meter_start)]
+                            ms_metric = self._metrics[
+                                (target_cid, csess.meter_start.value)
+                            ]
                             if ms_metric.value is None:
                                 ms_metric.value = value
                                 ms_metric.unit = unit
@@ -1000,7 +1046,15 @@ class ChargePoint(cp):
                                     (target_cid, csess.session_energy.value)
                                 ].unit = unit
                 else:
-                    unprocessed.append(sampled_value)
+                    normalized_value = MeasurandValue(
+                        measurand=measurand,
+                        value=value,
+                        phase=phase,
+                        unit=unit,
+                        context=context,
+                        location=location,
+                    )
+                    unprocessed.append(normalized_value)
 
             try:
                 self.process_phases(unprocessed, connector_id)

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -328,3 +328,69 @@ async def test_handle_call_wraps_notimplementederror_and_sends(hass):
         await cp._handle_call(DummyMsg())
 
     assert sent.get("payload") == "ERR_JSON"
+
+
+def test_process_phases_calculates_session_energy(hass):
+    """Test that process_phases derives real-time session energy for phase-tagged registers."""
+    cp = _mk_cp(hass)
+    target_cid = 1
+
+    # 1. Simulate an active charging session
+    # The car plugged in when the meter was at 100.0 kWh
+    cp._metrics[(target_cid, csess.meter_start.value)].value = 100.0
+    cp._metrics[(target_cid, csess.meter_start.value)].unit = HA_ENERGY_UNIT
+    # The transaction is currently active
+    cp._metrics[(target_cid, csess.transaction_id.value)].value = 999
+
+    # Pre-populate the session energy metric so it exists
+    cp._metrics[(target_cid, csess.session_energy.value)].value = 0.0
+    cp._metrics[(target_cid, csess.session_energy.value)].unit = HA_ENERGY_UNIT
+
+    # 2. Create the "unprocessed" payload from the charger (105.0 kWh on L1)
+    bucket = [
+        _mv("Energy.Active.Import.Register", 105.0, phase="L1", unit=HA_ENERGY_UNIT)
+    ]
+
+    # 3. Run the modified function
+    cp.process_phases(bucket, connector_id=target_cid)
+
+    # 4. Assert that the math worked perfectly
+    main_register = cp._metrics[(target_cid, "Energy.Active.Import.Register")].value
+    session_energy = cp._metrics[(target_cid, csess.session_energy.value)].value
+
+    assert main_register == 105.0, "Main register should update to the new L1 value."
+    assert session_energy == 5.0, (
+        "Session energy should be exactly 5.0 (105.0 - 100.0)."
+    )
+
+
+def test_process_phases_initializes_session_energy_baseline(hass):
+    """Test that process_phases initializes the session energy baseline if meter_start is missing."""
+    cp = _mk_cp(hass)
+    target_cid = 1
+
+    # 1. Simulate an active charging session BUT meter_start is None
+    cp._metrics[(target_cid, csess.meter_start.value)].value = None
+    cp._metrics[(target_cid, csess.transaction_id.value)].value = 999
+
+    # Pre-populate session energy
+    cp._metrics[(target_cid, csess.session_energy.value)].value = None
+
+    # 2. Create the "unprocessed" payload from the charger (105.0 kWh on L1)
+    bucket = [
+        _mv("Energy.Active.Import.Register", 105.0, phase="L1", unit=HA_ENERGY_UNIT)
+    ]
+
+    # 3. Run the modified function
+    cp.process_phases(bucket, connector_id=target_cid)
+
+    # 4. Assert the baseline was initialized perfectly
+    meter_start = cp._metrics[(target_cid, csess.meter_start.value)].value
+    session_energy = cp._metrics[(target_cid, csess.session_energy.value)].value
+
+    assert meter_start == 105.0, (
+        "Meter start should be initialized to the first L1 reading."
+    )
+    assert session_energy == 0.0, (
+        "Session energy should be exactly 0.0 at initialization."
+    )

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -237,6 +237,31 @@ def test_process_phases_voltage_and_current_branches(hass):
     p_kw = cp._metrics[(2, "Power.Active.Import")].value
     assert p_kw == (1000 + 2000 + 3000) / 1000  # -> 6 kW
     assert cp._metrics[(2, "Power.Active.Import")].unit == HA_POWER_UNIT
+    # Energy.Active.Import.Register in Wh should become kWh when aggregated
+    bucket3 = [
+        _mv(
+            "Energy.Active.Import.Register",
+            1000.0,
+            phase="L1",
+            unit=DEFAULT_ENERGY_UNIT,
+        ),
+        _mv(
+            "Energy.Active.Import.Register",
+            2000.0,
+            phase="L2",
+            unit=DEFAULT_ENERGY_UNIT,
+        ),
+        _mv(
+            "Energy.Active.Import.Register",
+            3000.0,
+            phase="L3",
+            unit=DEFAULT_ENERGY_UNIT,
+        ),
+    ]
+    cp.process_phases(bucket3, connector_id=3)
+    e_kwh = cp._metrics[(3, "Energy.Active.Import.Register")].value
+    assert e_kwh == (1000 + 2000 + 3000) / 1000  # -> 6.0 kWh
+    assert cp._metrics[(3, "Energy.Active.Import.Register")].unit == HA_ENERGY_UNIT
 
 
 def test_get_energy_kwh_and_session_derive(hass):

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -359,9 +359,9 @@ def test_process_phases_calculates_session_energy(hass):
     session_energy = cp._metrics[(target_cid, csess.session_energy.value)].value
 
     assert main_register == 105.0, "Main register should update to the new L1 value."
-    assert session_energy == 5.0, (
-        "Session energy should be exactly 5.0 (105.0 - 100.0)."
-    )
+    assert (
+        session_energy == 5.0
+    ), "Session energy should be exactly 5.0 (105.0 - 100.0)."
 
 
 def test_process_phases_initializes_session_energy_baseline(hass):
@@ -388,9 +388,9 @@ def test_process_phases_initializes_session_energy_baseline(hass):
     meter_start = cp._metrics[(target_cid, csess.meter_start.value)].value
     session_energy = cp._metrics[(target_cid, csess.session_energy.value)].value
 
-    assert meter_start == 105.0, (
-        "Meter start should be initialized to the first L1 reading."
-    )
-    assert session_energy == 0.0, (
-        "Session energy should be exactly 0.0 at initialization."
-    )
+    assert (
+        meter_start == 105.0
+    ), "Meter start should be initialized to the first L1 reading."
+    assert (
+        session_energy == 0.0
+    ), "Session energy should be exactly 0.0 at initialization."


### PR DESCRIPTION
PR #1920 has got into a mess. This is the cleaned up version.

This PR fixes a bug where the Session Energy sensor fails to update during an active charging session for chargers that send phase-specific energy readings (e.g., Energy.Active.Import.Register.L1).

For these chargers, the Session Energy sensor currently remains at 0 for the duration of the charge and only populates with the final value when the StopTransaction payload is received.

Root Cause :
In on_meter_values, the real-time session energy math (Current - Start) is currently trapped inside the if phase is None: block.

If a charger sends a phase-tagged main energy register, it bypasses this block and gets passed to process_phases() via the unprocessed list. While process_phases() correctly aggregates the phases and updates the main lifetime energy sensor, it lacked the logic to simultaneously update the active Session Energy sensor.

Fix :
Added the standard session energy calculation directly to the end of process_phases().

Refactored the final unit assignment to use a final_value variable.
Added a check to verify an active transaction.
If active, it derives the real-time session energy (final_value - meter_start) and updates the metric so the HA dashboard graph updates continuously during the charge.
Testing :

Verified that single-phase chargers sending L1 energy registers now correctly increment the Session Energy sensor in real-time upon receiving periodic MeterValues.
Verified this does not interfere with chargers that natively report session energy (_charger_reports_session_energy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable session energy tracking by deriving and updating session baselines from incoming energy readings when direct session reports are absent.
  * Normalized per-phase energy samples and improved aggregation into a single connector-level energy metric.

* **Tests**
  * Added tests covering phase aggregation and session-energy initialization and calculation during active transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->