### PR TITLE
fix: use correct metric key for meter_start in session energy calculation

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -982,7 +982,7 @@ class ChargePoint(cp):
                                 ].value
                         else:
                             # Initialize baseline on first tx-bound EAIR; then derive Session = EAIR - meter_start.
-                            ms_metric = self._metrics[(target_cid, csess.meter_start)]
+                            ms_metric = self._metrics[(target_cid, csess.meter_start.value)]
                             if ms_metric.value is None:
                                 ms_metric.value = value
                                 ms_metric.unit = unit

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -328,3 +328,36 @@ async def test_handle_call_wraps_notimplementederror_and_sends(hass):
         await cp._handle_call(DummyMsg())
 
     assert sent.get("payload") == "ERR_JSON"
+
+
+def test_session_energy_uses_meter_start_from_start_transaction(hass):
+    """Session energy should use the meter_start set by StartTransaction, not re-baseline from the first EAIR.
+
+    Regression test: process_measurands previously looked up csess.meter_start
+    (the enum member) instead of csess.meter_start.value (the string key),
+    so it never found the meter_start written by on_start_transaction and
+    created a shadow baseline from the first EAIR sample.
+    """
+    cp = _mk_cp(hass, version=OcppVersion.V201)
+
+    # Simulate on_start_transaction setting meter_start to 500.0 kWh
+    cp._metrics[(1, csess.meter_start.value)].value = 500.0
+    cp._metrics[(1, csess.meter_start.value)].unit = HA_ENERGY_UNIT
+
+    # First MeterValues: EAIR = 500200 Wh = 500.2 kWh
+    mv1 = _mv("Energy.Active.Import.Register", 500200.0, unit=DEFAULT_ENERGY_UNIT)
+    cp.process_measurands([[mv1]], is_transaction=True, connector_id=1)
+
+    # Session energy should be 500.2 - 500.0 = 0.2 kWh (not 0.0)
+    assert cp._metrics[(1, csess.session_energy.value)].value == pytest.approx(
+        0.2, abs=1e-6
+    )
+
+    # Second MeterValues: EAIR = 501500 Wh = 501.5 kWh
+    mv2 = _mv("Energy.Active.Import.Register", 501500.0, unit=DEFAULT_ENERGY_UNIT)
+    cp.process_measurands([[mv2]], is_transaction=True, connector_id=1)
+
+    # Session energy should be 501.5 - 500.0 = 1.5 kWh
+    assert cp._metrics[(1, csess.session_energy.value)].value == pytest.approx(
+        1.5, abs=1e-6
+    )


### PR DESCRIPTION
The session energy derivation path for cumulative-meter chargers (where meter_start > 0) was reading csess.meter_start — the enum member itself — instead of csess.meter_start.value (the string "Energy.Meter.Start"). Every other reference in the codebase uses .value.
Because the metrics store is backed by a defaultdict, looking up the enum key silently returned a new empty Metric instead of the one written by on_start_transaction. This caused the session energy baseline to be set from the first periodic EAIR sample rather than the actual meter reading at the start of the transaction.
The effect is that session energy was always slightly too low — by exactly the amount of energy charged between the transaction start and the first MeterValues sample (typically a few seconds' worth). On longer sessions the delta becomes negligible, but for short sessions or chargers with long sample intervals it could be noticeable.
The fix is a one-character change: csess.meter_start → csess.meter_start.value on the single affected line. I also added a regression test that sets meter_start to 500 kWh, sends two EAIR updates, and checks that session energy is computed against the original baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session energy calculation to use the correct baseline measurement from the start of the charging session.

* **Tests**
  * Added regression test to verify session energy calculation uses the proper baseline and is not recalculated using fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->