### PR TITLE
[wiki] Grizzl-E: added note about OCPP paywall

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -170,7 +170,7 @@ Supported OCPP requests for the 3.x.x firmware are documented in a PDF on their 
 
 Other Grizzl-E chargers on the 5.x.x firmware have some defects in OCPP implementation, which can be worked around. See [User Guide](https://github.com/lbbrhzn/ocpp/blob/main/docs/user-guide.md) section in Documentation for details.)
 
-Grizzle-E has now locked OCPP support behind a $200 paywall https://grizzl-e.com/ocpp-access/ (support may [unlock](https://community.home-assistant.io/t/grizzl-e-charger-and-has-ocpp-integration/804698/23) access for devices purchased before Sept 2025).
+Grizzl-E has now locked OCPP support behind a $200 paywall https://grizzl-e.com/ocpp-access/ (support may [unlock](https://community.home-assistant.io/t/grizzl-e-charger-and-has-ocpp-integration/804698/23) access for devices purchased before Sept 2025).
 
 ## [V2C Trydan](https://v2charge.com/trydan)
 

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -170,6 +170,8 @@ Supported OCPP requests for the 3.x.x firmware are documented in a PDF on their 
 
 Other Grizzl-E chargers on the 5.x.x firmware have some defects in OCPP implementation, which can be worked around. See [User Guide](https://github.com/lbbrhzn/ocpp/blob/main/docs/user-guide.md) section in Documentation for details.)
 
+Grizzle-E has now locked OCPP support behind a $200 paywall https://grizzl-e.com/ocpp-access/ (support may [unlock](https://community.home-assistant.io/t/grizzl-e-charger-and-has-ocpp-integration/804698/23) access for devices purchased before Sept 2025).
+
 ## [V2C Trydan](https://v2charge.com/trydan)
 
 ## [Vestel EVC04-AC22SW](https://www.vestel-echarger.com/EVC04_HomeSmart22kW.html)


### PR DESCRIPTION
Added information about Grizzl-E's OCPP support paywall and access details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supported Devices documentation to clarify Grizzl-E charger OCPP support availability and associated pricing information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbbrhzn/ocpp/pull/1960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->