### PR TITLE
Expose one logical connector when the OCPP 2.0.1 inventory yields none

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -277,8 +277,9 @@ class ChargePoint(cp):
             # reporting must not abort post_connect: swallowing the timeout
             # lets get_number_of_connectors fall back to one connector below.
             # Accepted trade-off: parts that did arrive may yield a partial
-            # inventory; anything wrong with it self-heals on the next
-            # reconnect, when the inventory is fetched again.
+            # inventory, and since a same-version reconnect reuses this
+            # ChargePoint, anything wrong with it persists until the
+            # integration is reloaded.
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(
                     self._wait_inventory.wait(), self._response_timeout
@@ -313,24 +314,36 @@ class ChargePoint(cp):
         Accepted limitation: a genuine multi-connector charger with an
         unusable inventory is exposed as a single connector - discovering
         more would require growing entities after setup. Statuses for a
-        second pair route to an index with no entity behind it; harmless,
-        and corrected on the next reconnect if the charger ever reports a
-        usable inventory.
+        second pair route to an index with no entity behind it; harmless.
+        A same-version reconnect reuses this ChargePoint and its maps, so
+        anything imperfect here persists until the integration is reloaded
+        (or the charger starts reporting a usable inventory and Home
+        Assistant is restarted).
         """
         await self._get_inventory()
         total = self._total_connectors()
         if total == 0:
             total = DEFAULT_NUM_CONNECTORS
-            # The inventory exchange is over and produced no usable topology,
-            # so nothing else will flush the statuses buffered during it.
-            # Route them through the dynamic allocation now (station-level
-            # (0, 0) entries go to the charger-level Status metric).
-            pending = self._pending_status_notifications
-            self._pending_status_notifications = []
-            for timestamp, status, evse_id, connector_id in pending:
-                self._apply_status_notification(
-                    timestamp, status, evse_id, connector_id
-                )
+            # Flush the statuses buffered during the exchange - but only if no
+            # inventory attempt is still in flight. post_connect can run twice
+            # (boot notification + the 10s monitor backstop), and with a slow
+            # multipart report _get_inventory returns early for the second
+            # caller while the first is still waiting: _inventory exists from
+            # the first part, but the connector counts have not arrived.
+            # Flushing here would install a dynamic map that the real
+            # inventory could then never replace (_build_connector_map keeps a
+            # populated map), leaving a working multi-connector charger's
+            # sensors permanently swapped. Left buffered, the statuses are
+            # flushed by the in-flight attempt's own completion instead.
+            # Station-level (0, 0) entries go to the charger-level Status
+            # metric.
+            if self._wait_inventory is None:
+                pending = self._pending_status_notifications
+                self._pending_status_notifications = []
+                for timestamp, status, evse_id, connector_id in pending:
+                    self._apply_status_notification(
+                        timestamp, status, evse_id, connector_id
+                    )
         return total
 
     async def set_standard_configuration(self):
@@ -699,17 +712,18 @@ class ChargePoint(cp):
             evse_id >= 1
             and connector_id >= 1
             and not self._ensure_connector_map()
-            and not self.post_connect_success
+            and (not self.post_connect_success or self._wait_inventory is not None)
         ):
-            # No inventory-derived map yet and setup is still running: hold
-            # the status until get_number_of_connectors has settled the
-            # topology, so a pre-inventory status cannot poison the map of a
-            # charger whose real report is still on its way.
+            # No inventory-derived map, and either setup is still running or
+            # an inventory attempt is in flight (stop_transaction re-fetches
+            # when none is cached, so this can happen after setup too): hold
+            # the status until the attempt settles, so it cannot poison the
+            # map of a charger whose real report is still on its way.
             #
-            # Once setup HAS finished without producing a map, the inventory
-            # is unusable and no flush is ever coming - fall through and let
-            # _pair_to_global's dynamic allocation route it instead of
-            # buffering it forever.
+            # Once setup has finished and no attempt is running, a missing
+            # map means the inventory is unusable and no flush is ever
+            # coming - fall through and let _pair_to_global's dynamic
+            # allocation route it instead of buffering it forever.
             self._pending_status_notifications.append(
                 (timestamp, connector_status, evse_id, connector_id)
             )

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -54,6 +54,7 @@ from .enums import (
 from .const import (
     CentralSystemSettings,
     ChargerSystemSettings,
+    DEFAULT_NUM_CONNECTORS,
     DOMAIN,
     HA_ENERGY_UNIT,
 )
@@ -272,15 +273,65 @@ class ChargePoint(cp):
         except OCPPError:
             self._inventory = None
         if (resp is not None) and (resp.status == "Accepted"):
-            await asyncio.wait_for(self._wait_inventory.wait(), self._response_timeout)
+            # A charger that accepts GetBaseReport but never finishes
+            # reporting must not abort post_connect: swallowing the timeout
+            # lets get_number_of_connectors fall back to one connector below.
+            # Accepted trade-off: parts that did arrive may yield a partial
+            # inventory; anything wrong with it self-heals on the next
+            # reconnect, when the inventory is fetched again.
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(
+                    self._wait_inventory.wait(), self._response_timeout
+                )
         self._wait_inventory = None
         if self._inventory:
             self._build_connector_map()
 
     async def get_number_of_connectors(self) -> int:
-        """Return number of connectors on this charger."""
+        """Return number of connectors on this charger.
+
+        Some chargers (e.g. FoxESS A-series, issue #2008) answer
+        GetBaseReport with an inventory that omits their EVSE/Connector
+        components - only a charging-station-level ``evse.id=0`` entry is
+        reported - so the inventory yields 0 connectors even though the
+        charger clearly has one (its StatusNotification reports
+        evseId=1/connectorId=1). Chargers that cannot answer GetBaseReport at
+        all land in the same place.
+
+        Returning 0 left the base post_connect connector-slot init loop
+        empty, so session metrics (Time.Session, Session.Energy, meter_start)
+        never received their units - raising a spurious `units_changed`
+        repair when a charger switches between OCPP 1.6 and 2.0.1 - and the
+        EVSE<->global connector map could never be built, so buffered
+        StatusNotifications were held forever.
+
+        Such a charger is exposed as one logical connector, matching the
+        OCPP 1.6 path which already defaults to 1. No topology is invented:
+        statuses route through _pair_to_global's existing dynamic
+        allocation, so the first charger-reported pair becomes connector 1.
+
+        Accepted limitation: a genuine multi-connector charger with an
+        unusable inventory is exposed as a single connector - discovering
+        more would require growing entities after setup. Statuses for a
+        second pair route to an index with no entity behind it; harmless,
+        and corrected on the next reconnect if the charger ever reports a
+        usable inventory.
+        """
         await self._get_inventory()
-        return self._total_connectors()
+        total = self._total_connectors()
+        if total == 0:
+            total = DEFAULT_NUM_CONNECTORS
+            # The inventory exchange is over and produced no usable topology,
+            # so nothing else will flush the statuses buffered during it.
+            # Route them through the dynamic allocation now (station-level
+            # (0, 0) entries go to the charger-level Status metric).
+            pending = self._pending_status_notifications
+            self._pending_status_notifications = []
+            for timestamp, status, evse_id, connector_id in pending:
+                self._apply_status_notification(
+                    timestamp, status, evse_id, connector_id
+                )
+        return total
 
     async def set_standard_configuration(self):
         """Send configuration values to the charger."""
@@ -644,7 +695,21 @@ class ChargePoint(cp):
         # charger whose inventory yields no map would strand them - and the
         # chargers that send station-level statuses (e.g. FoxESS A-series)
         # are exactly the ones with such inventories.
-        if evse_id >= 1 and connector_id >= 1 and not self._ensure_connector_map():
+        if (
+            evse_id >= 1
+            and connector_id >= 1
+            and not self._ensure_connector_map()
+            and not self.post_connect_success
+        ):
+            # No inventory-derived map yet and setup is still running: hold
+            # the status until get_number_of_connectors has settled the
+            # topology, so a pre-inventory status cannot poison the map of a
+            # charger whose real report is still on its way.
+            #
+            # Once setup HAS finished without producing a map, the inventory
+            # is unusable and no flush is ever coming - fall through and let
+            # _pair_to_global's dynamic allocation route it instead of
+            # buffering it forever.
             self._pending_status_notifications.append(
                 (timestamp, connector_status, evse_id, connector_id)
             )

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -287,6 +287,26 @@ class ChargePoint(cp):
         self._wait_inventory = None
         if self._inventory:
             self._build_connector_map()
+        # However this attempt ended - final report received, timed out,
+        # refused or unsupported - it is over, and nothing else will drain the
+        # statuses buffered while it ran: on_report's flush only fires when a
+        # final part arrives, and a timed-out partial report that yielded SOME
+        # connectors bypasses the zero-connector fallback below entirely.
+        # Drain here, at the one point every outcome passes through. With a
+        # map (even a partial one) statuses route through it; without one they
+        # take _pair_to_global's dynamic allocation, so the first
+        # charger-reported pair becomes connector 1. (Station-level statuses
+        # never buffer - on_status_notification applies them immediately - so
+        # only real connector pairs pass through here.)
+        # A concurrent second caller (boot notification racing the 10s monitor
+        # backstop) never reaches this point mid-stream - it returns early on
+        # the _inventory check above - so a half-streamed report can never be
+        # drained into a dynamic map that the real inventory could then not
+        # replace.
+        pending = self._pending_status_notifications
+        self._pending_status_notifications = []
+        for timestamp, status, evse_id, connector_id in pending:
+            self._apply_status_notification(timestamp, status, evse_id, connector_id)
 
     async def get_number_of_connectors(self) -> int:
         """Return number of connectors on this charger.
@@ -323,27 +343,10 @@ class ChargePoint(cp):
         await self._get_inventory()
         total = self._total_connectors()
         if total == 0:
+            # Buffered statuses were already drained when the inventory
+            # attempt settled (see _get_inventory); only the count needs
+            # flooring here.
             total = DEFAULT_NUM_CONNECTORS
-            # Flush the statuses buffered during the exchange - but only if no
-            # inventory attempt is still in flight. post_connect can run twice
-            # (boot notification + the 10s monitor backstop), and with a slow
-            # multipart report _get_inventory returns early for the second
-            # caller while the first is still waiting: _inventory exists from
-            # the first part, but the connector counts have not arrived.
-            # Flushing here would install a dynamic map that the real
-            # inventory could then never replace (_build_connector_map keeps a
-            # populated map), leaving a working multi-connector charger's
-            # sensors permanently swapped. Left buffered, the statuses are
-            # flushed by the in-flight attempt's own completion instead.
-            # Station-level (0, 0) entries go to the charger-level Status
-            # metric.
-            if self._wait_inventory is None:
-                pending = self._pending_status_notifications
-                self._pending_status_notifications = []
-                for timestamp, status, evse_id, connector_id in pending:
-                    self._apply_status_notification(
-                        timestamp, status, evse_id, connector_id
-                    )
         return total
 
     async def set_standard_configuration(self):
@@ -719,6 +722,8 @@ class ChargePoint(cp):
             # when none is cached, so this can happen after setup too): hold
             # the status until the attempt settles, so it cannot poison the
             # map of a charger whose real report is still on its way.
+            # _get_inventory drains this buffer when the attempt ends, however
+            # it ends, so nothing held here can be stranded.
             #
             # Once setup has finished and no attempt is running, a missing
             # map means the inventory is unusable and no flush is ever

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -233,15 +233,27 @@ class ChargePoint(cp):
                 v16 = ChargePointStatusv16.preparing
             self._report_evse_status(evse_id, v16)
 
-    def _flush_pending_status_notifications(self):
-        """Flush buffered status notifications when the map is ready."""
-        if not self._ensure_connector_map():
-            return
+    def _drain_pending_status_notifications(self):
+        """Apply and clear buffered status notifications, then notify HA.
+
+        The HA update must be scheduled here rather than left to
+        _apply_status_notification: that only schedules one via
+        _report_evse_status, which is skipped while any connector in the EVSE
+        still has no known status, so a drained entry could change a metric
+        without the sensor ever refreshing.
+        """
         pending = self._pending_status_notifications
         self._pending_status_notifications = []
         for t, st, evse_id, conn_id in pending:
             self._apply_status_notification(t, st, evse_id, conn_id)
-        self.hass.async_create_task(self.update(self.settings.cpid))
+        if pending:
+            self.hass.async_create_task(self.update(self.settings.cpid))
+
+    def _flush_pending_status_notifications(self):
+        """Flush buffered status notifications when the map is ready."""
+        if not self._ensure_connector_map():
+            return
+        self._drain_pending_status_notifications()
 
     def _total_connectors(self) -> int:
         """Total physical connectors across all EVSE."""
@@ -303,10 +315,7 @@ class ChargePoint(cp):
         # the _inventory check above - so a half-streamed report can never be
         # drained into a dynamic map that the real inventory could then not
         # replace.
-        pending = self._pending_status_notifications
-        self._pending_status_notifications = []
-        for timestamp, status, evse_id, connector_id in pending:
-            self._apply_status_notification(timestamp, status, evse_id, connector_id)
+        self._drain_pending_status_notifications()
 
     async def get_number_of_connectors(self) -> int:
         """Return number of connectors on this charger.

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1580,8 +1580,9 @@ async def test_cms_responses_v201(hass, socket_enabled):
     )
 
     # Same incomplete inventory, but no StatusNotification arrives until after
-    # setup completes: the provisional (1,1) fallback must be rebound to the
-    # first observed real pair.
+    # setup completes: no mapping exists yet (nothing is provisioned from
+    # nothing), so the first observed real pair must bind connector 1 via the
+    # dynamic allocation.
     cp_id5 = "CP_2_incomplete_late"
     entry = hass.config_entries._entries.get_entries_for_domain(OCPP_DOMAIN)[0]
     entry.data[CONF_CPIDS].append({cp_id5: MOCK_CONFIG_CP_APPEND.copy()})

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import datetime, timedelta, UTC
 
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.exceptions import HomeAssistantError
 from ocpp.v16.enums import Measurand
@@ -1224,6 +1225,48 @@ class ChargePointReportFailing(ChargePointAllFeatures):
         raise ocpp.exceptions.InternalError("Test failure")
 
 
+class ChargePointIncompleteInventory(ChargePointAllFeatures):
+    """A charge point accepting GetBaseReport but reporting no connectors.
+
+    Mirrors the FoxESS A-series: the FullInventory contains only a
+    charging-station-level EVSE component (evse.id=0) and no Connector
+    components, even though the charger has a real connector which it reports
+    via StatusNotification(evseId=1, connectorId=1).
+    """
+
+    @on(Action.get_base_report)
+    def _on_base_report(self, request_id: int, report_base: str, **kwargs):
+        assert report_base == ReportBaseEnumType.full_inventory.value
+        self.task = asyncio.create_task(self._send_incomplete_inventory(request_id))
+        return call_result.GetBaseReport(
+            GenericDeviceModelStatusEnumType.accepted.value
+        )
+
+    async def _send_incomplete_inventory(self, request_id: int):
+        # The real charger's StatusNotifications arrive before the inventory
+        # exchange completes; give them time to land first so they are
+        # buffered when the report below finishes.
+        await asyncio.sleep(1)
+        await self.call(
+            call.NotifyReport(
+                request_id,
+                datetime.now(tz=UTC).isoformat(),
+                0,
+                [
+                    ReportDataType(
+                        ComponentType("EVSE", evse=EVSEType(0)),
+                        VariableType("AllowReset"),
+                        [
+                            VariableAttributeType(
+                                value="true", mutability=MutabilityEnumType.read_only
+                            )
+                        ],
+                    ),
+                ],
+            )
+        )
+
+
 async def _unsupported_base_report_test(
     hass: HomeAssistant,
     cs: CentralSystem,
@@ -1249,8 +1292,164 @@ async def _unsupported_base_report_test(
         == Profiles.CORE | Profiles.REM | Profiles.FW
     )
 
+    # Regression: a charger whose GetBaseReport yields no connectors (either
+    # because it does not implement/answer it, or because — like the FoxESS
+    # A-series — it reports only a charging-station-level EVSE with id=0 and no
+    # Connector components) must still be treated as having at least one
+    # connector. Otherwise the base post_connect connector-slot init loop is
+    # empty, session metrics never receive their units, and switching the
+    # charger between OCPP 1.6 and 2.0.1 raises a spurious `units_changed`
+    # repair (issue #2008 companion). See get_number_of_connectors in ocppv201.
+    server_cp = cs.charge_points[cp_id]
+    assert server_cp.num_connectors >= 1
+    assert server_cp._metrics[(1, csess.session_time.value)].unit == UnitOfTime.MINUTES
 
-@pytest.mark.timeout(150)
+    # Creating the connector slots is only half the job: a StatusNotification
+    # must still be routable to them. A GetBaseReport answered with a CallError
+    # leaves _inventory None, so acquisition would never be marked complete and
+    # every StatusNotification would be buffered forever - the connector
+    # entities would exist but permanently read unknown.
+    await cp.call(
+        call.StatusNotification(
+            datetime.now(tz=UTC).isoformat(),
+            ConnectorStatusEnumType.occupied.value,
+            1,
+            1,
+        )
+    )
+    while (
+        cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
+        != ConnectorStatusEnumType.occupied.value
+    ):
+        await asyncio.sleep(0.1)
+    assert server_cp._pending_status_notifications == []
+
+
+async def _incomplete_inventory_test(
+    hass: HomeAssistant,
+    cs: CentralSystem,
+    cp: ChargePoint,
+    evse_id: int = 1,
+):
+    cp_id = cp.id[:-7]
+    cpid = cs.charge_points[cp_id].settings.cpid
+
+    await cp.call(
+        call.BootNotification(
+            {
+                "serial_number": "SERIAL",
+                "model": "MODEL",
+                "vendor_name": "VENDOR",
+                "firmware_version": "VERSION",
+            },
+            BootReasonEnumType.power_up.value,
+        )
+    )
+    # The real charger reports a station-level status (evseId=0/connectorId=0)
+    # followed by its connector status right after boot, before the inventory
+    # exchange completes, so both land in _pending_status_notifications while
+    # the EVSE map is not yet built. The station-level entry must not break
+    # the flush (regression: it previously raised IndexError via
+    # _connector_status[-1] on an empty list, aborting post_connect).
+    await cp.call(
+        call.StatusNotification(
+            datetime.now(tz=UTC).isoformat(),
+            ConnectorStatusEnumType.available.value,
+            0,
+            0,
+        )
+    )
+    await cp.call(
+        call.StatusNotification(
+            datetime.now(tz=UTC).isoformat(),
+            ConnectorStatusEnumType.occupied.value,
+            evse_id,
+            1,
+        )
+    )
+    await wait_ready(cs.charge_points[cp_id])
+
+    server_cp = cs.charge_points[cp_id]
+    # Inventory reported zero connectors -> normalised to the topology
+    # observed in the buffered StatusNotification: one real connector.
+    assert server_cp.num_connectors == 1
+    assert server_cp._metrics[(1, csess.session_time.value)].unit == UnitOfTime.MINUTES
+    # The buffered StatusNotification must be applied once the fallback
+    # connector map is built - not held in _pending_status_notifications -
+    # and must land on global connector 1, i.e. the map must reflect the
+    # charger's real (evse_id, connector_id) pair rather than an assumed
+    # (1, 1).
+    while (
+        cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
+        != ConnectorStatusEnumType.occupied.value
+    ):
+        await asyncio.sleep(0.1)
+    assert server_cp._pending_status_notifications == []
+    assert server_cp._evse_to_global == {(evse_id, 1): 1}
+    # The station-level notification must land on the charger-level Status
+    # metric (the key the OCPP 1.6 handler uses for connectorId=0 and the
+    # availability switch reads) - NOT on (0, Status.Connector), which is
+    # owned by the EVSE aggregation and would mask the connector's state via
+    # the flattened sensor's fallback chain.
+    assert (
+        server_cp._metrics[(0, cstat.status.value)].value
+        == ConnectorStatusEnumType.available.value
+    )
+
+
+async def _incomplete_inventory_late_evidence_test(
+    hass: HomeAssistant,
+    cs: CentralSystem,
+    cp: ChargePoint,
+):
+    cp_id = cp.id[:-7]
+    cpid = cs.charge_points[cp_id].settings.cpid
+
+    # No StatusNotification before or during the inventory exchange: the
+    # charger stays quiet until after setup has finished.
+    await cp.call(
+        call.BootNotification(
+            {
+                "serial_number": "SERIAL",
+                "model": "MODEL",
+                "vendor_name": "VENDOR",
+                "firmware_version": "VERSION",
+            },
+            BootReasonEnumType.power_up.value,
+        )
+    )
+    await wait_ready(cs.charge_points[cp_id])
+
+    server_cp = cs.charge_points[cp_id]
+    # One logical connector is exposed (so entities and units exist), and no
+    # mapping is invented from nothing.
+    assert server_cp.num_connectors == 1
+    assert server_cp._evse_to_global == {}
+
+    # The charger's first status arrives only after setup. With no
+    # inventory-derived map and no flush ever coming, it must route through
+    # the dynamic allocation - the first reported pair becomes connector 1 -
+    # rather than being buffered forever with the sensor stuck on unknown.
+    # Here the pair is (2, 2): the single-connector entities follow the
+    # charger's real connector wherever it lives.
+    await cp.call(
+        call.StatusNotification(
+            datetime.now(tz=UTC).isoformat(),
+            ConnectorStatusEnumType.occupied.value,
+            2,
+            2,
+        )
+    )
+    while (
+        cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
+        != ConnectorStatusEnumType.occupied.value
+    ):
+        await asyncio.sleep(0.1)
+    assert server_cp._evse_to_global == {(2, 2): 1}
+    assert server_cp.num_connectors == 1
+
+
+@pytest.mark.timeout(360)
 async def test_cms_responses_v201(hass, socket_enabled):
     """Test central system responses to a charger."""
 
@@ -1343,6 +1542,60 @@ async def test_cms_responses_v201(hass, socket_enabled):
         ["ocpp2.0.1"],
         lambda ws: ChargePointReportFailing("CP_2_report_fail_client", ws),
         [lambda cp: _unsupported_base_report_test(hass, cs, cp)],
+    )
+
+    cp_id3 = "CP_2_incomplete"
+    entry = hass.config_entries._entries.get_entries_for_domain(OCPP_DOMAIN)[0]
+    entry.data[CONF_CPIDS].append({cp_id3: MOCK_CONFIG_CP_APPEND.copy()})
+    entry.data[CONF_CPIDS][-1][cp_id3][CONF_CPID] = "test_v201_cpid3"
+    # need to reload to setup sensors etc for new charger
+    await hass.config_entries.async_reload(entry.entry_id)
+    cs = hass.data[DOMAIN][entry.entry_id]
+
+    await run_charge_point_test(
+        config_entry,
+        cp_id3,
+        ["ocpp2.0.1"],
+        lambda ws: ChargePointIncompleteInventory("CP_2_incomplete_client", ws),
+        [lambda cp: _incomplete_inventory_test(hass, cs, cp)],
+    )
+
+    # Same incomplete inventory, but the charger's real connector lives on
+    # EVSE 2: the fallback topology must follow the observed
+    # StatusNotification, not assume (1, 1).
+    cp_id4 = "CP_2_incomplete_evse2"
+    entry = hass.config_entries._entries.get_entries_for_domain(OCPP_DOMAIN)[0]
+    entry.data[CONF_CPIDS].append({cp_id4: MOCK_CONFIG_CP_APPEND.copy()})
+    entry.data[CONF_CPIDS][-1][cp_id4][CONF_CPID] = "test_v201_cpid4"
+    # need to reload to setup sensors etc for new charger
+    await hass.config_entries.async_reload(entry.entry_id)
+    cs = hass.data[DOMAIN][entry.entry_id]
+
+    await run_charge_point_test(
+        config_entry,
+        cp_id4,
+        ["ocpp2.0.1"],
+        lambda ws: ChargePointIncompleteInventory("CP_2_incomplete_evse2_client", ws),
+        [lambda cp: _incomplete_inventory_test(hass, cs, cp, evse_id=2)],
+    )
+
+    # Same incomplete inventory, but no StatusNotification arrives until after
+    # setup completes: the provisional (1,1) fallback must be rebound to the
+    # first observed real pair.
+    cp_id5 = "CP_2_incomplete_late"
+    entry = hass.config_entries._entries.get_entries_for_domain(OCPP_DOMAIN)[0]
+    entry.data[CONF_CPIDS].append({cp_id5: MOCK_CONFIG_CP_APPEND.copy()})
+    entry.data[CONF_CPIDS][-1][cp_id5][CONF_CPID] = "test_v201_cpid5"
+    # need to reload to setup sensors etc for new charger
+    await hass.config_entries.async_reload(entry.entry_id)
+    cs = hass.data[DOMAIN][entry.entry_id]
+
+    await run_charge_point_test(
+        config_entry,
+        cp_id5,
+        ["ocpp2.0.1"],
+        lambda ws: ChargePointIncompleteInventory("CP_2_incomplete_late_client", ws),
+        [lambda cp: _incomplete_inventory_late_evidence_test(hass, cs, cp)],
     )
 
     await remove_configuration(hass, config_entry)

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -1,0 +1,105 @@
+"""The one-connector floor for OCPP 2.0.1 chargers with unusable inventories.
+
+The websocket-level scenarios in test_charge_point_v201.py cover the FoxESS
+shape (inventory with no connector components), refused and unsupported
+GetBaseReport, and a first status arriving only after setup. These unit tests
+cover the one shape a test charge point cannot conveniently fake: a charger
+that accepts GetBaseReport and then never finishes reporting.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from ocpp.exceptions import OCPPError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import HAChargerStatuses as cstat
+from custom_components.ocpp.ocppv201 import ChargePoint
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _mk_cp(hass):
+    """Build a v201 ChargePoint detached from any real connection."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32.0,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    cp._response_timeout = 0.05
+    return cp
+
+
+@pytest.mark.asyncio
+async def test_silent_charger_still_gets_the_floor(hass):
+    """Accepting GetBaseReport and never reporting must not abort setup.
+
+    The report-wait TimeoutError previously escaped get_number_of_connectors
+    and post_connect swallowed it, so the connector slots were never created:
+    no units, a spurious units_changed repair, and statuses buffered forever.
+    """
+    cp = _mk_cp(hass)
+
+    async def accept_and_never_report(req):
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = accept_and_never_report
+
+    # buffered during the (silent) inventory exchange
+    cp._pending_status_notifications = [("2026-01-01T00:00:00Z", "Available", 1, 1)]
+
+    total = await cp.get_number_of_connectors()  # must not raise
+
+    assert total == 1
+    assert cp._pending_status_notifications == []
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+
+
+@pytest.mark.asyncio
+async def test_refused_inventory_still_gets_the_floor(hass):
+    """A refused GetBaseReport lands in the same place: one logical connector."""
+    cp = _mk_cp(hass)
+
+    async def refuse(req):
+        raise OCPPError("refused")
+
+    cp.call = refuse
+
+    total = await cp.get_number_of_connectors()
+
+    assert total == 1

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -154,17 +154,28 @@ async def test_second_post_connect_during_slow_inventory_does_not_poison_map(has
 
 
 @pytest.mark.asyncio
-async def test_status_buffers_while_post_setup_refetch_is_in_flight(hass):
-    """The dynamic-routing fall-through must also wait out an active attempt.
+async def test_status_buffered_during_refetch_is_drained_when_it_times_out(hass):
+    """A status held for an in-flight attempt must be applied when it settles.
 
     stop_transaction re-fetches the inventory when none is cached, so an
     attempt can be in flight after setup succeeded. A status arriving then
-    must buffer - not route dynamically past the attempt - and route only
-    once the attempt has settled.
+    buffers - it must not route dynamically past the attempt - and the
+    attempt's settling must drain it: a silently timed-out refetch previously
+    left the entry buffered forever, and repeated silent refetches would
+    accumulate more.
     """
     cp = _mk_cp(hass)
     cp.post_connect_success = True
-    cp._wait_inventory = asyncio.Event()  # post-setup refetch in flight
+    started = asyncio.Event()
+
+    async def accept_then_go_quiet(req):
+        started.set()
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = accept_then_go_quiet
+
+    refetch = asyncio.create_task(cp._get_inventory())
+    await started.wait()
 
     cp.on_status_notification(
         timestamp="2026-01-01T00:00:00Z",
@@ -177,13 +188,84 @@ async def test_status_buffers_while_post_setup_refetch_is_in_flight(hass):
     ], "a status must not route dynamically while an attempt is in flight"
     assert cp._evse_to_global == {}
 
-    # attempt settles with nothing usable; the next status routes dynamically
-    cp._wait_inventory = None
+    await refetch  # the attempt times out and settles
+
+    assert (
+        cp._pending_status_notifications == []
+    ), "settling the attempt must drain the buffer"
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._evse_to_global == {(1, 1): 1}
+
+    # and a later status now routes directly
     cp.on_status_notification(
         timestamp="2026-01-01T00:00:02Z",
         connector_status="Occupied",
         evse_id=1,
         connector_id=1,
     )
-    assert cp._evse_to_global == {(1, 1): 1}
+    assert cp._pending_status_notifications == []
     assert cp._metrics[(1, cstat.status_connector.value)].value == "Occupied"
+
+
+@pytest.mark.asyncio
+async def test_partial_topology_timeout_still_drains_buffered_statuses(hass):
+    """A timed-out report that yielded SOME connectors must still drain.
+
+    A first NotifyReport part can supply real EVSE/connector counts before the
+    charger goes quiet. The floor is then bypassed (total > 0), so the drain
+    cannot live only in the zero-connector fallback: the boot status buffered
+    during the exchange previously stayed unapplied forever even though setup
+    succeeded.
+    """
+    cp = _mk_cp(hass)
+    started = asyncio.Event()
+
+    async def accept_then_go_quiet(req):
+        started.set()
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = accept_then_go_quiet
+
+    setup = asyncio.create_task(cp.get_number_of_connectors())
+    await started.wait()
+
+    # the charger's boot status lands first, before any report part exists to
+    # build a map from - so it buffers
+    cp.on_status_notification(
+        timestamp="2026-01-01T00:00:01Z",
+        connector_status="Available",
+        evse_id=1,
+        connector_id=1,
+    )
+    assert cp._pending_status_notifications, "status buffers during the exchange"
+
+    # then the first report part arrives, describing one EVSE with one
+    # connector - and the final part never comes
+    cp.on_report(
+        1,
+        "2026-01-01T00:00:00Z",
+        0,
+        report_data=[
+            {
+                "component": {"name": "EVSE", "evse": {"id": 1}},
+                "variable": {"name": "AvailabilityState"},
+            },
+            {
+                "component": {
+                    "name": "Connector",
+                    "evse": {"id": 1, "connector_id": 1},
+                },
+                "variable": {"name": "AvailabilityState"},
+            },
+        ],
+        tbc=True,
+    )
+
+    total = await setup  # report wait times out; partial inventory kept
+
+    assert total == 1, "the partial inventory bypasses the floor"
+    assert (
+        cp._pending_status_notifications == []
+    ), "the drain must not live only in the zero-connector fallback"
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._evse_to_global == {(1, 1): 1}

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -174,17 +174,27 @@ async def test_status_buffered_during_refetch_is_drained_when_it_times_out(hass)
 
     cp.call = accept_then_go_quiet
 
+    updates: list[str] = []
+
+    async def record_update(cpid):
+        updates.append(cpid)
+
+    cp.update = record_update
+
     refetch = asyncio.create_task(cp._get_inventory())
     await started.wait()
 
+    # connector 2 of an EVSE whose connector 1 has no known status: the
+    # EVSE aggregation in _apply_status_notification skips its HA update in
+    # exactly this shape, so only the drain's own notify covers it
     cp.on_status_notification(
         timestamp="2026-01-01T00:00:00Z",
         connector_status="Available",
         evse_id=1,
-        connector_id=1,
+        connector_id=2,
     )
     assert cp._pending_status_notifications == [
-        ("2026-01-01T00:00:00Z", "Available", 1, 1)
+        ("2026-01-01T00:00:00Z", "Available", 1, 2)
     ], "a status must not route dynamically while an attempt is in flight"
     assert cp._evse_to_global == {}
 
@@ -194,14 +204,19 @@ async def test_status_buffered_during_refetch_is_drained_when_it_times_out(hass)
         cp._pending_status_notifications == []
     ), "settling the attempt must drain the buffer"
     assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
-    assert cp._evse_to_global == {(1, 1): 1}
+    assert cp._evse_to_global == {(1, 2): 1}
+    await asyncio.sleep(0)  # let the scheduled update task run
+    assert updates, (
+        "the drain must notify HA itself - _report_evse_status skips while "
+        "any connector in the EVSE has no known status"
+    )
 
     # and a later status now routes directly
     cp.on_status_notification(
         timestamp="2026-01-01T00:00:02Z",
         connector_status="Occupied",
         evse_id=1,
-        connector_id=1,
+        connector_id=2,
     )
     assert cp._pending_status_notifications == []
     assert cp._metrics[(1, cstat.status_connector.value)].value == "Occupied"

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -103,3 +103,87 @@ async def test_refused_inventory_still_gets_the_floor(hass):
     total = await cp.get_number_of_connectors()
 
     assert total == 1
+
+
+@pytest.mark.asyncio
+async def test_second_post_connect_during_slow_inventory_does_not_poison_map(hass):
+    """A concurrent setup pass must not flush statuses mid-inventory.
+
+    post_connect can run twice (boot notification + the 10s monitor
+    backstop). With a slow multipart inventory, the first NotifyReport part
+    makes _inventory truthy before any connector counts arrive, so the second
+    pass skips the wait, sees zero connectors, and - if it flushed - would
+    install a dynamic map from buffered statuses. Arrived in the order
+    (2,1), (1,1), that map is reversed, and _build_connector_map keeps an
+    already-populated map when the real inventory lands: a working
+    two-connector charger's sensors stay swapped until the integration is
+    reloaded.
+    """
+    cp = _mk_cp(hass)
+
+    # owner attempt in flight; first report part arrived, counts still absent
+    cp._wait_inventory = asyncio.Event()
+    from custom_components.ocpp.ocppv201 import InventoryReport
+
+    cp._inventory = InventoryReport()
+    cp._pending_status_notifications = [
+        ("2026-01-01T00:00:00Z", "Faulted", 2, 1),
+        ("2026-01-01T00:00:01Z", "Available", 1, 1),
+    ]
+
+    total = await cp.get_number_of_connectors()  # the second, concurrent pass
+
+    assert total == 1  # the floor still applies to the returned count
+    assert (
+        cp._evse_to_global == {}
+    ), "no map may be installed while the inventory attempt is in flight"
+    assert (
+        len(cp._pending_status_notifications) == 2
+    ), "statuses must stay buffered for the real map"
+
+    # the real inventory finishes: two EVSEs, one connector each
+    cp._inventory.evse_count = 2
+    cp._inventory.connector_count = [1, 1]
+    cp._wait_inventory = None
+    assert cp._build_connector_map()
+    cp._flush_pending_status_notifications()
+
+    assert cp._evse_to_global == {(1, 1): 1, (2, 1): 2}
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._metrics[(2, cstat.status_connector.value)].value == "Faulted"
+
+
+@pytest.mark.asyncio
+async def test_status_buffers_while_post_setup_refetch_is_in_flight(hass):
+    """The dynamic-routing fall-through must also wait out an active attempt.
+
+    stop_transaction re-fetches the inventory when none is cached, so an
+    attempt can be in flight after setup succeeded. A status arriving then
+    must buffer - not route dynamically past the attempt - and route only
+    once the attempt has settled.
+    """
+    cp = _mk_cp(hass)
+    cp.post_connect_success = True
+    cp._wait_inventory = asyncio.Event()  # post-setup refetch in flight
+
+    cp.on_status_notification(
+        timestamp="2026-01-01T00:00:00Z",
+        connector_status="Available",
+        evse_id=1,
+        connector_id=1,
+    )
+    assert cp._pending_status_notifications == [
+        ("2026-01-01T00:00:00Z", "Available", 1, 1)
+    ], "a status must not route dynamically while an attempt is in flight"
+    assert cp._evse_to_global == {}
+
+    # attempt settles with nothing usable; the next status routes dynamically
+    cp._wait_inventory = None
+    cp.on_status_notification(
+        timestamp="2026-01-01T00:00:02Z",
+        connector_status="Occupied",
+        evse_id=1,
+        connector_id=1,
+    )
+    assert cp._evse_to_global == {(1, 1): 1}
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Occupied"


### PR DESCRIPTION
Final piece of the OCPP 2.0.1 work from #2008 (follows #2012, #2013 and #2020).

## The problem

Some chargers answer `GetBaseReport(FullInventory)` with an inventory that omits their EVSE/Connector components. The FoxESS A-series reports only a charging-station-level `evse.id=0` entry, so the inventory yields **0 connectors** even though the charger has one and reports it via `StatusNotification(evseId=1, connectorId=1)`. Chargers that refuse `GetBaseReport` land in the same place, and one that *accepts* the request and then never finishes reporting previously aborted setup outright (the report-wait `TimeoutError` escaped `post_connect`).

Returning 0 connectors left the base `post_connect` connector-slot init loop empty:

- session metrics (`Time.Session`, `Session.Energy`, `meter_start`) never received their units, raising a spurious `units_changed` repair whenever a charger switches between OCPP 1.6 and 2.0.1;
- the EVSE↔global connector map could never be built, so buffered `StatusNotification`s were held forever and the connector status sensor read `unknown` permanently.

## The fix — deliberately minimal, no new lifecycle state

1. **`get_number_of_connectors`**: an inventory yielding 0 connectors is floored at `DEFAULT_NUM_CONNECTORS` (1), matching the OCPP 1.6 path which already defaults to 1. No topology is invented — statuses route through `_pair_to_global`'s existing dynamic allocation, so the first charger-reported pair becomes connector 1.
2. **`_get_inventory`**: buffered statuses are drained at the settle point of the inventory attempt — the one place every outcome (final report, timeout, refusal, unsupported) passes through. With a map, even a partial one, they route through it; without one they take the dynamic allocation. A concurrent second `post_connect` (boot notification racing the 10s monitor backstop) returns early on the cached-inventory check and can never drain a half-streamed report into a map the real inventory couldn't replace.
3. **`_get_inventory`**: the report-wait timeout is suppressed so a charger that accepts and then goes silent still reaches the floor instead of aborting setup.
4. **`on_status_notification`**: connector statuses buffer only while setup is running or an inventory attempt is in flight; after that, a missing map means no flush is ever coming, so they route via dynamic allocation instead of buffering forever.

Accepted limitations are documented in code comments where they live: a genuine multi-connector charger with an unusable inventory is exposed as a single logical connector (growing entities after setup is out of scope), and a timed-out partial report may route imperfectly until the integration is reloaded. Both are strict improvements over the current behaviour (no entities/units, statuses stuck forever, or setup aborted).

## Testing

- Websocket-level scenarios: a FoxESS-shaped inventory (station-level entry only) with statuses buffered during the exchange, the same with the connector on EVSE 2, unsupported and failing `GetBaseReport`, and a first status arriving only after setup.
- Unit tests for the shapes a test charge point can't conveniently fake: accepted-then-silent inventory (timeout floor), refused inventory, a concurrent second `post_connect` during a slow multipart report (must not install a poisoned map), a status buffered during a post-setup re-fetch being drained on settle, and a timed-out *partial* report (floor bypassed, drain still required).
- The load-bearing branches are mutation-verified: removing the floor, the timeout suppression, the settle-point drain, or the buffering gate each fails specific tests.

## Validated on live hardware

Soaked on a FoxESS A022KP1 (HA OS 2026.7.4) against this branch stacked on #2020: on OCPP 2.0.1 the charger gets one connector entity, `sensor.charger_status_connector` populates (previously permanently `unknown`), `Time.Session` carries its unit, and **no `units_changed` repair fires** across repeated 1.6↔2.0.1↔auto switches — including both directions of #2012's version-change rebuild and a reconnect where the charger skipped its `BootNotification` entirely (the 10s backstop path). Full suite and `pre-commit run --all-files` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCPP 2.0.1 initialization when connector inventory is missing, incomplete, refused, or delayed by treating the charger as having at least one logical connector (“one-connector floor”).
  * Tightened buffering for incoming connector status updates during inventory/setup so they’re applied promptly once connector mapping is available.
  * Prevented incorrect EVSE-to-global connector mapping when setup occurs concurrently with slow inventory refreshes; ensured buffered statuses are drained correctly after timeouts.

* **Tests**
  * Added new regression coverage for silent/refused/incomplete/partial inventory and concurrent setup edge cases, including late evidence routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->