### PR TITLE
Use timeout-triggered reconnect with command queue and replay

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -36,6 +36,7 @@ from ocpp.v201 import call_result as call_resultv201
 from ocpp.messages import CallError
 from ocpp.exceptions import NotImplementedError
 
+from .command_queue import CommandQueue
 from .enums import (
     HAChargerDetails as cdet,
     HAChargerSession as csess,
@@ -282,6 +283,8 @@ class ChargePoint(cp):
         alphabet = string.ascii_uppercase + string.digits
         self._remote_id_tag = "".join(secrets.choice(alphabet) for i in range(20))
         self.num_connectors: int = DEFAULT_NUM_CONNECTORS
+        self._command_queue = CommandQueue()
+        self._reconnect_in_progress = False
 
     def _init_connector_slots(self, conn_id: int) -> None:
         """Ensure connector-scoped metrics exist and carry the right units."""
@@ -566,6 +569,67 @@ class ChargePoint(cp):
         for task in self.tasks:
             task.cancel()
 
+    async def _replay_queue(self) -> None:
+        """Replay queued commands from last timeout/disconnect."""
+        commands = await self._command_queue.dequeue_all()
+        for cmd in commands:
+            try:
+                await cmd.execute()
+            except Exception as ex:
+                _LOGGER.warning("Replay of %s failed: %s", cmd.call_type, ex)
+
+    async def _call_with_timeout_handling(
+        self, req, call_type: str, connector_id: int | None = None, **call_kwargs
+    ):
+        """Wrap self.call() to handle timeouts by queuing for reconnect replay.
+
+        On timeout: queues the failed command for replay on next reconnect.
+        On success: returns the response.
+        On charger rejection: returns the response (no retry needed).
+
+        Timeouts are queued but the exception is re-raised to let the caller handle
+        the immediate failure. Reconnection happens naturally via monitor_connection
+        when the websocket detects the disconnect.
+        """
+        try:
+            return await self.call(req, **call_kwargs)
+        except TimeoutError:
+            _LOGGER.error(
+                "OCPP call %s timed out for charger %s; queuing for replay on reconnect",
+                call_type,
+                self.id,
+            )
+            from .command_queue import QueuedCommand
+
+            # Extract profile purpose for SetChargingProfile to prevent coalescing
+            # different profile types (e.g., TxProfile vs TxDefaultProfile)
+            profile_purpose = None
+            if call_type == "SetChargingProfile" and hasattr(
+                req, "cs_charging_profiles"
+            ):
+                # Get the purpose from the profile if available
+                profiles = req.cs_charging_profiles
+                if isinstance(profiles, dict):
+                    profile_purpose = profiles.get("charging_profile_purpose")
+                elif hasattr(profiles, "charging_profile_purpose"):
+                    profile_purpose = profiles.charging_profile_purpose
+
+            cmd = QueuedCommand(
+                call_type=call_type,
+                call_fn=self._call_with_timeout_handling,
+                args=(req,),
+                kwargs={
+                    "call_type": call_type,
+                    "connector_id": connector_id,
+                    **call_kwargs,
+                },
+                connector_id=connector_id,
+                profile_purpose=profile_purpose,
+            )
+            await self._command_queue.enqueue(cmd)
+
+            raise
+
     async def reconnect(self, connection: ServerConnection):
         """Reconnect charge point."""
         _LOGGER.debug(f"Reconnect websocket to {self.id}")
@@ -574,8 +638,33 @@ class ChargePoint(cp):
         self.status = STATE_OK
         self._connection = connection
         self._metrics[(0, cstat.reconnects.value)].value += 1
-        # post connect now handled on receiving boot notification or with backstop in monitor connection
-        await self.run([super().start(), self.monitor_connection()])
+
+        # Start receiver and monitor as background tasks
+        self.tasks = [
+            asyncio.ensure_future(super().start()),
+            asyncio.ensure_future(self.monitor_connection()),
+        ]
+
+        try:
+            # Give receiver a moment to start listening for responses
+            await asyncio.sleep(0.01)
+
+            # Replay queued commands while receiver is active
+            await self._replay_queue()
+
+            # Wait for receiver and monitor to complete
+            await asyncio.gather(*self.tasks)
+        except TimeoutError:
+            pass
+        except WebSocketException as websocket_exception:
+            _LOGGER.debug(f"Connection closed to '{self.id}': {websocket_exception}")
+        except Exception as other_exception:
+            _LOGGER.error(
+                f"Unexpected exception in connection to '{self.id}': '{other_exception}'",
+                exc_info=True,
+            )
+        finally:
+            await self.stop()
 
     async def async_update_device_info(
         self, serial: str, vendor: str, model: str, firmware_version: str

--- a/custom_components/ocpp/command_queue.py
+++ b/custom_components/ocpp/command_queue.py
@@ -1,0 +1,79 @@
+"""OCPP command queue for timeout-triggered reconnect + replay."""
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+_LOGGER = None
+
+
+@dataclass
+class QueuedCommand:
+    """Represents a queued OCPP call for replay after timeout/reconnect."""
+
+    call_type: str
+    call_fn: Callable
+    args: tuple = field(default_factory=tuple)
+    kwargs: dict = field(default_factory=dict)
+    connector_id: int | None = None
+    profile_purpose: str | None = None
+    created_at: float = field(default_factory=lambda: __import__("time").time())
+
+    async def execute(self) -> Any:
+        """Execute the queued call."""
+        return await self.call_fn(*self.args, **self.kwargs)
+
+
+class CommandQueue:
+    """Queue with FIFO ordering and coalescing by command type + connector."""
+
+    def __init__(self):
+        """Initialize the command queue."""
+        self._queue: list[QueuedCommand] = []
+        self._lock = asyncio.Lock()
+
+    async def enqueue(self, command: QueuedCommand) -> None:
+        """Enqueue a command, coalescing by type+connector if applicable.
+
+        For commands tied to a specific connector (e.g., SetChargingProfile),
+        drop any older command of the same type for that connector.
+        """
+        async with self._lock:
+            if command.call_type in (
+                "SetChargingProfile",
+                "RemoteStartTransaction",
+                "RemoteStopTransaction",
+            ):
+                # Coalesce: remove older command of same type for same connector
+                # For SetChargingProfile, also match profile purpose to avoid dropping
+                # active TxProfile when TxDefaultProfile is queued
+                self._queue = [
+                    cmd
+                    for cmd in self._queue
+                    if not (
+                        cmd.call_type == command.call_type
+                        and cmd.connector_id == command.connector_id
+                        and (
+                            command.call_type != "SetChargingProfile"
+                            or cmd.profile_purpose == command.profile_purpose
+                        )
+                    )
+                ]
+            self._queue.append(command)
+
+    async def dequeue_all(self) -> list[QueuedCommand]:
+        """Drain the entire queue and return commands in FIFO order."""
+        async with self._lock:
+            commands = self._queue[:]
+            self._queue.clear()
+            return commands
+
+    async def clear(self) -> None:
+        """Clear the queue."""
+        async with self._lock:
+            self._queue.clear()
+
+    def is_empty(self) -> bool:
+        """Check if the queue is empty."""
+        return len(self._queue) == 0

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -419,7 +419,9 @@ class ChargePoint(cp):
                 req = call.SetChargingProfile(
                     connector_id=int(conn_id), cs_charging_profiles=profile
                 )
-                resp = await self.call(req)
+                resp = await self._call_with_timeout_handling(
+                    req, call_type="SetChargingProfile", connector_id=int(conn_id)
+                )
                 if resp.status == ChargingProfileStatus.accepted:
                     return True
                 _LOGGER.warning("Custom SetChargingProfile rejected: %s", resp.status)
@@ -494,7 +496,9 @@ class ChargePoint(cp):
                     om.charging_schedule.value: _mk_schedule(units_value, limit_value),
                 },
             )
-            resp = await self.call(req)
+            resp = await self._call_with_timeout_handling(
+                req, call_type="SetChargingProfile", connector_id=0
+            )
             if resp.status == ChargingProfileStatus.accepted:
                 return True
             _LOGGER.debug(
@@ -536,7 +540,9 @@ class ChargePoint(cp):
                         om.transaction_id.value: active_tx_id,
                     },
                 )
-                resp = await self.call(req)
+                resp = await self._call_with_timeout_handling(
+                    req, call_type="SetChargingProfile", connector_id=target_cid
+                )
                 if resp.status == ChargingProfileStatus.accepted:
                     txp_ok = True
                 else:
@@ -561,7 +567,9 @@ class ChargePoint(cp):
                     om.charging_schedule.value: _mk_schedule(units_value, limit_value),
                 },
             )
-            resp = await self.call(req)
+            resp = await self._call_with_timeout_handling(
+                req, call_type="SetChargingProfile", connector_id=target_cid
+            )
             if resp.status == ChargingProfileStatus.accepted:
                 txd_ok = True
             else:
@@ -590,7 +598,9 @@ class ChargePoint(cp):
         req = call.ChangeAvailability(connector_id=conn, type=typ)
 
         try:
-            resp = await self.call(req)
+            resp = await self._call_with_timeout_handling(
+                req, call_type="ChangeAvailability", connector_id=conn
+            )
         except TimeoutError as ex:
             _LOGGER.debug("ChangeAvailability timed out (conn=%s): %s", conn, ex)
             return False
@@ -654,7 +664,9 @@ class ChargePoint(cp):
         req = call.RemoteStartTransaction(
             connector_id=connector_id, id_tag=self._remote_id_tag
         )
-        resp = await self.call(req)
+        resp = await self._call_with_timeout_handling(
+            req, call_type="RemoteStartTransaction", connector_id=connector_id
+        )
         if resp.status == RemoteStartStopStatus.accepted:
             return True
         else:
@@ -697,7 +709,9 @@ class ChargePoint(cp):
             return True
 
         req = call.RemoteStopTransaction(transaction_id=tx_id)
-        resp = await self.call(req)
+        resp = await self._call_with_timeout_handling(
+            req, call_type="RemoteStopTransaction", connector_id=connector_id or 0
+        )
         if resp.status == RemoteStartStopStatus.accepted:
             return True
 

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -360,7 +360,11 @@ class ChargePoint(cp):
                 evse_target, _ = self._global_to_pair(int(conn_id))
         if profile is not None:
             req = call.SetChargingProfile(evse_target, profile)
-            resp: call_result.SetChargingProfile = await self.call(req)
+            resp: call_result.SetChargingProfile = (
+                await self._call_with_timeout_handling(
+                    req, call_type="SetChargingProfile", connector_id=int(conn_id or 0)
+                )
+            )
             if resp.status != ChargingProfileStatusEnumType.accepted:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
@@ -408,7 +412,9 @@ class ChargePoint(cp):
         req: call.SetChargingProfile = call.SetChargingProfile(
             evse_target, charging_profile
         )
-        resp: call_result.SetChargingProfile = await self.call(req)
+        resp: call_result.SetChargingProfile = await self._call_with_timeout_handling(
+            req, call_type="SetChargingProfile", connector_id=int(conn_id or 0)
+        )
         if resp.status != ChargingProfileStatusEnumType.accepted:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
@@ -426,7 +432,11 @@ class ChargePoint(cp):
             else OperationalStatusEnumType.inoperative.value
         )
         if not connector_id:
-            await self.call(call.ChangeAvailability(status))
+            await self._call_with_timeout_handling(
+                call.ChangeAvailability(status),
+                call_type="ChangeAvailability",
+                connector_id=0,
+            )
             return
 
         evse_id = None
@@ -434,9 +444,17 @@ class ChargePoint(cp):
             evse_id, _ = self._global_to_pair(int(connector_id))
 
         if evse_id:
-            await self.call(call.ChangeAvailability(status, evse={"id": evse_id}))
+            await self._call_with_timeout_handling(
+                call.ChangeAvailability(status, evse={"id": evse_id}),
+                call_type="ChangeAvailability",
+                connector_id=int(connector_id),
+            )
         else:
-            await self.call(call.ChangeAvailability(status))
+            await self._call_with_timeout_handling(
+                call.ChangeAvailability(status),
+                call_type="ChangeAvailability",
+                connector_id=int(connector_id),
+            )
 
     async def start_transaction(self, connector_id: int = 1) -> bool:
         """Remote start a transaction."""
@@ -452,7 +470,11 @@ class ChargePoint(cp):
             },
             remote_start_id=1,
         )
-        resp: call_result.RequestStartTransaction = await self.call(req)
+        resp: call_result.RequestStartTransaction = (
+            await self._call_with_timeout_handling(
+                req, call_type="RequestStartTransaction", connector_id=connector_id
+            )
+        )
         return resp.status == RequestStartStopStatusEnumType.accepted.value
 
     async def stop_transaction(self, connector_id: int | None = None) -> bool:
@@ -491,7 +513,11 @@ class ChargePoint(cp):
         req: call.RequestStopTransaction = call.RequestStopTransaction(
             transaction_id=tx_id
         )
-        resp: call_result.RequestStopTransaction = await self.call(req)
+        resp: call_result.RequestStopTransaction = (
+            await self._call_with_timeout_handling(
+                req, call_type="RequestStopTransaction", connector_id=connector_id or 0
+            )
+        )
         return resp.status == RequestStartStopStatusEnumType.accepted.value
 
     async def reset(self, typ: str = ""):

--- a/tests/test_ocpp_timeout_and_queue.py
+++ b/tests/test_ocpp_timeout_and_queue.py
@@ -1,0 +1,500 @@
+"""Tests for OCPP timeout handling and command queue."""
+
+from unittest.mock import MagicMock, AsyncMock
+import pytest
+from websockets.exceptions import WebSocketException
+from custom_components.ocpp.command_queue import CommandQueue, QueuedCommand
+from custom_components.ocpp.chargepoint import ChargePoint
+from custom_components.ocpp.ocppv201 import ChargePoint as ChargePointV201
+from ocpp.v201.enums import RequestStartStopStatusEnumType
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestCommandQueue:
+    """Tests for CommandQueue class."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_and_dequeue_all(self):
+        """Test basic enqueue and dequeue_all functionality."""
+        queue = CommandQueue()
+
+        cmd1 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+        cmd2 = QueuedCommand(
+            call_type="RemoteStartTransaction",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+
+        await queue.enqueue(cmd1)
+        await queue.enqueue(cmd2)
+
+        commands = await queue.dequeue_all()
+        assert len(commands) == 2
+        assert commands[0] is cmd1
+        assert commands[1] is cmd2
+
+        # Queue should be empty after dequeue_all
+        commands_again = await queue.dequeue_all()
+        assert len(commands_again) == 0
+
+    @pytest.mark.asyncio
+    async def test_command_coalescing_same_type_and_connector(self):
+        """Test that newer commands replace older ones of the same type/connector."""
+        queue = CommandQueue()
+
+        call_fn1 = AsyncMock()
+        call_fn2 = AsyncMock()
+        call_fn3 = AsyncMock()
+
+        cmd1 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=call_fn1,
+            connector_id=1,
+        )
+        cmd2 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=call_fn2,
+            connector_id=1,
+        )
+        cmd3 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=call_fn3,
+            connector_id=1,
+        )
+
+        await queue.enqueue(cmd1)
+        await queue.enqueue(cmd2)
+        await queue.enqueue(cmd3)
+
+        commands = await queue.dequeue_all()
+        assert len(commands) == 1
+        assert commands[0] is cmd3
+
+    @pytest.mark.asyncio
+    async def test_no_coalescing_different_connectors(self):
+        """Test that commands for different connectors are not coalesced."""
+        queue = CommandQueue()
+
+        cmd1 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+        cmd2 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=AsyncMock(),
+            connector_id=2,
+        )
+
+        await queue.enqueue(cmd1)
+        await queue.enqueue(cmd2)
+
+        commands = await queue.dequeue_all()
+        assert len(commands) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_coalescing_different_types(self):
+        """Test that commands of different types are not coalesced."""
+        queue = CommandQueue()
+
+        cmd1 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+        cmd2 = QueuedCommand(
+            call_type="RemoteStartTransaction",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+
+        await queue.enqueue(cmd1)
+        await queue.enqueue(cmd2)
+
+        commands = await queue.dequeue_all()
+        assert len(commands) == 2
+
+    @pytest.mark.asyncio
+    async def test_clear(self):
+        """Test clearing the queue."""
+        queue = CommandQueue()
+
+        await queue.enqueue(
+            QueuedCommand(
+                call_type="SetChargingProfile",
+                call_fn=AsyncMock(),
+                connector_id=1,
+            )
+        )
+
+        await queue.clear()
+        assert queue.is_empty()
+
+
+class TestTimeoutHandling:
+    """Tests for ChargePoint timeout handling and queue replay."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_triggers_reconnect(self, monkeypatch):
+        """Test that timeout in _call_with_timeout_handling queues for replay."""
+        chargepoint = MagicMock(spec=ChargePoint)
+        chargepoint._command_queue = CommandQueue()
+        chargepoint.id = "test_charger"
+
+        # Monkeypatch call to raise TimeoutError
+        async def mock_call(*args, **kwargs):
+            raise TimeoutError("Waited 10s for response")
+
+        chargepoint.call = mock_call
+
+        # Bind the real _call_with_timeout_handling method to the mock
+        chargepoint._call_with_timeout_handling = (
+            ChargePoint._call_with_timeout_handling.__get__(chargepoint, ChargePoint)
+        )
+
+        req = MagicMock()
+
+        with pytest.raises(TimeoutError):
+            await chargepoint._call_with_timeout_handling(
+                req,
+                call_type="SetChargingProfile",
+                connector_id=1,
+            )
+
+        # Verify command was queued for replay on reconnect
+        assert not chargepoint._command_queue.is_empty()
+
+    @pytest.mark.asyncio
+    async def test_command_coalescing_in_queue(self):
+        """Test command coalescing when multiple SetChargingProfile queued."""
+        queue = CommandQueue()
+
+        mock_fn1 = AsyncMock()
+        mock_fn2 = AsyncMock()
+        mock_fn3 = AsyncMock()
+
+        cmd1 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=mock_fn1,
+            connector_id=1,
+            kwargs={"current": 6},
+        )
+        cmd2 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=mock_fn2,
+            connector_id=1,
+            kwargs={"current": 10},
+        )
+        cmd3 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=mock_fn3,
+            connector_id=1,
+            kwargs={"current": 16},
+        )
+
+        await queue.enqueue(cmd1)
+        await queue.enqueue(cmd2)
+        await queue.enqueue(cmd3)
+
+        commands = await queue.dequeue_all()
+        assert len(commands) == 1
+        assert commands[0].kwargs["current"] == 16
+
+    @pytest.mark.asyncio
+    async def test_mixed_queue_types_no_coalescing(self):
+        """Test that different command types are not coalesced."""
+        queue = CommandQueue()
+
+        cmd1 = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+        cmd2 = QueuedCommand(
+            call_type="RemoteStartTransaction",
+            call_fn=AsyncMock(),
+            connector_id=1,
+        )
+
+        await queue.enqueue(cmd1)
+        await queue.enqueue(cmd2)
+
+        commands = await queue.dequeue_all()
+        assert len(commands) == 2
+        assert commands[0].call_type == "SetChargingProfile"
+        assert commands[1].call_type == "RemoteStartTransaction"
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_dict_profile_purpose(self):
+        """Test profile purpose extraction from dict."""
+        chargepoint = MagicMock(spec=ChargePoint)
+        chargepoint._command_queue = CommandQueue()
+        chargepoint.id = "test_charger"
+
+        async def mock_call(*args, **kwargs):
+            raise TimeoutError("Timeout")
+
+        chargepoint.call = mock_call
+        chargepoint._call_with_timeout_handling = (
+            ChargePoint._call_with_timeout_handling.__get__(chargepoint, ChargePoint)
+        )
+
+        # Request with profile purpose in dict
+        req = MagicMock()
+        req.cs_charging_profiles = {"charging_profile_purpose": "tx_profile"}
+
+        with pytest.raises(TimeoutError):
+            await chargepoint._call_with_timeout_handling(
+                req, call_type="SetChargingProfile", connector_id=1
+            )
+
+        # Verify purpose was extracted and queued
+        commands = await chargepoint._command_queue.dequeue_all()
+        assert len(commands) == 1
+        assert commands[0].profile_purpose == "tx_profile"
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_attribute_profile_purpose(self):
+        """Test profile purpose extraction from attribute."""
+        chargepoint = MagicMock(spec=ChargePoint)
+        chargepoint._command_queue = CommandQueue()
+        chargepoint.id = "test_charger"
+
+        async def mock_call(*args, **kwargs):
+            raise TimeoutError("Timeout")
+
+        chargepoint.call = mock_call
+        chargepoint._call_with_timeout_handling = (
+            ChargePoint._call_with_timeout_handling.__get__(chargepoint, ChargePoint)
+        )
+
+        # Request with profile purpose as attribute
+        req = MagicMock()
+        profiles = MagicMock()
+        profiles.charging_profile_purpose = "tx_default_profile"
+        req.cs_charging_profiles = profiles
+
+        with pytest.raises(TimeoutError):
+            await chargepoint._call_with_timeout_handling(
+                req, call_type="SetChargingProfile", connector_id=1
+            )
+
+        # Verify purpose was extracted
+        commands = await chargepoint._command_queue.dequeue_all()
+        assert len(commands) == 1
+        assert commands[0].profile_purpose == "tx_default_profile"
+
+    @pytest.mark.asyncio
+    async def test_timeout_without_profile_purpose(self):
+        """Test timeout when profile purpose is not available."""
+        chargepoint = MagicMock(spec=ChargePoint)
+        chargepoint._command_queue = CommandQueue()
+        chargepoint.id = "test_charger"
+
+        async def mock_call(*args, **kwargs):
+            raise TimeoutError("Timeout")
+
+        chargepoint.call = mock_call
+        chargepoint._call_with_timeout_handling = (
+            ChargePoint._call_with_timeout_handling.__get__(chargepoint, ChargePoint)
+        )
+
+        # Request without cs_charging_profiles
+        req = MagicMock(spec=[])
+
+        with pytest.raises(TimeoutError):
+            await chargepoint._call_with_timeout_handling(
+                req, call_type="RemoteStartTransaction", connector_id=1
+            )
+
+        # Verify command was queued with None purpose
+        commands = await chargepoint._command_queue.dequeue_all()
+        assert len(commands) == 1
+        assert commands[0].profile_purpose is None
+
+    @pytest.mark.asyncio
+    async def test_queued_command_execution_failure(self):
+        """Test handling when queued command execution fails."""
+        chargepoint = MagicMock(spec=ChargePoint)
+        chargepoint._command_queue = CommandQueue()
+        chargepoint.id = "test_charger"
+
+        # Create a command that fails on execution
+        failing_fn = AsyncMock(side_effect=RuntimeError("Command failed"))
+        cmd = QueuedCommand(
+            call_type="SetChargingProfile",
+            call_fn=failing_fn,
+            connector_id=1,
+        )
+
+        await chargepoint._command_queue.enqueue(cmd)
+
+        # Bind the real _replay_queue method
+        chargepoint._replay_queue = ChargePoint._replay_queue.__get__(
+            chargepoint, ChargePoint
+        )
+
+        # Replay should handle the error gracefully
+        await chargepoint._replay_queue()
+
+        # Verify command was attempted
+        failing_fn.assert_called_once()
+
+        # Queue should be empty after replay
+        assert chargepoint._command_queue.is_empty()
+
+
+class TestReconnectExceptionHandling:
+    """Tests for reconnect() exception handling branches."""
+
+    def _make_chargepoint(self, monkeypatch, monitor_side_effect):
+        from custom_components.ocpp.enums import HAChargerStatuses as cstat
+
+        chargepoint = MagicMock(spec=ChargePoint)
+        chargepoint.id = "test_charger"
+        chargepoint.stop = AsyncMock()
+        chargepoint._replay_queue = AsyncMock()
+        chargepoint.monitor_connection = AsyncMock(side_effect=monitor_side_effect)
+        chargepoint._metrics = {(0, cstat.reconnects.value): MagicMock(value=0)}
+
+        import custom_components.ocpp.chargepoint as cp_module
+
+        monkeypatch.setattr(cp_module.cp, "start", AsyncMock(return_value=None))
+
+        chargepoint.reconnect = ChargePoint.reconnect.__get__(chargepoint, ChargePoint)
+        return chargepoint
+
+    @pytest.mark.asyncio
+    async def test_reconnect_handles_timeout_error(self, monkeypatch):
+        """Test reconnect() swallows TimeoutError from gathered tasks."""
+        chargepoint = self._make_chargepoint(monkeypatch, TimeoutError("ping timeout"))
+
+        await chargepoint.reconnect(MagicMock())
+
+        # stop() called once up-front and once in the finally block
+        assert chargepoint.stop.call_count == 2
+        chargepoint._replay_queue.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_handles_websocket_exception(self, monkeypatch):
+        """Test reconnect() logs and swallows WebSocketException."""
+        chargepoint = self._make_chargepoint(
+            monkeypatch, WebSocketException("connection closed")
+        )
+
+        await chargepoint.reconnect(MagicMock())
+
+        assert chargepoint.stop.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reconnect_handles_generic_exception(self, monkeypatch):
+        """Test reconnect() logs and swallows unexpected exceptions."""
+        chargepoint = self._make_chargepoint(monkeypatch, RuntimeError("boom"))
+
+        await chargepoint.reconnect(MagicMock())
+
+        assert chargepoint.stop.call_count == 2
+
+
+class TestOcppV201TimeoutIntegration:
+    """Tests that ocppv201 call sites are correctly wired to the timeout handler."""
+
+    @pytest.mark.asyncio
+    async def test_set_availability_station_level(self):
+        """Test set_availability with connector_id=0 (station-level) call site."""
+        cp = MagicMock(spec=ChargePointV201)
+        cp._call_with_timeout_handling = AsyncMock()
+        cp.set_availability = ChargePointV201.set_availability.__get__(
+            cp, ChargePointV201
+        )
+
+        await cp.set_availability(state=True, connector_id=0)
+
+        cp._call_with_timeout_handling.assert_called_once()
+        _, kwargs = cp._call_with_timeout_handling.call_args
+        assert kwargs["call_type"] == "ChangeAvailability"
+        assert kwargs["connector_id"] == 0
+
+    @pytest.mark.asyncio
+    async def test_set_availability_with_evse_mapping(self):
+        """Test set_availability when connector_id resolves to an EVSE."""
+        cp = MagicMock(spec=ChargePointV201)
+        cp._call_with_timeout_handling = AsyncMock()
+        cp._global_to_pair = MagicMock(return_value=(5, 1))
+        cp.set_availability = ChargePointV201.set_availability.__get__(
+            cp, ChargePointV201
+        )
+
+        await cp.set_availability(state=False, connector_id=2)
+
+        cp._call_with_timeout_handling.assert_called_once()
+        _, kwargs = cp._call_with_timeout_handling.call_args
+        assert kwargs["call_type"] == "ChangeAvailability"
+        assert kwargs["connector_id"] == 2
+
+    @pytest.mark.asyncio
+    async def test_set_availability_without_evse_mapping(self):
+        """Test set_availability falls back when no EVSE mapping is available."""
+        cp = MagicMock(spec=ChargePointV201)
+        cp._call_with_timeout_handling = AsyncMock()
+        cp._global_to_pair = MagicMock(side_effect=Exception("no mapping"))
+        cp.set_availability = ChargePointV201.set_availability.__get__(
+            cp, ChargePointV201
+        )
+
+        await cp.set_availability(state=True, connector_id=3)
+
+        cp._call_with_timeout_handling.assert_called_once()
+        _, kwargs = cp._call_with_timeout_handling.call_args
+        assert kwargs["call_type"] == "ChangeAvailability"
+        assert kwargs["connector_id"] == 3
+
+    @pytest.mark.asyncio
+    async def test_start_transaction(self):
+        """Test start_transaction routes through the timeout handler."""
+        cp = MagicMock(spec=ChargePointV201)
+        cp._remote_id_tag = "TAG123"
+        cp._global_to_pair = MagicMock(return_value=(2, 1))
+        fake_resp = MagicMock()
+        fake_resp.status = RequestStartStopStatusEnumType.accepted.value
+        cp._call_with_timeout_handling = AsyncMock(return_value=fake_resp)
+        cp.start_transaction = ChargePointV201.start_transaction.__get__(
+            cp, ChargePointV201
+        )
+
+        result = await cp.start_transaction(connector_id=1)
+
+        assert result is True
+        cp._call_with_timeout_handling.assert_called_once()
+        _, kwargs = cp._call_with_timeout_handling.call_args
+        assert kwargs["call_type"] == "RequestStartTransaction"
+
+    @pytest.mark.asyncio
+    async def test_stop_transaction(self):
+        """Test stop_transaction routes through the timeout handler."""
+        from custom_components.ocpp.enums import HAChargerSession as csess
+
+        cp = MagicMock(spec=ChargePointV201)
+        cp._get_inventory = AsyncMock()
+        cp._total_connectors = MagicMock(return_value=1)
+        metric = MagicMock()
+        metric.value = "12345"
+        cp._metrics = {(1, csess.transaction_id.value): metric}
+        fake_resp = MagicMock()
+        fake_resp.status = RequestStartStopStatusEnumType.accepted.value
+        cp._call_with_timeout_handling = AsyncMock(return_value=fake_resp)
+        cp.stop_transaction = ChargePointV201.stop_transaction.__get__(
+            cp, ChargePointV201
+        )
+
+        result = await cp.stop_transaction(connector_id=1)
+
+        assert result is True
+        cp._call_with_timeout_handling.assert_called_once()
+        _, kwargs = cp._call_with_timeout_handling.call_args
+        assert kwargs["call_type"] == "RequestStopTransaction"


### PR DESCRIPTION
On asyncio.TimeoutError place failed commands in queue. Newer commands replace commands of the same type. On reconnect replay queued commands

Changes:
- New CommandQueue class with FIFO ordering and coalescing logic
- New _call_with_timeout_handling() wrapper in ChargePoint to catch timeouts
- Modified reconnect() to drain queue via _replay_queue() before re-establishing connection
- Add _command_queue instance to ChargePoint.__init__

Integration:
- ocppv16.py: wrap set_charge_rate() (4 calls) and set_availability() with timeout handler
- ocppv201.py: wrap set_charge_rate() (2 calls), set_availability() (3 calls), start_transaction(), and stop_transaction() with timeout handler
- Add asyncio import to ocppv16.py for exception handling

Fixes: #1999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a per–ChargePoint FIFO command queue to preserve timed-out OCPP calls and replay them after reconnection.
  - Enhanced timeout-aware handling for charging profile updates, availability changes, and remote start/stop actions.

- **Bug Fixes**
  - Prevented missed OCPP requests by queueing failed calls on timeout, then replaying them sequentially after reconnect.
  - Improved command coalescing for charging profile updates using charging-profile purpose to avoid incorrectly dropping distinct requests.

- **Tests**
  - Added async pytest coverage for queue order, coalescing rules, and timeout-to-replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->