### PR TITLE
docs: troubleshooting for a charger with no connector entities

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -93,9 +93,6 @@ Filtering for websockets.server should yield something like this:
 2022-03-16 16:35:40 DEBUG (MainThread) [websockets.server] > TEXT '[3,"5191e2e7-f555-48b3-8b08-626679df5a80",{}]' [45 bytes]
 ```
 
-Troubleshooting
-===============
-
 No Charge Control switch, and the charger cannot be started
 -----------------------------------------------------------
 
@@ -128,41 +125,6 @@ A charger reporting `0` is affected.
 charger connects and completes its setup, so reconnecting the charger is
 usually enough. If the charger cannot complete setup, removing the
 integration and adding it back also clears it.
-
-To repair the stored value directly instead, back it up first, then edit and
-restart Home Assistant Core:
-
-```bash
-cp /config/.storage/core.config_entries /config/core.config_entries.backup
-
-python3 -c "
-import json,pathlib
-p=pathlib.Path('/config/.storage/core.config_entries')
-d=json.loads(p.read_text())
-for e in d['data']['entries']:
-    if e['domain']=='ocpp':
-        for c in e['data'].get('cpids',[]):
-            for k,v in c.items():
-                if v.get('num_connectors')==0:
-                    v['num_connectors']=1
-                    print('fixed',k)
-p.write_text(json.dumps(d))
-"
-
-ha core restart
-```
-
-Use `ha core restart`, not `ha core stop`. The Terminal & SSH add-on runs
-separately from Core, but its *web* terminal is reached through Home Assistant's
-own web interface, so stopping Core leaves you without the terminal you are
-working in. A direct SSH session to the add-on is not affected.
-
-After the restart, run the check command again to confirm the new value was
-kept. Home Assistant holds config entries in memory and rewrites the file
-whenever they change, so an edit made while Core is running can be overwritten.
-If the value has gone back to `0`, stop Core before editing — from a direct SSH
-session to the add-on or the Home Assistant OS console, rather than the web
-terminal — and start it again afterwards.
 
 Once the connector entities are recreated, the session sensors regain their
 units and Home Assistant may raise a one-time `units_changed` repair for

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -152,15 +152,17 @@ p.write_text(json.dumps(d))
 ha core restart
 ```
 
-Use `ha core restart`, not `ha core stop` — the Terminal add-on is served by
-Home Assistant Core, so stopping it also closes the terminal you are working in.
+Use `ha core restart`, not `ha core stop`. The Terminal & SSH add-on runs
+separately from Core, but its *web* terminal is reached through Home Assistant's
+own web interface, so stopping Core leaves you without the terminal you are
+working in. A direct SSH session to the add-on is not affected.
 
 After the restart, run the check command again to confirm the new value was
 kept. Home Assistant holds config entries in memory and rewrites the file
 whenever they change, so an edit made while Core is running can be overwritten.
-If the value has gone back to `0`, stop Core before editing — from a terminal
-that does not depend on it, such as the Home Assistant OS console — and start it
-again afterwards.
+If the value has gone back to `0`, stop Core before editing — from a direct SSH
+session to the add-on or the Home Assistant OS console, rather than the web
+terminal — and start it again afterwards.
 
 Once the connector entities are recreated, the session sensors regain their
 units and Home Assistant may raise a one-time `units_changed` repair for

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -104,8 +104,11 @@ No Charge Control switch, and the charger cannot be started
 Home Assistant. In *Developer tools / States* the entity either does not appear
 at all, or appears as `unavailable` with a `restored: true` attribute (meaning
 it is a leftover registry entry that the integration is not creating). There is
-no error in the log, and restarting Home Assistant, reloading the integration or
-switching the charger between OCPP 1.6 and 2.0.1 makes no difference.
+no error in the log. If the charger cannot complete its connection setup —
+because it is offline, or failing partway through setup — then restarting Home
+Assistant, reloading the integration and switching the charger between OCPP 1.6
+and 2.0.1 all appear to change nothing, because the count is stored in the
+config entry rather than held in runtime state.
 
 **Cause:** the connector count stored in the config entry is `0`. The
 per-connector entities are created from that number, so a stored `0` creates
@@ -115,7 +118,7 @@ the value is written into the config entry it survives restarts and updates.
 
 **Check it** — in the *Terminal* add-on:
 
-```
+```bash
 python3 -c "import json;d=json.load(open('/config/.storage/core.config_entries'));[print(k,v.get('num_connectors')) for e in d['data']['entries'] if e['domain']=='ocpp' for c in e['data'].get('cpids',[]) for k,v in c.items()]"
 ```
 
@@ -129,7 +132,7 @@ integration and adding it back also clears it.
 To repair the stored value directly instead, back it up first, then edit and
 restart Home Assistant Core:
 
-```
+```bash
 cp /config/.storage/core.config_entries /config/core.config_entries.backup
 
 python3 -c "
@@ -151,6 +154,13 @@ ha core restart
 
 Use `ha core restart`, not `ha core stop` — the Terminal add-on is served by
 Home Assistant Core, so stopping it also closes the terminal you are working in.
+
+After the restart, run the check command again to confirm the new value was
+kept. Home Assistant holds config entries in memory and rewrites the file
+whenever they change, so an edit made while Core is running can be overwritten.
+If the value has gone back to `0`, stop Core before editing — from a terminal
+that does not depend on it, such as the Home Assistant OS console — and start it
+again afterwards.
 
 Once the connector entities are recreated, the session sensors regain their
 units and Home Assistant may raise a one-time `units_changed` repair for

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -92,3 +92,69 @@ Filtering for websockets.server should yield something like this:
 2022-03-16 16:35:40 DEBUG (MainThread) [websockets.server] < TEXT '[2,"5191e2e7-f555-48b3-8b08-626679df5a80","Mete... 0,"transactionId": 0}]' [304 bytes]
 2022-03-16 16:35:40 DEBUG (MainThread) [websockets.server] > TEXT '[3,"5191e2e7-f555-48b3-8b08-626679df5a80",{}]' [45 bytes]
 ```
+
+Troubleshooting
+===============
+
+No Charge Control switch, and the charger cannot be started
+-----------------------------------------------------------
+
+**Symptom:** the charger's connector entities are missing — most visibly
+`switch.<cpid>_charge_control`, so charging cannot be started or stopped from
+Home Assistant. In *Developer tools / States* the entity either does not appear
+at all, or appears as `unavailable` with a `restored: true` attribute (meaning
+it is a leftover registry entry that the integration is not creating). There is
+no error in the log, and restarting Home Assistant, reloading the integration or
+switching the charger between OCPP 1.6 and 2.0.1 makes no difference.
+
+**Cause:** the connector count stored in the config entry is `0`. The
+per-connector entities are created from that number, so a stored `0` creates
+none of them. Chargers whose OCPP 2.0.1 `GetBaseReport` inventory reports no
+`Connector` components could produce a `0` on earlier versions, and because
+the value is written into the config entry it survives restarts and updates.
+
+**Check it** — in the *Terminal* add-on:
+
+```
+python3 -c "import json;d=json.load(open('/config/.storage/core.config_entries'));[print(k,v.get('num_connectors')) for e in d['data']['entries'] if e['domain']=='ocpp' for c in e['data'].get('cpids',[]) for k,v in c.items()]"
+```
+
+A charger reporting `0` is affected.
+
+**Fix it.** Current versions correct the value automatically the next time a
+charger connects and completes its setup, so reconnecting the charger is
+usually enough. If the charger cannot complete setup, removing the
+integration and adding it back also clears it.
+
+To repair the stored value directly instead, back it up first, then edit and
+restart Home Assistant Core:
+
+```
+cp /config/.storage/core.config_entries /config/core.config_entries.backup
+
+python3 -c "
+import json,pathlib
+p=pathlib.Path('/config/.storage/core.config_entries')
+d=json.loads(p.read_text())
+for e in d['data']['entries']:
+    if e['domain']=='ocpp':
+        for c in e['data'].get('cpids',[]):
+            for k,v in c.items():
+                if v.get('num_connectors')==0:
+                    v['num_connectors']=1
+                    print('fixed',k)
+p.write_text(json.dumps(d))
+"
+
+ha core restart
+```
+
+Use `ha core restart`, not `ha core stop` — the Terminal add-on is served by
+Home Assistant Core, so stopping it also closes the terminal you are working in.
+
+Once the connector entities are recreated, the session sensors regain their
+units and Home Assistant may raise a one-time `units_changed` repair for
+`sensor.<cpid>_time_session`. Choose **"Update the unit of the historic
+statistic values, without converting"** to keep the existing history: the values
+were always minutes, only the unit label was missing while the connector slots
+were uninitialised.


### PR DESCRIPTION
Follows #2025 — you preferred to address this in readthedocs rather than code, so here it is as docs.

Adds a Troubleshooting section to `docs/debugging.md` for a charger left with no connector entities because the stored connector count is `0`: no Charge Control switch, so charging can't be started or stopped from Home Assistant.

The reason it's worth documenting is that the user gets nothing to go on. The entity is simply absent (or a `restored: true` registry stub), there's no error in the log, and restarting, reloading and switching OCPP versions all appear to do nothing — because the value is in the config entry, not runtime state. I only found it by reading `.storage`.

The section covers the symptom, the cause, a one-liner to check the stored value, and the fixes — reconnecting the charger and re-adding the integration first, since #2023 means a completed `post_connect` now rewrites the value, with a direct repair of the stored value as a fallback for a charger that can't complete setup. It also notes the one-time `units_changed` repair that appears once the connector entities return, and which option keeps the existing history.

Docs only, no code changes. `debugging` is already in the `index.rst` toctree so no index change was needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for missing charger control entities when the stored connector count is zero.
  * Documented symptoms, diagnostic commands, and automatic recovery options.
  * Added reinstallation steps for cases where automatic recovery is unsuccessful.
  * Clarified the expected session-sensor unit repair after charger entities are recreated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->