### PR TITLE
Clamp a stored connector count of zero to one

### DIFF
--- a/custom_components/ocpp/button.py
+++ b/custom_components/ocpp/button.py
@@ -71,8 +71,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
         for item in entry.data.get(CONF_CPIDS, []):
             for _, cfg in item.items():
                 if cfg.get(CONF_CPID) == cpid:
-                    num_connectors = int(
-                        cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS)
+                    # Clamp to at least one connector: a stored count of 0
+                    # would make the entity loops below empty, so the charger
+                    # would come up with no connector entities at all and no
+                    # indication why. Config can hold 0 from an integration
+                    # version whose OCPP 2.0.1 inventory handling yielded no
+                    # connectors - post_connect persists whatever it computed.
+                    num_connectors = max(
+                        1, int(cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS))
                     )
                     break
             else:

--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -73,8 +73,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
         for item in entry.data.get(CONF_CPIDS, []):
             for _, cfg in item.items():
                 if cfg.get(CONF_CPID) == cpid:
-                    num_connectors = int(
-                        cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS)
+                    # Clamp to at least one connector: a stored count of 0
+                    # would make the entity loops below empty, so the charger
+                    # would come up with no connector entities at all and no
+                    # indication why. Config can hold 0 from an integration
+                    # version whose OCPP 2.0.1 inventory handling yielded no
+                    # connectors - post_connect persists whatever it computed.
+                    num_connectors = max(
+                        1, int(cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS))
                     )
                     break
             else:

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -56,8 +56,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
         for item in entry.data.get(CONF_CPIDS, []):
             for _, cfg in item.items():
                 if cfg.get(CONF_CPID) == cpid:
-                    num_connectors = int(
-                        cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS)
+                    # Clamp to at least one connector: a stored count of 0
+                    # would make the entity loops below empty, so the charger
+                    # would come up with no connector entities at all and no
+                    # indication why. Config can hold 0 from an integration
+                    # version whose OCPP 2.0.1 inventory handling yielded no
+                    # connectors - post_connect persists whatever it computed.
+                    num_connectors = max(
+                        1, int(cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS))
                     )
                     break
             else:

--- a/custom_components/ocpp/switch.py
+++ b/custom_components/ocpp/switch.py
@@ -107,8 +107,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
         for item in entry.data.get(CONF_CPIDS, []):
             for _, cfg in item.items():
                 if cfg.get(CONF_CPID) == cpid:
-                    num_connectors = int(
-                        cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS)
+                    # Clamp to at least one connector: a stored count of 0
+                    # would make the entity loops below empty, so the charger
+                    # would come up with no connector entities at all and no
+                    # indication why. Config can hold 0 from an integration
+                    # version whose OCPP 2.0.1 inventory handling yielded no
+                    # connectors - post_connect persists whatever it computed.
+                    num_connectors = max(
+                        1, int(cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS))
                     )
                     break
             else:

--- a/tests/test_zero_connector_config.py
+++ b/tests/test_zero_connector_config.py
@@ -48,9 +48,9 @@ async def test_zero_num_connectors_still_creates_connector_entities(
     await create_configuration(hass, config_entry)
     try:
         cpid = cp_cfg[CONF_CPID]
-        assert hass.states.get(f"switch.{cpid}_charge_control") is not None, (
-            "a stored count of 0 must not suppress the charge control switch"
-        )
+        assert (
+            hass.states.get(f"switch.{cpid}_charge_control") is not None
+        ), "a stored count of 0 must not suppress the charge control switch"
         # the other per-connector platforms are built from the same value
         assert hass.states.get(f"number.{cpid}_maximum_current") is not None
         assert hass.states.get(f"button.{cpid}_reset") is not None

--- a/tests/test_zero_connector_config.py
+++ b/tests/test_zero_connector_config.py
@@ -1,0 +1,58 @@
+"""A stored connector count of zero must not erase a charger's entities."""
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ocpp.const import (
+    CONF_CPID,
+    CONF_CPIDS,
+    CONF_CSID,
+    CONF_NUM_CONNECTORS,
+    CONF_PORT,
+    DOMAIN as OCPP_DOMAIN,
+)
+
+from .charge_point_test import create_configuration, remove_configuration
+from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_CP_APPEND
+
+
+@pytest.mark.timeout(90)
+async def test_zero_num_connectors_still_creates_connector_entities(
+    hass, socket_enabled
+):
+    """A charger whose config says 0 connectors must still get its controls.
+
+    post_connect persists whatever get_number_of_connectors() computed, so a
+    version whose OCPP 2.0.1 inventory handling yielded no connectors could
+    store 0. The per-connector entity loops then ran over an empty range and
+    the charger came up with no Charge Control - leaving the integration
+    unable to start a charge, with nothing to indicate why. The stored count
+    is clamped to at least one so this cannot happen however it got there.
+    """
+    cp_cfg = {**MOCK_CONFIG_CP_APPEND, CONF_NUM_CONNECTORS: 0}
+    entry_data = {
+        **MOCK_CONFIG_DATA,
+        CONF_CSID: "test_csid_zero_conn",
+        CONF_PORT: 9021,
+        CONF_CPIDS: [{"CP_zero": cp_cfg}],
+    }
+    config_entry = MockConfigEntry(
+        domain=OCPP_DOMAIN,
+        data=entry_data,
+        entry_id="test_cms_zero_conn",
+        title="test_cms_zero_conn",
+        version=2,
+        minor_version=0,
+    )
+
+    await create_configuration(hass, config_entry)
+    try:
+        cpid = cp_cfg[CONF_CPID]
+        assert hass.states.get(f"switch.{cpid}_charge_control") is not None, (
+            "a stored count of 0 must not suppress the charge control switch"
+        )
+        # the other per-connector platforms are built from the same value
+        assert hass.states.get(f"number.{cpid}_maximum_current") is not None
+        assert hass.states.get(f"button.{cpid}_reset") is not None
+    finally:
+        await remove_configuration(hass, config_entry)


### PR DESCRIPTION
Follow-up to #2023, found while running that fix on real hardware.

## The problem

`post_connect` persists whatever `get_number_of_connectors()` computed into the config entry:

```python
self.num_connectors = await self.get_number_of_connectors()
...
s[CONF_NUM_CONNECTORS] = int(self.num_connectors)
```

Before #2023, an OCPP 2.0.1 charger whose `GetBaseReport` reported no connectors (the FoxESS A-series shape from #2008) made that `0` — and `0` was written to config. The per-connector entity loops in `switch`, `number`, `button` and `sensor` then run `range(1, 0 + 1)`, which is empty, so **the charger comes up with no Charge Control switch at all**. The integration cannot start a charge, and there is nothing in the UI or the log to say why: the entity is simply absent, showing only as a `restored: true` stub from the registry.

Because it is config rather than runtime state, it survives restarts, OCPP version changes and integration updates. It does self-repair on the next `post_connect` that completes — but a charger that never gets that far, one erroring during setup or simply offline, stays silently unusable. The existing migration doesn't help either: it only fills the key in when it is *missing*, not when it is present and zero.

## The fix

Clamp the stored count to at least one where the entities are built:

```diff
-                    num_connectors = int(
-                        cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS)
-                    )
+                    num_connectors = max(
+                        1, int(cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS))
+                    )
```

in the four platforms that build per-connector entities. #2023 stops the bad value being produced; this stops any stored value from erasing a charger's controls, and repairs an already-affected config on the next load rather than making it wait for a clean `post_connect`.

## Testing

`tests/test_zero_connector_config.py` sets up a charger whose config entry says `num_connectors: 0` and asserts the charge control switch, maximum current number and reset button all exist. Mutation-verified: with the clamp removed the test fails with `switch.<cpid>_charge_control` returning `None` — the exact real-world symptom.

Full suite and `pre-commit run --all-files` pass.

## How it was found

A FoxESS A022KP1 that had run OCPP 2.0.1 against a version predating the connector floor. Its config entry held `num_connectors: 0`; the charge control switch was missing entirely and the charger could not be started from Home Assistant. Restarting, rebooting and switching the charger between 1.6 and 2.0.1 all made no difference — the value only cleared when the config entry was corrected directly.

## Note for users recovering from a stored `0`

When the connector entities come back, session sensors regain their units — `Time.Session` goes from unit-less to `min` — so Home Assistant raises a one-time `units_changed` repair against the unit-less statistics recorded during the affected period. Choosing **"Update the unit of the historic statistic values, without converting"** relabels the history and keeps it; the values were always minutes, only the label was missing while the connector slots were uninitialised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where devices configured with zero connectors would not create essential control and monitoring entities. Charge control buttons, current adjustments, sensor readings, and reset functions now properly appear regardless of connector count configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->