### PR TITLE
Handle station-level StatusNotification in OCPP 2.0.1

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -165,6 +165,24 @@ class ChargePoint(cp):
         self, timestamp: str, connector_status: str, evse_id: int, connector_id: int
     ):
         """Update per connector and evse aggregated."""
+        # Station-level notifications (evseId=0 / connectorId=0, which the OCPP
+        # 2.0.1 spec allows and e.g. the FoxESS A-series sends on every boot)
+        # don't belong in the per-connector bookkeeping below: evse_id - 1 == -1
+        # would either raise IndexError, on the first such notification when
+        # _connector_status is still empty, or silently write the station's
+        # status into the LAST EVSE's slot once it is not.
+        # Record them as the charger-level Status metric instead - the same key
+        # the OCPP 1.6 handler uses for connectorId=0 and that the availability
+        # switch reads. (0, Status.Connector) must stay owned by the EVSE
+        # aggregation in _report_evse_status, or a station-level 'Available'
+        # would mask a faulted connector via the flattened sensor's fallback
+        # chain.
+        if evse_id < 1 or connector_id < 1:
+            self._metrics[(0, cstat.status.value)].value = ConnectorStatusEnumType(
+                connector_status
+            ).value
+            return
+
         if evse_id > len(self._connector_status):
             needed = evse_id - len(self._connector_status)
             self._connector_status.extend([[] for _ in range(needed)])

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -177,10 +177,24 @@ class ChargePoint(cp):
         # aggregation in _report_evse_status, or a station-level 'Available'
         # would mask a faulted connector via the flattened sensor's fallback
         # chain.
-        if evse_id < 1 or connector_id < 1:
+        if evse_id == 0 and connector_id == 0:
             self._metrics[(0, cstat.status.value)].value = ConnectorStatusEnumType(
                 connector_status
             ).value
+            return
+        if evse_id < 1 or connector_id < 1:
+            # Degenerate ids that are neither station-level nor a real
+            # connector, e.g. (1, 0) or (0, 1). The per-connector bookkeeping
+            # below would index them with -1 - the crash this guard exists to
+            # prevent - and the charger-level metric would misattribute them,
+            # so log and drop.
+            _LOGGER.debug(
+                "Ignoring malformed StatusNotification "
+                "(evse_id=%s, connector_id=%s, status=%s)",
+                evse_id,
+                connector_id,
+                connector_status,
+            )
             return
 
         if evse_id > len(self._connector_status):
@@ -625,7 +639,12 @@ class ChargePoint(cp):
         self, timestamp: str, connector_status: str, evse_id: int, connector_id: int
     ):
         """Perform OCPP callback."""
-        if not self._ensure_connector_map():
+        # Station-level (0, 0) and malformed ids never route through the
+        # connector map, so they are applied immediately: buffering them on a
+        # charger whose inventory yields no map would strand them - and the
+        # chargers that send station-level statuses (e.g. FoxESS A-series)
+        # are exactly the ones with such inventories.
+        if evse_id >= 1 and connector_id >= 1 and not self._ensure_connector_map():
             self._pending_status_notifications.append(
                 (timestamp, connector_status, evse_id, connector_id)
             )

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1041,6 +1041,20 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
     assert boot_res.status == RegistrationStatusEnumType.accepted.value
     assert boot_res.status_info is None
     datetime.fromisoformat(boot_res.current_time)
+    # Regression: a station-level StatusNotification (evseId=0/connectorId=0,
+    # which the spec permits and which e.g. the FoxESS A-series sends on every
+    # boot) must not enter the per-connector bookkeeping. It previously indexed
+    # _connector_status[-1], raising IndexError while that list was still empty
+    # and aborting post_connect. A deliberately different status is used here so
+    # the assertions below also catch it being written to the connector's slot.
+    await cp.call(
+        call.StatusNotification(
+            datetime.now(tz=UTC).isoformat(),
+            ConnectorStatusEnumType.unavailable,
+            0,
+            0,
+        )
+    )
     await cp.call(
         call.StatusNotification(
             datetime.now(tz=UTC).isoformat(), ConnectorStatusEnumType.available, 1, 1
@@ -1069,6 +1083,21 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
     assert (
         cs.get_metric(cpid, cstat.status_connector.value)
         == ConnectorStatusEnumType.available.value
+    )
+    # The station-level notification landed on the charger-level Status metric
+    # (the key the OCPP 1.6 handler uses for connectorId=0 and the availability
+    # switch reads) and did not overwrite the connector's own status above.
+    server_cp = cs.charge_points[cp_id]
+    assert (
+        server_cp._metrics[(0, cstat.status.value)].value
+        == ConnectorStatusEnumType.unavailable.value
+    )
+    # (0, Status.Connector) stays owned by the EVSE aggregation - a
+    # station-level 'Unavailable' written there would mask the connector's real
+    # state through the flattened sensor's fallback chain.
+    assert (
+        server_cp._metrics[(0, cstat.status_connector.value)].value
+        != ConnectorStatusEnumType.unavailable.value
     )
     assert cp.tx_updated_interval == DEFAULT_METER_INTERVAL
     assert cp.tx_updated_measurands == supported_measurands

--- a/tests/test_v201_station_status.py
+++ b/tests/test_v201_station_status.py
@@ -1,0 +1,110 @@
+"""Station-level and malformed StatusNotification handling for OCPP 2.0.1.
+
+The websocket-level scenario in test_charge_point_v201.py covers a
+station-level notification on a charger whose inventory builds a real map.
+These unit tests cover the charger the map guard cannot serve: one whose
+inventory yields no connector map at all - which is exactly the kind of
+charger that sends station-level statuses in the first place.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import HAChargerStatuses as cstat
+from custom_components.ocpp.ocppv201 import ChargePoint
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _mk_cp(hass):
+    """Build a v201 ChargePoint detached from any real connection."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32.0,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    return ChargePoint("CP_A", conn, hass, entry, central, charger)
+
+
+@pytest.mark.asyncio
+async def test_station_level_status_applies_without_a_connector_map(hass):
+    """A (0, 0) notification must not wait for a map that may never exist.
+
+    It does not route through the map at all, so buffering it behind
+    _ensure_connector_map stranded it forever on chargers whose inventory
+    yields no connectors - leaving the charger-level Status unset.
+    """
+    cp = _mk_cp(hass)
+    assert cp._evse_to_global == {}  # no map, and none is coming
+
+    cp.on_status_notification(
+        timestamp="2026-01-01T00:00:00Z",
+        connector_status="Available",
+        evse_id=0,
+        connector_id=0,
+    )
+
+    assert cp._pending_status_notifications == []
+    assert cp._metrics[(0, cstat.status.value)].value == "Available"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("evse_id,connector_id", [(1, 0), (0, 1), (-1, 0), (0, -1)])
+async def test_malformed_ids_are_dropped_not_crashed_or_misattributed(
+    hass, evse_id, connector_id
+):
+    """Degenerate ids are neither station-level nor a real connector.
+
+    Fed to the per-connector bookkeeping they would index with -1 - the
+    IndexError / silent last-slot overwrite this guard exists to prevent -
+    and recorded as station-level they would misattribute another entity's
+    state to the charger. They must be dropped.
+    """
+    cp = _mk_cp(hass)
+
+    cp.on_status_notification(
+        timestamp="2026-01-01T00:00:00Z",
+        connector_status="Faulted",
+        evse_id=evse_id,
+        connector_id=connector_id,
+    )
+
+    assert cp._pending_status_notifications == []
+    assert cp._metrics[(0, cstat.status.value)].value is None
+    assert cp._connector_status == []


### PR DESCRIPTION
Part of the OCPP 2.0.1 work from #2008 (follows #2012 and #2013). One more PR — a connector-count fallback for chargers whose inventory reports no connectors — builds on this and will follow separately.

## The problem

Some chargers send a **station-level** `StatusNotification` with `evseId=0` / `connectorId=0` — the FoxESS A-series sends one on every boot, mirroring OCPP 1.6's `connectorId=0` convention for the charge point itself.

`_apply_status_notification` feeds it straight into the per-connector bookkeeping, where `evse_id - 1 == -1`:

- on the first such notification, while `_connector_status` is still empty, `self._connector_status[-1]` raises `IndexError`, which propagates out of the status-notification flush and **aborts `post_connect`** — the charger never finishes setting up;
- once `_connector_status` is populated, Python's negative indexing makes it **silently write the station's status into the LAST EVSE's slot**.

## The fix

Station-level notifications are recorded as the charger-level `Status` metric — the same key the OCPP 1.6 handler uses for `connectorId=0` and that the availability switch reads — and never enter the per-connector path.

Deliberately **not** written to `(0, Status.Connector)`: that key is owned by the EVSE aggregation in `_report_evse_status`, and a station-level `Available` written there would mask a faulted connector through the flattened sensor's fallback chain.

## Testing

- Regression test added to the main v201 flow: a station-level `Unavailable` arrives before the connector's `Available`, and the test asserts no crash, the charger-level `Status` metric receives it, and the connector's own status is not clobbered. Mutation-verified: with the guard removed, the flush aborts and connector status never lands.
- Validated on live hardware (FoxESS A022KP1, HA 2026.7.4): the charger's boot-time `(0,0)` notification routes to the charger `Status` sensor on every 2.0.1 connection, with normal connector handling unchanged.
- Full suite and `pre-commit run --all-files` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCPP 2.0.1/2.1 station-level `StatusNotification` handling to apply correctly for the valid `(0,0)` case.
  * Prevented misattribution of status when notifications contain malformed or degenerate EVSE/connector identifiers; such updates are now dropped safely.
  * Ensured station-level availability is tracked independently without overwriting EVSE-level aggregated connector status.
* **Tests**
  * Added unit coverage for station-level status behavior, including immediate handling without a connector map and validation that malformed identifiers don’t update metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->