### PR TITLE
Fix: Support Session Energy for single-phase chargers sending L1 EAIR tags (3-phase chargers left untouched)

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -883,9 +883,8 @@ class ChargePoint(cp):
             # Pre-scan: Count how many distinct phases are reported for the main energy register
             eair_phases = set()
             for v in bucket:
-                if getattr(v, "measurand", None) == DEFAULT_MEASURAND and getattr(
-                    v, "phase", None
-                ):
+                v_measurand = getattr(v, "measurand", None) or DEFAULT_MEASURAND
+                if v_measurand == DEFAULT_MEASURAND and getattr(v, "phase", None):
                     eair_phases.add(v.phase)
 
             for idx, sampled_value in enumerate(bucket):
@@ -898,8 +897,9 @@ class ChargePoint(cp):
 
                 # Strip the phase tag ONLY if a single-phase charger sends an isolated L1 energy reading.
                 # If multiple phases exist (e.g., L1, L2), leave them intact so process_phases() can sum them.
+                normalized_measurand = measurand or DEFAULT_MEASURAND
                 if (
-                    measurand == DEFAULT_MEASURAND
+                    normalized_measurand == DEFAULT_MEASURAND
                     and phase == Phase.l1.value
                     and len(eair_phases) == 1
                 ):

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -904,7 +904,9 @@ class ChargePoint(cp):
                     # Charger reports Energy.Active.Import.Register directly as Session energy for transactions.
                     self._charger_reports_session_energy = True
 
-                if phase is None:
+                is_eair = measurand == DEFAULT_MEASURAND
+                is_best_eair = is_eair and (idx == best_eair_idx)
+                if phase is None or is_best_eair:
                     is_eair = measurand == DEFAULT_MEASURAND
 
                     # Determine if this is a single-connector charger (only if explicitly known)

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -873,6 +873,14 @@ class ChargePoint(cp):
 
             unprocessed: list[MeasurandValue] = []
 
+            # Pre-scan: Count how many distinct phases are reported for the main energy register
+            eair_phases = set()
+            for v in bucket:
+                if getattr(v, "measurand", None) == DEFAULT_MEASURAND and getattr(
+                    v, "phase", None
+                ):
+                    eair_phases.add(v.phase)
+
             for idx, sampled_value in enumerate(bucket):
                 measurand = sampled_value.measurand
                 value = sampled_value.value
@@ -880,6 +888,15 @@ class ChargePoint(cp):
                 phase = sampled_value.phase
                 location = sampled_value.location
                 context = sampled_value.context or ReadingContext.sample_periodic.value
+
+                # Strip the phase tag ONLY if a single-phase charger sends an isolated L1 energy reading.
+                # If multiple phases exist (e.g., L1, L2), leave them intact so process_phases() can sum them.
+                if (
+                    measurand == DEFAULT_MEASURAND
+                    and phase == Phase.l1.value
+                    and len(eair_phases) == 1
+                ):
+                    phase = None
 
                 # Backwards compatibility
                 if sampled_value.measurand is None:
@@ -904,9 +921,7 @@ class ChargePoint(cp):
                     # Charger reports Energy.Active.Import.Register directly as Session energy for transactions.
                     self._charger_reports_session_energy = True
 
-                is_eair = measurand == DEFAULT_MEASURAND
-                is_best_eair = is_eair and (idx == best_eair_idx)
-                if phase is None or is_best_eair:
+                if phase is None:
                     is_eair = measurand == DEFAULT_MEASURAND
 
                     # Determine if this is a single-connector charger (only if explicitly known)

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -426,6 +426,7 @@ async def test_session_and_lifetime_eair_distinction(hass):
 
     When the charger does NOT report session energy in EAIR:
     - both an in-transaction EAIR reading and a non-transaction EAIR reading write the lifetime EAIR metric.
+    - a single-phase EAIR reading tagged with "L1" has its phase stripped to derive session energy correctly.
     """
 
     # ------ First scenario: charger reports session energy ------
@@ -513,3 +514,45 @@ async def test_session_and_lifetime_eair_distinction(hass):
     main_after_life2 = srv2._metrics[(1, "Energy.Active.Import.Register")].value
     # Lifetime EAIR should be updated to 123.45 kWh.
     assert pytest.approx(main_after_life2, rel=1e-6) == 123.45
+
+    # ------ Third scenario: single-phase charger sending L1 tag on main EAIR ------
+    # New CP instance to test the L1 stripping logic.
+    srv3 = BaseCP(
+        "cp_dummy3",
+        fake_conn,
+        version,
+        fake_hass,
+        fake_entry,
+        fake_central,
+        fake_settings,
+    )
+    srv3._ocpp_version = "1.6"
+    srv3._charger_reports_session_energy = False
+
+    # 1) Set baseline meter_start (Car plugged in at 10.0 kWh)
+    # The correct string key is "Energy.Meter.Start"
+    srv3._metrics[(1, "Energy.Meter.Start")].value = 10.0
+    srv3._metrics[(1, "Energy.Meter.Start")].unit = "kWh"
+
+    # 2) Send in-transaction EAIR reading with an isolated L1 phase (10500 Wh -> 10.5 kWh)
+    l1_samples = [
+        [
+            MeasurandValue(
+                measurand="Energy.Active.Import.Register",
+                value=10500.0,
+                phase="L1",
+                unit="Wh",
+                context=None,
+                location=None,
+            )
+        ]
+    ]
+    srv3.process_measurands(l1_samples, is_transaction=True, connector_id=1)
+
+    # 3) Lifetime EAIR should update to 10.5 kWh
+    main_l1 = srv3._metrics[(1, "Energy.Active.Import.Register")]
+    assert pytest.approx(main_l1.value, rel=1e-6) == 10.5
+
+    # 4) Session Energy should derive to 0.5 kWh (10.5 - 10.0)
+    sess_l1 = srv3._metrics[(1, "Energy.Session")]
+    assert sess_l1.value == pytest.approx(0.5, rel=1e-6)

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -561,6 +561,7 @@ async def test_session_and_lifetime_eair_distinction(hass):
     sess_l1 = srv3._metrics[(1, "Energy.Session")]
     assert sess_l1.value == pytest.approx(0.5, rel=1e-6)
 
+
 @pytest.mark.asyncio
 async def test_process_phases_neutral_shield():
     """Test that isolated Neutral (N) phases do not overwrite main sensors with 0.0."""


### PR DESCRIPTION
This PR resolves an issue where single-phase chargers that explicitly tag their main Energy.Active.Import.Register (EAIR) with Phase.L1 fail to report Session Energy (the sensor remains permanently at 0).

The Bug:
Currently, the Session Energy derivation math (Current EAIR - meter_start) inside process_measurands is gated behind an if phase is None: check. When a single-phase charger sends an L1 tag, it bypasses this math block entirely and falls into the unprocessed bucket. While process_phases() later picks this up and successfully updates the Lifetime energy total, the Session energy math is never executed.

The Solution:
Instead of a massive architectural rewrite, or forcing best_eair_idx to bypass the phase check (good shout @drc38, as it's quick and simple, but it break's true 3-phase tagged chargers by processing a single phase as the total session energy), this PR introduces a lightweight pre-scan logic.

Scan: Before processing the bucket, we count how many distinct phases are reported for the main energy register.

Intercept: If L1 is the strictly singular phase reported for energy (len(eair_phases) == 1), we normalize the tag to phase = None. This routes the reading into the existing Session Energy math block.

Untouched 3-Phase: If multiple phases are detected (e.g., L1, L2, L3), the tags are completely ignored and left intact. They fall safely into the unprocessed bucket where process_phases() aggregates them as normal.

Why this approach?
During testing, we discovered that using idx == best_eair_idx to bypass the phase is None gatekeeper actively breaks 3-phase chargers that do not send a total EAIR. (e.g., best_eair_idx grabs the highest value phase, processes it as the session total, and steals it from the process_phases aggregation pool).

This pre-scan approach acts as a dynamic fix specifically for weird single-phase chargers (looking at you SyncEV), while mathematically guaranteeing zero interference with existing 3-phase logic.

Testing:
Verified that Session Energy properly calculates for Phase.L1 single-phase chargers.

Verified that test_process_phases_energy_sum_and_convert_to_kwh passes successfully, confirming that multi-phase EAIR payloads are properly ignored by this fix and routed to process_phases() for correct summation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of phase information in energy meter readings to correctly process single-phase and multi-phase charging scenarios.

* **Tests**
  * Added test coverage for session energy calculations with phase-tagged meter readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->