### PR TITLE
Add retry logic with exponential backoff to SetChargingProfile

### DIFF
--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1,5 +1,6 @@
 """Representation of a OCPP 1.6 charging station."""
 
+import asyncio
 from datetime import datetime, timedelta, UTC
 import logging
 
@@ -415,19 +416,33 @@ class ChargePoint(cp):
     ) -> bool:
         """Set charge rate."""
         if profile is not None:
-            try:
-                req = call.SetChargingProfile(
-                    connector_id=int(conn_id), cs_charging_profiles=profile
-                )
-                resp = await self.call(req)
-                if resp.status == ChargingProfileStatus.accepted:
-                    return True
-                _LOGGER.warning("Custom SetChargingProfile rejected: %s", resp.status)
-            except Exception as ex:
-                _LOGGER.warning("Custom SetChargingProfile failed: %s", ex)
-                await self.notify_ha(
-                    "Warning: Set charging profile failed with response Exception"
-                )
+            req = call.SetChargingProfile(
+                connector_id=int(conn_id), cs_charging_profiles=profile
+            )
+            for attempt in range(3):
+                try:
+                    resp = await self.call(req)
+                    if resp.status == ChargingProfileStatus.accepted:
+                        return True
+                    _LOGGER.warning(
+                        "Custom SetChargingProfile rejected: %s", resp.status
+                    )
+                    return False
+                except Exception as ex:
+                    if attempt < 2:
+                        _LOGGER.debug(
+                            "SetChargingProfile attempt %d failed, retrying: %s",
+                            attempt + 1,
+                            ex,
+                        )
+                        await asyncio.sleep(0.5 + (attempt * 0.5))
+                    else:
+                        _LOGGER.warning(
+                            "Custom SetChargingProfile failed after 3 attempts: %s", ex
+                        )
+                        await self.notify_ha(
+                            "Warning: Set charging profile failed with response Exception"
+                        )
             return False
 
         if not (int(self.supported_features or 0) & prof.SMART):

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -360,7 +360,21 @@ class ChargePoint(cp):
                 evse_target, _ = self._global_to_pair(int(conn_id))
         if profile is not None:
             req = call.SetChargingProfile(evse_target, profile)
-            resp: call_result.SetChargingProfile = await self.call(req)
+            resp: call_result.SetChargingProfile | None = None
+            for attempt in range(3):
+                try:
+                    resp = await self.call(req)
+                    break
+                except Exception as ex:
+                    if attempt < 2:
+                        _LOGGER.debug(
+                            "SetChargingProfile attempt %d failed, retrying: %s",
+                            attempt + 1,
+                            ex,
+                        )
+                        await asyncio.sleep(0.5 + (attempt * 0.5))
+                    else:
+                        raise
             if resp.status != ChargingProfileStatusEnumType.accepted:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
@@ -408,7 +422,21 @@ class ChargePoint(cp):
         req: call.SetChargingProfile = call.SetChargingProfile(
             evse_target, charging_profile
         )
-        resp: call_result.SetChargingProfile = await self.call(req)
+        resp: call_result.SetChargingProfile | None = None
+        for attempt in range(3):
+            try:
+                resp = await self.call(req)
+                break
+            except Exception as ex:
+                if attempt < 2:
+                    _LOGGER.debug(
+                        "SetChargingProfile attempt %d failed, retrying: %s",
+                        attempt + 1,
+                        ex,
+                    )
+                    await asyncio.sleep(0.5 + (attempt * 0.5))
+                else:
+                    raise
         if resp.status != ChargingProfileStatusEnumType.accepted:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,


### PR DESCRIPTION
Fixes #1999

When SetChargingProfile times out due to transient network issues or charger processing delay, retry up to 3 times with exponential backoff (0.5s, 1s) before notifying the user. Immediate charger rejections still fail fast.

This prevents dynamic charge rate adjustments from silently failing on brief network hiccups.

## Changes
- Adds asyncio import for sleep() during retry backoff
- Retries up to 3 times for exceptions (transient failures)
- Fails immediately for active rejections (charger policy)
- Only notifies user if all retries exhausted
- Includes debug logging for retry attempts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when applying charging profiles by retrying failed requests up to three times.
  * Added short backoff delays between attempts to recover from temporary communication issues.
  * Charging requests now stop immediately on acceptance or explicit rejection, while repeated exceptions still trigger warning notification after the final attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->