### PR TITLE
Fix WebSocket handshake failure for chargers missing Connection: Upgrade header

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -16,6 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from websockets import Subprotocol, NegotiationError
+from websockets.http11 import Request, Response
 import websockets.server
 from websockets.asyncio.server import ServerConnection
 
@@ -180,10 +181,33 @@ class CentralSystem:
         else:
             self.ssl_context = None
 
+        async def _fix_missing_connection_header(
+            connection: ServerConnection, request: Request
+        ) -> Response | None:
+            """Work around a bug in some charger firmware (e.g. Autel MaxiCharger
+            US AC LW10-N14, firmware v1.38.00/v1.22.00) that omits the required
+            Connection: Upgrade header from the WebSocket opening handshake.
+
+            websockets 14+ strictly validates this header and raises
+            InvalidUpgrade when it is absent, preventing the charger from
+            ever connecting.  We inject the header before the library validates
+            it so that the handshake can proceed normally.
+            """
+            if not request.headers.get_all("Connection"):
+                _LOGGER.warning(
+                    "Charger at %s sent a WebSocket upgrade request without the "
+                    "required 'Connection: Upgrade' header. Injecting header as "
+                    "a workaround — consider updating the charger firmware.",
+                    connection.remote_address,
+                )
+                request.headers["Connection"] = "upgrade"
+            return None
+
         server = await websockets.serve(
             self.on_connect,
             self.settings.host,
             self.settings.port,
+            process_request=_fix_missing_connection_header,
             select_subprotocol=self.select_subprotocol,
             subprotocols=self.subprotocols,
             ping_interval=None,  # ping interval is not used here, because we send pings mamually in ChargePoint.monitor_connection()

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -38,6 +38,29 @@ from .chargepoint import SetVariableResult
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 # Uncomment these when Debugging
 # logging.getLogger("asyncio").setLevel(logging.DEBUG)
+
+
+async def _fix_missing_connection_header(
+    connection: ServerConnection, request: Request
+) -> Response | None:
+    """Work around a bug in some charger firmware (e.g. Autel MaxiCharger
+    US AC LW10-N14, firmware v1.38.00/v1.22.00) that omits the required
+    Connection: Upgrade header from the WebSocket opening handshake.
+
+    websockets 14+ strictly validates this header and raises
+    InvalidUpgrade when it is absent, preventing the charger from
+    ever connecting.  We inject the header before the library validates
+    it so that the handshake can proceed normally.
+    """
+    if not request.headers.get_all("Connection"):
+        _LOGGER.warning(
+            "Charger at %s sent a WebSocket upgrade request without the "
+            "required 'Connection: Upgrade' header. Injecting header as "
+            "a workaround — consider updating the charger firmware.",
+            connection.remote_address,
+        )
+        request.headers["Connection"] = "upgrade"
+    return None
 # logging.getLogger("websockets").setLevel(logging.DEBUG)
 
 UFW_SERVICE_DATA_SCHEMA = vol.Schema(
@@ -180,28 +203,6 @@ class CentralSystem:
             )
         else:
             self.ssl_context = None
-
-        async def _fix_missing_connection_header(
-            connection: ServerConnection, request: Request
-        ) -> Response | None:
-            """Work around a bug in some charger firmware (e.g. Autel MaxiCharger
-            US AC LW10-N14, firmware v1.38.00/v1.22.00) that omits the required
-            Connection: Upgrade header from the WebSocket opening handshake.
-
-            websockets 14+ strictly validates this header and raises
-            InvalidUpgrade when it is absent, preventing the charger from
-            ever connecting.  We inject the header before the library validates
-            it so that the handshake can proceed normally.
-            """
-            if not request.headers.get_all("Connection"):
-                _LOGGER.warning(
-                    "Charger at %s sent a WebSocket upgrade request without the "
-                    "required 'Connection: Upgrade' header. Injecting header as "
-                    "a workaround — consider updating the charger firmware.",
-                    connection.remote_address,
-                )
-                request.headers["Connection"] = "upgrade"
-            return None
 
         server = await websockets.serve(
             self.on_connect,

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -43,9 +43,11 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 async def _fix_missing_connection_header(
     connection: ServerConnection, request: Request
 ) -> Response | None:
-    """Work around a bug in some charger firmware (e.g. Autel MaxiCharger
-    US AC LW10-N14, firmware v1.38.00/v1.22.00) that omits the required
-    Connection: Upgrade header from the WebSocket opening handshake.
+    """Work around charger firmware that omits the Connection: Upgrade header.
+
+    Some charger firmware (e.g. Autel MaxiCharger US AC LW10-N14,
+    firmware v1.38.00/v1.22.00) omits the required Connection: Upgrade
+    header from the WebSocket opening handshake.
 
     websockets 14+ strictly validates this header and raises
     InvalidUpgrade when it is absent, preventing the charger from
@@ -61,6 +63,8 @@ async def _fix_missing_connection_header(
         )
         request.headers["Connection"] = "upgrade"
     return None
+
+
 # logging.getLogger("websockets").setLevel(logging.DEBUG)
 
 UFW_SERVICE_DATA_SCHEMA = vol.Schema(

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -433,8 +433,9 @@ async def test_fix_missing_connection_header_injects_when_absent(caplog):
 
 
 @pytest.mark.asyncio
-async def test_fix_missing_connection_header_leaves_existing_intact():
+async def test_fix_missing_connection_header_leaves_existing_intact(caplog):
     """Existing Connection header is not overwritten and no warning is logged."""
+    import logging
     from websockets.datastructures import Headers
 
     headers = Headers()
@@ -442,7 +443,9 @@ async def test_fix_missing_connection_header_leaves_existing_intact():
     request = SimpleNamespace(headers=headers)
     connection = SimpleNamespace(remote_address=("192.168.1.100", 9000))
 
-    result = await _fix_missing_connection_header(connection, request)
+    with caplog.at_level(logging.WARNING):
+        result = await _fix_missing_connection_header(connection, request)
 
     assert result is None
     assert request.headers.get("Connection") == "Upgrade"
+    assert not any(r.levelname == "WARNING" for r in caplog.records)

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -10,7 +10,7 @@ from homeassistant.const import STATE_OK, STATE_UNAVAILABLE
 from homeassistant.exceptions import HomeAssistantError
 from websockets import NegotiationError
 
-from custom_components.ocpp.api import CentralSystem
+from custom_components.ocpp.api import CentralSystem, _fix_missing_connection_header
 from custom_components.ocpp.const import DOMAIN
 from custom_components.ocpp.enums import (
     HAChargerServices as csvcs,
@@ -412,3 +412,37 @@ def test_del_metric_variants(hass):
 
     # --- Case C: unknown cpid -> returns None, no exception
     assert cs.del_metric("unknown_cpid", "Voltage") is None
+
+
+@pytest.mark.asyncio
+async def test_fix_missing_connection_header_injects_when_absent(caplog):
+    """Header is injected and warning logged when Connection header is missing."""
+    import logging
+    from websockets.datastructures import Headers
+
+    headers = Headers()  # empty — no Connection header
+    request = SimpleNamespace(headers=headers)
+    connection = SimpleNamespace(remote_address=("192.168.1.100", 9000))
+
+    with caplog.at_level(logging.WARNING):
+        result = await _fix_missing_connection_header(connection, request)
+
+    assert result is None
+    assert request.headers.get("Connection") == "upgrade"
+    assert "Connection: Upgrade" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fix_missing_connection_header_leaves_existing_intact():
+    """Existing Connection header is not overwritten and no warning is logged."""
+    from websockets.datastructures import Headers
+
+    headers = Headers()
+    headers["Connection"] = "Upgrade"
+    request = SimpleNamespace(headers=headers)
+    connection = SimpleNamespace(remote_address=("192.168.1.100", 9000))
+
+    result = await _fix_missing_connection_header(connection, request)
+
+    assert result is None
+    assert request.headers.get("Connection") == "Upgrade"


### PR DESCRIPTION
## Problem

Some charger firmware omits the required `Connection: Upgrade` HTTP header from the WebSocket opening handshake. This has been confirmed with:

- **Autel MaxiCharger US AC LW10-N14**
  - Charge control firmware: v1.38.00
  - Power control firmware: v1.22.00

`websockets` 14+ (used by this integration) strictly validates this header in `ServerProtocol.accept()` and raises:

```
websockets.exceptions.InvalidUpgrade: missing Connection header
```

The handshake fails immediately, the server sends `CLOSE 1000`, and the charger retries indefinitely — it can never connect.

## Fix

Add a `process_request` hook to the `websockets.serve()` call. This hook runs before the library validates the handshake headers, giving us the opportunity to inject `Connection: upgrade` when it is absent.

The hook logs a `WARNING` so operators know the charger has a firmware bug and can pursue an update from their charger vendor.

## Notes

- Only triggers when the `Connection` header is completely absent (not just malformed), so well-behaved chargers are unaffected
- `websockets.datastructures.Headers` is mutable, so the injection works cleanly
- Tested and confirmed working with the Autel MaxiCharger US AC LW10-N14 (firmware v1.38.00/v1.22.00)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket handshake handling: missing Connection headers are detected, a warning is logged, and the header is set to "Upgrade" to avoid handshake failures.
* **Tests**
  * Added tests that verify header-correction behavior and confirm existing Connection headers are preserved without modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->