### PR TITLE
Fix duplicate cpid validation in charge point config flow

### DIFF
--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -196,6 +196,26 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
         return await self.async_step_cp_user()
 
+    def _other_cpids_in_use(self) -> set[str]:
+        """Return every cpid already configured for a charge point other than the current one.
+
+        cpid (as opposed to cp_id, the OCPP-level charge point identity) is
+        user-chosen and is what entities' unique_id is built from
+        (DOMAIN.cpid.key...), so it must stay unique across every charge
+        point of every OCPP config entry, not just within the current
+        central system. The charge point currently being (re)configured
+        (self._cp_id) is excluded so re-submitting its own cpid is not
+        flagged as a duplicate of itself.
+        """
+        cpids: set[str] = set()
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            for cp_data in entry.data.get(CONF_CPIDS, []):
+                for cp_id, cp_settings in cp_data.items():
+                    if cp_id == self._cp_id:
+                        continue
+                    cpids.add(cp_settings[CONF_CPID])
+        return cpids
+
     async def async_step_cp_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -203,8 +223,6 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # Don't allow duplicate cpids to be used
-            self._async_abort_entries_match({CONF_CPID: user_input[CONF_CPID]})
             # Validate cpid format against entity id requirements (lowercase letters, digits and _)
             schema = vol.Schema(
                 {vol.Required(CONF_CPID): cv.matches_regex(r"^[\da-z_]+$")}
@@ -214,6 +232,13 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             except vol.Invalid:
                 errors["base"] = "invalid_cpid"
             else:
+                # cpid is used to build entity unique_ids (DOMAIN.cpid.key...)
+                # across every OCPP config entry, so it must be unique
+                # integration-wide, not just within this central system.
+                if user_input[CONF_CPID] in self._other_cpids_in_use():
+                    errors["base"] = "duplicate_cpid"
+
+            if not errors:
                 cp_data = {
                     **user_input,
                     CONF_NUM_CONNECTORS: self._detected_num_connectors,

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -203,15 +203,20 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         user-chosen and is what entities' unique_id is built from
         (DOMAIN.cpid.key...), so it must stay unique across every charge
         point of every OCPP config entry, not just within the current
-        central system. The charge point currently being (re)configured
-        (self._cp_id) is excluded so re-submitting its own cpid is not
-        flagged as a duplicate of itself.
+        central system. Only the charge point currently being (re)configured
+        -- matched on both its entry and its cp_id -- is excluded, so
+        re-submitting its own cpid is not flagged as a duplicate of itself.
         """
+        # Match on the entry as well as the charge point: cp_id is the
+        # OCPP-level identity, so two central systems can each have one with
+        # the same name. Skipping on cp_id alone would also skip the *other*
+        # system's record and let a genuine duplicate through.
+        own_entry_id = getattr(getattr(self, "_entry", None), "entry_id", None)
         cpids: set[str] = set()
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             for cp_data in entry.data.get(CONF_CPIDS, []):
                 for cp_id, cp_settings in cp_data.items():
-                    if cp_id == self._cp_id:
+                    if entry.entry_id == own_entry_id and cp_id == self._cp_id:
                         continue
                     cpids.add(cp_settings[CONF_CPID])
         return cpids
@@ -284,6 +289,20 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._data[CONF_CPIDS][-1][self._cp_id][CONF_MONITORED_VARIABLES] = (
                     self._measurands
                 )
+
+                # With autoconfig off, the cpid was validated a step earlier and
+                # nothing has been written yet, so another flow could have taken
+                # it in the meantime. Re-check immediately before persisting:
+                # there is no await between this and async_update_entry, so on
+                # the single-threaded event loop nothing can slip in between.
+                pending_cpid = self._data[CONF_CPIDS][-1][self._cp_id][CONF_CPID]
+                if pending_cpid in self._other_cpids_in_use():
+                    errors["base"] = "duplicate_cpid"
+                    return self.async_show_form(
+                        step_id="measurands",
+                        data_schema=STEP_USER_MEASURANDS_SCHEMA,
+                        errors=errors,
+                    )
 
                 self.hass.config_entries.async_update_entry(
                     self._entry, data=self._data

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -86,7 +86,8 @@
         "error": {
             "auth": "Username/Password is wrong.",
             "no_measurands_selected": "No measurand selected: please select at least one",
-            "invalid_cpid": "Invalid charge point identity name: use only lower case letters, digits and _"
+            "invalid_cpid": "Invalid charge point identity name: use only lower case letters, digits and _",
+            "duplicate_cpid": "This charge point identity is already used by another charge point. Choose a unique one."
         },
         "abort": {
             "single_instance_allowed": "Only a single instance is allowed",

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -86,7 +86,8 @@
         "error": {
             "auth": "Username/Password is wrong.",
             "no_measurands_selected": "No measurand selected: please select at least one",
-            "invalid_cpid": "Invalid charge point identity name: use only lower case letters, digits and _"
+            "invalid_cpid": "Invalid charge point identity name: use only lower case letters, digits and _",
+            "duplicate_cpid": "This charge point identity is already used by another charge point. Choose a unique one."
         },
         "abort": {
             "single_instance_allowed": "Only a single instance is allowed",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     MOCK_CONFIG_CS,
     MOCK_CONFIG_CP,
     MOCK_CONFIG_FLOW,
+    CONF_CPID,
     CONF_CPIDS,
     CONF_MONITORED_VARIABLES_AUTOCONFIG,
     DEFAULT_MONITORED_VARIABLES,
@@ -140,7 +141,10 @@ async def test_successful_discovery_flow(hass, bypass_get_data):
     assert result2_disc["step_id"] == "cp_user"
     result2_disc["discovery_info"] = info2
 
+    # Use a different cpid too: cpid (not cp_id) is what entity unique_ids
+    # are built from, so two charge points sharing one would collide.
     cp2_input = MOCK_CONFIG_CP.copy()
+    cp2_input[CONF_CPID] = "test_cpid_2"
     result_cp2 = await hass.config_entries.flow.async_configure(
         result2_disc["flow_id"], user_input=cp2_input
     )
@@ -186,6 +190,184 @@ async def test_duplicate_cpid_discovery_flow(hass, bypass_get_data):
     )
     assert result2["type"] == data_entry_flow.FlowResultType.ABORT
     assert result2["reason"] == "already_in_progress"
+
+
+async def test_duplicate_cpid_value_rejected(hass, bypass_get_data):
+    """Reject a second, different charge point that reuses an already-used cpid.
+
+    cp_id (the OCPP websocket identity) and cpid (the user-chosen name used
+    to build entity unique_ids) are different things. Two distinct chargers
+    (distinct cp_id) must not be allowed to share the same cpid, otherwise
+    their entities collide on unique_id.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_CS,
+        entry_id="test_cms_dup_cpid",
+        title="test_cms_dup_cpid",
+        version=2,
+    )
+    if hass.data.get(DOMAIN) is None:
+        hass.data.setdefault(DOMAIN, {})
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    entry = hass.config_entries._entries.get_entries_for_domain(DOMAIN)[0]
+
+    # First charge point (cp_id "cp_a") configures cpid "shared_cpid".
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_a", "entry": entry},
+    )
+    cp1_input = MOCK_CONFIG_CP.copy()
+    cp1_input[CONF_CPID] = "shared_cpid"
+    result1 = await hass.config_entries.flow.async_configure(
+        result1["flow_id"], user_input=cp1_input
+    )
+    assert result1["type"] == data_entry_flow.FlowResultType.ABORT
+    assert len(entry.data[CONF_CPIDS]) == 1
+
+    # Second, different charge point (cp_id "cp_b") tries to reuse "shared_cpid".
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_b", "entry": entry},
+    )
+    cp2_input = MOCK_CONFIG_CP.copy()
+    cp2_input[CONF_CPID] = "shared_cpid"
+    result2 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], user_input=cp2_input
+    )
+
+    # Rejected with a form error, not silently accepted.
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["step_id"] == "cp_user"
+    assert result2["errors"]["base"] == "duplicate_cpid"
+    # No second charge point was added to this entry.
+    assert len(entry.data[CONF_CPIDS]) == 1
+
+    # Retrying with a genuinely unique cpid succeeds.
+    cp2_input[CONF_CPID] = "cp_b_cpid"
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], user_input=cp2_input
+    )
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
+    assert len(entry.data[CONF_CPIDS]) == 2
+
+
+async def test_duplicate_cpid_value_rejected_across_entries(hass, bypass_get_data):
+    """A cpid must be unique across every OCPP config entry (central system).
+
+    Entity unique_id is built from DOMAIN + cpid only, with no per-entry
+    scoping, so a second central system reusing a cpid already used by a
+    charge point on a different central system would also collide.
+    """
+    entry_a = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_CS, "port": 9101},
+        entry_id="test_cms_dup_cpid_a",
+        title="test_cms_dup_cpid_a",
+        version=2,
+    )
+    entry_b_data = {**MOCK_CONFIG_CS, "port": 9102}
+    from custom_components.ocpp.const import CONF_CSID
+
+    entry_b_data[CONF_CSID] = "test_csid_flow_b"
+    entry_b = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_b_data,
+        entry_id="test_cms_dup_cpid_b",
+        title="test_cms_dup_cpid_b",
+        version=2,
+    )
+    if hass.data.get(DOMAIN) is None:
+        hass.data.setdefault(DOMAIN, {})
+    entry_a.add_to_hass(hass)
+    entry_b.add_to_hass(hass)
+    # Setting up the first entry also brings up the "ocpp" component, which
+    # in turn loads every other already-registered entry of that domain
+    # (entry_b included), so a second explicit async_setup call for entry_b
+    # would find it already loaded.
+    assert await hass.config_entries.async_setup(entry_a.entry_id)
+    await hass.async_block_till_done()
+    assert entry_a.state is config_entries.ConfigEntryState.LOADED
+    assert entry_b.state is config_entries.ConfigEntryState.LOADED
+
+    # Charge point on central system A takes "shared_cpid".
+    result_a = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_on_a", "entry": entry_a},
+    )
+    cp_a_input = MOCK_CONFIG_CP.copy()
+    cp_a_input[CONF_CPID] = "shared_cpid"
+    result_a = await hass.config_entries.flow.async_configure(
+        result_a["flow_id"], user_input=cp_a_input
+    )
+    assert result_a["type"] == data_entry_flow.FlowResultType.ABORT
+
+    # A charge point on the unrelated central system B tries to reuse it.
+    result_b = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_on_b", "entry": entry_b},
+    )
+    cp_b_input = MOCK_CONFIG_CP.copy()
+    cp_b_input[CONF_CPID] = "shared_cpid"
+    result_b = await hass.config_entries.flow.async_configure(
+        result_b["flow_id"], user_input=cp_b_input
+    )
+
+    assert result_b["type"] == data_entry_flow.FlowResultType.FORM
+    assert result_b["errors"]["base"] == "duplicate_cpid"
+
+
+async def test_reconfigure_own_cpid_not_flagged_duplicate(hass, bypass_get_data):
+    """Resubmitting a charge point's own cpid must not be flagged as a duplicate.
+
+    The duplicate check excludes the cp_id currently being configured, so a
+    charge point being (re)configured is never compared against itself.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_CS,
+        entry_id="test_cms_self_cpid",
+        title="test_cms_self_cpid",
+        version=2,
+    )
+    if hass.data.get(DOMAIN) is None:
+        hass.data.setdefault(DOMAIN, {})
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    entry = hass.config_entries._entries.get_entries_for_domain(DOMAIN)[0]
+
+    # Configure the charge point once.
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_self", "entry": entry},
+    )
+    cp_input = MOCK_CONFIG_CP.copy()
+    cp_input[CONF_CPID] = "self_cpid"
+    result1 = await hass.config_entries.flow.async_configure(
+        result1["flow_id"], user_input=cp_input
+    )
+    assert result1["type"] == data_entry_flow.FlowResultType.ABORT
+
+    # Run the cp_user step again for the same cp_id, submitting the same
+    # cpid it already owns. It must not be treated as a duplicate of itself.
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_self", "entry": entry},
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], user_input=cp_input
+    )
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert "errors" not in result2 or not result2.get("errors")
 
 
 async def test_failed_config_flow(hass, error_on_get_data):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -323,6 +323,124 @@ async def test_duplicate_cpid_value_rejected_across_entries(hass, bypass_get_dat
     assert result_b["errors"]["base"] == "duplicate_cpid"
 
 
+async def test_duplicate_cpid_rejected_when_cp_id_matches_on_another_entry(
+    hass, bypass_get_data
+):
+    """Two central systems can each have a charge point with the same cp_id.
+
+    cp_id is the OCPP-level identity, chosen by the charger, so it is not
+    unique across central systems. Excluding a record on cp_id alone would
+    also exclude the *other* system's charge point and let its cpid be reused.
+    """
+    from custom_components.ocpp.const import CONF_CSID
+
+    entry_a = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_CS, "port": 9111},
+        entry_id="test_cms_same_cpid_a",
+        title="test_cms_same_cpid_a",
+        version=2,
+    )
+    entry_b_data = {**MOCK_CONFIG_CS, "port": 9112}
+    entry_b_data[CONF_CSID] = "test_csid_same_cp_id_b"
+    entry_b = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_b_data,
+        entry_id="test_cms_same_cpid_b",
+        title="test_cms_same_cpid_b",
+        version=2,
+    )
+    if hass.data.get(DOMAIN) is None:
+        hass.data.setdefault(DOMAIN, {})
+    entry_a.add_to_hass(hass)
+    entry_b.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry_a.entry_id)
+    await hass.async_block_till_done()
+
+    # Both chargers announce themselves with the *same* cp_id.
+    compartido = "charger"
+
+    result_a = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": compartido, "entry": entry_a},
+    )
+    cp_a_input = MOCK_CONFIG_CP.copy()
+    cp_a_input[CONF_CPID] = "taken_cpid"
+    result_a = await hass.config_entries.flow.async_configure(
+        result_a["flow_id"], user_input=cp_a_input
+    )
+    assert result_a["type"] == data_entry_flow.FlowResultType.ABORT
+
+    # The one on B shares the cp_id but is a different charge point, so it
+    # must not be able to take the cpid already in use on A.
+    result_b = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": compartido, "entry": entry_b},
+    )
+    cp_b_input = MOCK_CONFIG_CP.copy()
+    cp_b_input[CONF_CPID] = "taken_cpid"
+    result_b = await hass.config_entries.flow.async_configure(
+        result_b["flow_id"], user_input=cp_b_input
+    )
+
+    assert result_b["type"] == data_entry_flow.FlowResultType.FORM
+    assert result_b["errors"]["base"] == "duplicate_cpid"
+
+
+async def test_duplicate_cpid_caught_at_measurands_step(hass, bypass_get_data):
+    """With autoconfig off the cpid is validated a step before it is written.
+
+    Another flow can take it in between, so the check is repeated immediately
+    before persisting. Simulated here by writing the colliding cpid into the
+    entry after the first validation has already passed.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_CS, "port": 9121},
+        entry_id="test_cms_measurands_race",
+        title="test_cms_measurands_race",
+        version=2,
+    )
+    if hass.data.get(DOMAIN) is None:
+        hass.data.setdefault(DOMAIN, {})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={"cp_id": "cp_race", "entry": entry},
+    )
+    cp_input = MOCK_CONFIG_CP.copy()
+    cp_input[CONF_CPID] = "raced_cpid"
+    cp_input[CONF_MONITORED_VARIABLES_AUTOCONFIG] = False
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=cp_input
+    )
+    assert result["step_id"] == "measurands"
+
+    # Someone else persists the same cpid while this flow sits on the
+    # measurands form.
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_CPIDS: [{"other_cp": {CONF_CPID: "raced_cpid"}}],
+        },
+    )
+
+    measurands = dict.fromkeys(DEFAULT_MONITORED_VARIABLES.split(","), True)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=measurands
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["errors"]["base"] == "duplicate_cpid"
+
+
 async def test_reconfigure_own_cpid_not_flagged_duplicate(hass, bypass_get_data):
     """Resubmitting a charge point's own cpid must not be flagged as a duplicate.
 


### PR DESCRIPTION
## Symptom

After adding a second charge point, HA logs a burst of ~36 errors like:

```
Platform ocpp does not generate unique IDs. ID ocpp.charger.power.active.import.sensor already exists - ignoring sensor.charger_power_active_import
```

repeated across sensor/switch/number/button, and the second charger's entities are silently dropped or corrupt the first charger's entities. Reported in #1991 and #1884; #1658 hit the same symptom and was closed by the stale bot without a fix.

## Root cause

`custom_components/ocpp/config_flow.py`, `async_step_cp_user` (around line 207 pre-fix):

```python
if user_input is not None:
    # Don't allow duplicate cpids to be used
    self._async_abort_entries_match({CONF_CPID: user_input[CONF_CPID]})
```

`_async_abort_entries_match` compares against each config entry's **top-level** `data`. But `cpid` never lives at that level — it's nested inside `entry.data[CONF_CPIDS] = [{cp_id: {"cpid": "...", ...}}, ...]` (see `__init__.py` around line 118-127, and where `cp_user` itself builds this structure a few lines below the check, around line 217-223).

So the match dict `{CONF_CPID: "some_cpid"}` is checked against a key that never exists at the top level of `entry.data` — the check can never find a hit. **It's a no-op.** Two different charge points (different `cp_id`, the OCPP-level websocket identity) can be configured with the same `cpid` (the user-chosen friendly name), with nothing to stop it.

That matters because `cpid` — not `cp_id` — is what entity `unique_id`s are built from, integration-wide, with no per-config-entry scoping:

```python
parts = [DOMAIN, self.cpid, self.entity_description.key, SENSOR_DOMAIN]
```

(`sensor.py`; same pattern in `switch.py`, `number.py`, `button.py`). Duplicate `cpid` → duplicate `unique_id` → HA drops the second charger's entities.

`#1886` (merged) added *format* validation for cpid (regex for lowercase/digits/`_`), not *uniqueness*. That gap is still open — confirmed no other open PR addresses it as of writing.

## Fix

Replaced the no-op `_async_abort_entries_match` call with a real uniqueness check, `_other_cpids_in_use()`, that:
- walks every OCPP config entry's `CONF_CPIDS` (not just the current central system's — `unique_id` isn't scoped per entry, so two charge points on two different central systems can't share a cpid either),
- excludes the charge point currently being (re)configured (`self._cp_id`), so resubmitting its own cpid isn't flagged as a duplicate of itself,
- and on a hit, shows a form error `duplicate_cpid` instead of silently proceeding — following the same pattern `#1886` used for `invalid_cpid` (added the string to `translations/en.json` and `translations/i-default.json`, English only).

## Why this is low risk for existing installations

This only changes the **new charge point** step of the config flow (`async_step_cp_user`), which runs when a not-yet-configured `cp_id` connects (see `api.py::on_connect`, which only triggers discovery when `cp_id not in self.settings.cpids`). It does **not**:
- change how `unique_id` is computed for any existing entity,
- migrate or touch any stored config entry data,
- affect chargers that are already configured.

It's strictly tightening input validation on setup of a brand-new charge point — not the "add unique_id to a platform that didn't have one" case that would actually duplicate entities in production.

## What I validated

- Confirmed via `gh pr list`/`gh issue view` that no open PR currently covers #1991 or #1884, and #1658 is closed unresolved by the stale bot.
- Read `__init__.py`, `api.py`, `sensor.py`/`switch.py`/`number.py`/`button.py` to confirm the `unique_id` construction and the `on_connect` discovery-trigger condition described above.
- Added tests to `tests/test_config_flow.py`:
  - `test_duplicate_cpid_value_rejected`: two different charge points (different `cp_id`) reusing the same `cpid` is rejected with `errors["base"] == "duplicate_cpid"`; a genuinely unique `cpid` on retry succeeds.
  - `test_duplicate_cpid_value_rejected_across_entries`: the same rejection holds across two different central-system config entries.
  - `test_reconfigure_own_cpid_not_flagged_duplicate`: resubmitting a charge point's own cpid for its own `cp_id` is not flagged as a duplicate of itself.
  - Fixed `test_successful_discovery_flow`, which was unknowingly relying on the bug — its "different CP IDs are allowed" second charge point reused the *same* `cpid` as the first and asserted success. Gave it a distinct cpid, which is the behavior that should actually be required.
- Ran the full suite (`pytest tests`, 172 tests) before and after: all passing both times, confirming the fix doesn't regress anything else.
- Ran `pre-commit run --all-files` (pyupgrade, ruff, ruff-format): passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate charge-point identities across configuration entries.
  * Rechecked identity uniqueness before saving configuration to prevent setup conflicts.
  * Allowed an existing charge point to resubmit its own identity without triggering a conflict.
  * Preserved existing identity format validation.
  * Added localized messages for invalid and duplicate identities.

* **Tests**
  * Expanded coverage for duplicate validation within and across entries, including setup-time race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->