### PR TITLE
Always cancel charge point tasks when stopping

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -560,11 +560,16 @@ class ChargePoint(cp):
     async def stop(self):
         """Close connection and cancel ongoing tasks."""
         self.status = STATE_UNAVAILABLE
-        if self._connection.state is State.OPEN:
-            _LOGGER.debug(f"Closing websocket to '{self.id}'")
-            await self._connection.close()
-        for task in self.tasks:
-            task.cancel()
+        try:
+            if self._connection.state is State.OPEN:
+                _LOGGER.debug(f"Closing websocket to '{self.id}'")
+                await self._connection.close()
+        finally:
+            # Cancel regardless of how the close went: a close that raises or
+            # is cancelled must not leave monitor_connection running against a
+            # connection this charge point no longer owns.
+            for task in self.tasks or []:
+                task.cancel()
 
     async def reconnect(self, connection: ServerConnection):
         """Reconnect charge point."""

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from websockets.protocol import State
 
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
 
 from custom_components.ocpp.chargepoint import (
@@ -328,3 +329,70 @@ async def test_handle_call_wraps_notimplementederror_and_sends(hass):
         await cp._handle_call(DummyMsg())
 
     assert sent.get("payload") == "ERR_JSON"
+
+
+# -----------------------------
+# stop() must always cancel tasks
+# -----------------------------
+def _mk_task():
+    """Return a task-like object that records cancellation."""
+    task = SimpleNamespace(cancelled=False)
+    task.cancel = lambda t=task: setattr(t, "cancelled", True)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_tasks_when_close_fails(hass):
+    """A websocket close that raises must not skip task cancellation.
+
+    monitor_connection lives in self.tasks and keeps pinging the connection
+    forever, so leaving it running after stop() means the charge point never
+    really stops.
+    """
+    cp = _mk_cp(hass)
+    cp.tasks = [_mk_task(), _mk_task()]
+
+    async def failing_close():
+        raise OSError("close failed")
+
+    cp._connection.state = State.OPEN
+    cp._connection.close = failing_close
+
+    # the caller still learns the close failed
+    with pytest.raises(OSError):
+        await cp.stop()
+
+    assert all(
+        task.cancelled for task in cp.tasks
+    ), "tasks must be cancelled even when the websocket close raises"
+    assert cp.status == STATE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_stop_without_tasks_does_not_raise(hass):
+    """stop() before run() has populated self.tasks must be a no-op, not a crash."""
+    cp = _mk_cp(hass)
+    assert cp.tasks is None  # never started
+
+    await cp.stop()
+
+    assert cp.status == STATE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_stop_closes_connection_and_cancels_tasks(hass):
+    """The normal path still closes the websocket and cancels the tasks."""
+    cp = _mk_cp(hass)
+    cp.tasks = [_mk_task()]
+    closed = []
+
+    async def close():
+        closed.append(True)
+
+    cp._connection.state = State.OPEN
+    cp._connection.close = close
+
+    await cp.stop()
+
+    assert closed == [True]
+    assert all(task.cancelled for task in cp.tasks)

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -369,6 +369,33 @@ async def test_stop_cancels_tasks_when_close_fails(hass):
 
 
 @pytest.mark.asyncio
+async def test_stop_cancels_tasks_when_close_is_cancelled(hass):
+    """Cancellation of the close must not skip task cancellation either.
+
+    CancelledError derives from BaseException, so an "except Exception" guard
+    around stop() at a call site would not catch it. Only the finally block
+    keeps the tasks from outliving the charge point on this path.
+    """
+    cp = _mk_cp(hass)
+    cp.tasks = [_mk_task(), _mk_task()]
+
+    async def cancelled_close():
+        raise asyncio.CancelledError
+
+    cp._connection.state = State.OPEN
+    cp._connection.close = cancelled_close
+
+    # cancellation is not swallowed
+    with pytest.raises(asyncio.CancelledError):
+        await cp.stop()
+
+    assert all(
+        task.cancelled for task in cp.tasks
+    ), "tasks must be cancelled even when the websocket close is cancelled"
+    assert cp.status == STATE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
 async def test_stop_without_tasks_does_not_raise(hass):
     """stop() before run() has populated self.tasks must be a no-op, not a crash."""
     cp = _mk_cp(hass)


### PR DESCRIPTION
Split out of #2012 — @drc38 asked for the `stop()` fix as a separate PR.

## The problem

`ChargePoint.stop()` closes the websocket *before* cancelling `self.tasks`:

```python
async def stop(self):
    self.status = STATE_UNAVAILABLE
    if self._connection.state is State.OPEN:
        await self._connection.close()   # <-- if this raises...
    for task in self.tasks:              # <-- ...this never runs
        task.cancel()
```

If the close raises or is cancelled, the tasks are never cancelled. `self.tasks` holds `monitor_connection()`, which loops forever pinging the connection and writing metrics — so a charge point that is supposed to have stopped keeps running against a connection it no longer owns.

There are three call sites, and all of them are paths where something has already gone wrong, which is exactly when a close is most likely to fail:

- `run()`'s `finally` (`chargepoint.py`) — reached after the connection dropped
- `reconnect()` — the old connection is being torn down
- `CentralSystem.on_connect()` — the rebuild path added in #2012

Separately, `self.tasks` is initialised to `None` and only populated by `run()`. `stop()` is reachable before that, and raises `TypeError: 'NoneType' object is not iterable` when it is.

## The fix

Move cancellation into a `finally` and tolerate `tasks` being `None`:

```python
async def stop(self):
    self.status = STATE_UNAVAILABLE
    try:
        if self._connection.state is State.OPEN:
            _LOGGER.debug(f"Closing websocket to '{self.id}'")
            await self._connection.close()
    finally:
        for task in self.tasks or []:
            task.cancel()
```

The close exception still propagates, so callers are not deprived of the information that the close failed — only the cancellation is made unconditional.

## Tests

Three tests in `tests/test_charge_point_core.py`:

- `test_stop_cancels_tasks_when_close_fails` — close raises `OSError`; asserts the tasks are still cancelled and that the `OSError` still reaches the caller
- `test_stop_without_tasks_does_not_raise` — `stop()` on a charge point that never ran
- `test_stop_closes_connection_and_cancels_tasks` — the normal path still closes and cancels

The first two were mutation-verified: with the old `stop()` restored they fail (`TypeError` / uncancelled tasks), and pass with the fix.

## Note on #2012

`CentralSystem.on_connect()` currently wraps `charge_point.stop()` in a `try/except` that cancels the stale instance's tasks by hand, precisely because of this bug. With `stop()` fixed that inner loop is belt-and-braces — the `try/except` itself is still needed so a failed close doesn't abort the rebuild. I left it alone to keep this PR to the one change you asked for, but happy to simplify it in a follow-up if you'd prefer.

`pre-commit run --all-files` and the full test suite pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charge point shutdown reliability when the connection is already closed or cannot be closed.
  * Ensured background tasks are consistently cancelled during shutdown.
  * Prevented errors when stopping a charge point that has not started.
  * Charge points now correctly report an unavailable status when shutdown encounters a connection error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->