### PR TITLE
Give the inventory attempt a single owner

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -275,6 +275,15 @@ class ChargePoint(cp):
     async def _get_inventory(self):
         if self._inventory is not None:
             return
+        if self._wait_inventory is not None:
+            # An attempt is already in flight (post_connect can run twice:
+            # boot notification racing the 10s monitor backstop). Taking
+            # ownership here would overwrite the owner's event, and once the
+            # owner settled and cleared it, this caller's accepted response
+            # would dereference None at _wait_inventory.wait(). Return and
+            # leave the attempt - and the drain at its settle point - to the
+            # single owner.
+            return
         self._wait_inventory = asyncio.Event()
         req = call.GetBaseReport(1, "FullInventory")
         resp: call_result.GetBaseReport | None = None
@@ -352,8 +361,10 @@ class ChargePoint(cp):
         await self._get_inventory()
         total = self._total_connectors()
         if total == 0:
-            # Buffered statuses were already drained when the inventory
-            # attempt settled (see _get_inventory); only the count needs
+            # Buffered statuses are drained by the owning attempt when it
+            # settles (see _get_inventory); a concurrent second caller can
+            # reach this floor while that attempt is still in flight, and
+            # correctly leaves them for the owner. Only the count needs
             # flooring here.
             total = DEFAULT_NUM_CONNECTORS
         return total

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -288,24 +288,32 @@ class ChargePoint(cp):
         req = call.GetBaseReport(1, "FullInventory")
         resp: call_result.GetBaseReport | None = None
         try:
-            resp = await self.call(req)
-        except ocpp.exceptions.NotImplementedError:
-            self._inventory = InventoryReport()
-        except OCPPError:
-            self._inventory = None
-        if (resp is not None) and (resp.status == "Accepted"):
-            # A charger that accepts GetBaseReport but never finishes
-            # reporting must not abort post_connect: swallowing the timeout
-            # lets get_number_of_connectors fall back to one connector below.
-            # Accepted trade-off: parts that did arrive may yield a partial
-            # inventory, and since a same-version reconnect reuses this
-            # ChargePoint, anything wrong with it persists until the
-            # integration is reloaded.
-            with contextlib.suppress(TimeoutError):
-                await asyncio.wait_for(
-                    self._wait_inventory.wait(), self._response_timeout
-                )
-        self._wait_inventory = None
+            try:
+                resp = await self.call(req)
+            except ocpp.exceptions.NotImplementedError:
+                self._inventory = InventoryReport()
+            except OCPPError:
+                self._inventory = None
+            if (resp is not None) and (resp.status == "Accepted"):
+                # A charger that accepts GetBaseReport but never finishes
+                # reporting must not abort post_connect: swallowing the
+                # timeout lets get_number_of_connectors fall back to one
+                # connector below. Accepted trade-off: parts that did arrive
+                # may yield a partial inventory, and since a same-version
+                # reconnect reuses this ChargePoint, anything wrong with it
+                # persists until the integration is reloaded.
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        self._wait_inventory.wait(), self._response_timeout
+                    )
+        finally:
+            # Release ownership on EVERY exit. The request itself can raise
+            # something the handlers above don't cover - the ocpp library's
+            # response timeout is a bare TimeoutError, and the task can be
+            # cancelled - and now that an in-flight event turns other callers
+            # away, leaking it set would make every future attempt silently
+            # return forever.
+            self._wait_inventory = None
         if self._inventory:
             self._build_connector_map()
         # However this attempt ended - final report received, timed out,

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -314,25 +314,28 @@ class ChargePoint(cp):
             # away, leaking it set would make every future attempt silently
             # return forever.
             self._wait_inventory = None
-        if self._inventory:
-            self._build_connector_map()
-        # However this attempt ended - final report received, timed out,
-        # refused or unsupported - it is over, and nothing else will drain the
-        # statuses buffered while it ran: on_report's flush only fires when a
-        # final part arrives, and a timed-out partial report that yielded SOME
-        # connectors bypasses the zero-connector fallback below entirely.
-        # Drain here, at the one point every outcome passes through. With a
-        # map (even a partial one) statuses route through it; without one they
-        # take _pair_to_global's dynamic allocation, so the first
-        # charger-reported pair becomes connector 1. (Station-level statuses
-        # never buffer - on_status_notification applies them immediately - so
-        # only real connector pairs pass through here.)
-        # A concurrent second caller (boot notification racing the 10s monitor
-        # backstop) never reaches this point mid-stream - it returns early on
-        # the _inventory check above - so a half-streamed report can never be
-        # drained into a dynamic map that the real inventory could then not
-        # replace.
-        self._drain_pending_status_notifications()
+            # However this attempt ended - final report received, timed out,
+            # refused, unsupported, or an escaping exception - it is over,
+            # and nothing else will drain the statuses buffered while it ran:
+            # on_report's flush only fires when a final part arrives, a
+            # timed-out partial report that yielded SOME connectors bypasses
+            # the zero-connector fallback entirely, and on a persistently
+            # failing charger the next attempt would strand them again. Drain
+            # inside the finally so this really is the one point every
+            # outcome passes through. With a map (even a partial one)
+            # statuses route through it; without one they take
+            # _pair_to_global's dynamic allocation, so the first
+            # charger-reported pair becomes connector 1. (Station-level
+            # statuses never buffer - on_status_notification applies them
+            # immediately - so only real connector pairs pass through here.)
+            # A concurrent second caller (boot notification racing the 10s
+            # monitor backstop) never reaches this point mid-stream - it
+            # returns early on the _inventory check above - so a
+            # half-streamed report can never be drained into a dynamic map
+            # that the real inventory could then not replace.
+            if self._inventory:
+                self._build_connector_map()
+            self._drain_pending_status_notifications()
 
     async def get_number_of_connectors(self) -> int:
         """Return number of connectors on this charger.

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -272,15 +272,54 @@ async def test_partial_topology_timeout_still_drains_buffered_statuses(hass):
                 },
                 "variable": {"name": "AvailabilityState"},
             },
+            {
+                "component": {
+                    "name": "Connector",
+                    "evse": {"id": 1, "connector_id": 2},
+                },
+                "variable": {"name": "AvailabilityState"},
+            },
         ],
         tbc=True,
     )
 
     total = await setup  # report wait times out; partial inventory kept
 
-    assert total == 1, "the partial inventory bypasses the floor"
+    # two connectors proves the partial topology was RETAINED - the
+    # one-connector floor would have produced 1
+    assert total == 2, "the partial inventory bypasses the floor"
     assert (
         cp._pending_status_notifications == []
     ), "the drain must not live only in the zero-connector fallback"
     assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
-    assert cp._evse_to_global == {(1, 1): 1}
+    assert cp._evse_to_global == {(1, 1): 1, (1, 2): 2}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_inventory_has_a_single_owner(hass):
+    """A second concurrent _get_inventory must not take over the attempt.
+
+    Both callers used to pass the cached-inventory guard before any report
+    part arrived, so the second overwrote the owner's event - and once the
+    owner settled and cleared it, the second caller's accepted response
+    dereferenced None at _wait_inventory.wait(). Only one GetBaseReport may
+    go out, and the second caller must return without touching the attempt.
+    """
+    cp = _mk_cp(hass)
+    calls: list[int] = []
+
+    async def slow_accept(req):
+        calls.append(len(calls) + 1)
+        await asyncio.sleep(0.02)
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = slow_accept
+
+    async def second_caller():
+        await asyncio.sleep(0.005)  # enter while the first call is pending
+        await cp._get_inventory()
+
+    await asyncio.gather(cp._get_inventory(), second_caller())
+
+    assert len(calls) == 1, "only the owning attempt may send GetBaseReport"
+    assert cp._wait_inventory is None

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -346,12 +346,20 @@ async def test_failed_attempt_releases_ownership_for_the_next_one(hass):
 
     cp.call = timeout_then_refuse
 
+    # buffered while the failing attempt is in flight
+    cp._pending_status_notifications = [("2026-01-01T00:00:00Z", "Available", 1, 1)]
+
     with pytest.raises(TimeoutError):
         await cp.get_number_of_connectors()
 
     assert (
         cp._wait_inventory is None
     ), "a failed attempt must release ownership on its way out"
+    assert cp._pending_status_notifications == [], (
+        "even a failed attempt must drain on its way out - on a persistently "
+        "failing charger the next attempt would strand these again"
+    )
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
 
     total = await cp.get_number_of_connectors()
 

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -323,3 +323,37 @@ async def test_concurrent_get_inventory_has_a_single_owner(hass):
 
     assert len(calls) == 1, "only the owning attempt may send GetBaseReport"
     assert cp._wait_inventory is None
+
+
+@pytest.mark.asyncio
+async def test_failed_attempt_releases_ownership_for_the_next_one(hass):
+    """An escaping request failure must not leave the attempt gate locked.
+
+    The ocpp library's response timeout raises a bare TimeoutError that the
+    inventory handlers don't cover. With an in-flight event now turning other
+    callers away, leaking it set would make every future attempt - including
+    post_connect re-running after the charger's next boot - silently return
+    forever.
+    """
+    cp = _mk_cp(hass)
+    calls: list[int] = []
+
+    async def timeout_then_refuse(req):
+        calls.append(len(calls) + 1)
+        if len(calls) == 1:
+            raise TimeoutError("lib response timeout")
+        raise OCPPError("refused")
+
+    cp.call = timeout_then_refuse
+
+    with pytest.raises(TimeoutError):
+        await cp.get_number_of_connectors()
+
+    assert (
+        cp._wait_inventory is None
+    ), "a failed attempt must release ownership on its way out"
+
+    total = await cp.get_number_of_connectors()
+
+    assert len(calls) == 2, "the next attempt must be able to run"
+    assert total == 1


### PR DESCRIPTION
Follow-up to #2023: this was the fix for CodeRabbit's second-round finding there, but the PR merged while it was being pushed, so it never entered the merge.

## The problem

Before the first `NotifyReport` part creates `_inventory`, two concurrent `_get_inventory()` calls — the boot notification's `post_connect` racing the 10s monitor backstop's — both pass the cached-inventory guard. The second overwrites the owner's `_wait_inventory` event, and once either attempt settles and clears it, the other's accepted `GetBaseReport` response dereferences `None` at `self._wait_inventory.wait()` — an `AttributeError` that aborts its `post_connect`. (The race predates #2023; this closes it.)

## The fix

A second concurrent caller returns without touching the attempt: no second `GetBaseReport`, no event overwrite, and the buffered-status drain stays with the single owner's settle point. The concurrent caller proceeding early is the already-documented double-`post_connect` behaviour — now without a crash path.

Also strengthens the partial-topology regression from #2023 to report two connectors, so its count assertion distinguishes retained partial topology (2) from the one-connector floor (1).

## Testing

New regression: two concurrent `_get_inventory()` calls with a slow accepted request — asserts exactly one `GetBaseReport` goes out and the attempt settles cleanly. Mutation-verified: with the guard removed, the test fails with a second request sent. Full suite and `pre-commit run --all-files` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of simultaneous inventory requests to prevent conflicting updates.
  * Ensured connector information and buffered status notifications are retained correctly during partial inventory responses.
  * Prevented duplicate inventory requests and ensured waiting states are cleared after completion, including when an inventory attempt fails or is cancelled.
  * Ensured subsequent inventory requests can proceed after an unsuccessful attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->