### PR TITLE
Honour force_smart_charging on OCPP 2.0.1

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -424,6 +424,14 @@ class ChargePoint(cp):
         if self._inventory and self._inventory.local_auth_available:
             features |= Profiles.AUTH
 
+        # Mirrors the OCPP 1.6 path. SmartChargingCtrlr/Available is optional
+        # in OCPP 2.0.1, so a charger can implement smart charging and still
+        # not advertise it, leaving the profile off. This override lets the
+        # user restore it, and is the only escape hatch when detection fails.
+        if self.settings.force_smart_charging:
+            _LOGGER.warning("Force Smart Charging feature profile")
+            features |= Profiles.SMART
+
         fw_req = call.UpdateFirmware(
             1,
             {

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1287,9 +1287,13 @@ async def _unsupported_base_report_test(
         )
     )
     await wait_ready(cs.charge_points[cp_id])
+    # This charger answers no GetBaseReport, so nothing is detectable from an
+    # inventory and SMART can only come from force_smart_charging, which the
+    # test charger enables (tests/const.py). Before the override was honoured
+    # on 2.0.1 this expectation omitted SMART.
     assert (
         cs.get_metric(cpid, cdet.features.value, connector_id=0)
-        == Profiles.CORE | Profiles.REM | Profiles.FW
+        == Profiles.CORE | Profiles.REM | Profiles.FW | Profiles.SMART
     )
 
     # Regression: a charger whose GetBaseReport yields no connectors (either

--- a/tests/test_v201_force_smart_charging.py
+++ b/tests/test_v201_force_smart_charging.py
@@ -1,0 +1,144 @@
+"""The force_smart_charging override on OCPP 2.0.1.
+
+SmartChargingCtrlr/Available is optional in OCPP 2.0.1, so a charger can
+implement smart charging and still not advertise it - the FoxESS A-series
+reports ProfileStackLevel, RateUnit and PeriodsPerSchedule but no Available -
+and the SMART profile is then dropped. The override existed only in the OCPP
+1.6 path, so on 2.0.1 it silently did nothing and there was no way to restore
+the profile.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from ocpp.exceptions import OCPPError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import Profiles
+from custom_components.ocpp.ocppv201 import ChargePoint, InventoryReport
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _mk_cp(hass, force_smart_charging: bool):
+    """Build a v201 ChargePoint detached from any real connection."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=force_smart_charging,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    # A charger that does not advertise SmartChargingCtrlr/Available. Seeding
+    # the inventory also short-circuits _get_inventory, so the only calls made
+    # are the UpdateFirmware and TriggerMessage capability probes.
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    async def refuse_probes(req):
+        raise OCPPError("not supported")
+
+    cp.call = refuse_probes
+    return cp
+
+
+@pytest.mark.asyncio
+async def test_force_smart_charging_restores_the_profile(hass):
+    """The override must apply on 2.0.1, as it already does on 1.6."""
+    cp = _mk_cp(hass, force_smart_charging=True)
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+
+
+@pytest.mark.asyncio
+async def test_smart_profile_absent_without_the_override(hass):
+    """Control: the same charger yields no SMART when the override is off.
+
+    Without this the test above would pass even if the override were ignored
+    and SMART came from somewhere else.
+    """
+    cp = _mk_cp(hass, force_smart_charging=False)
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART not in features
+
+
+@pytest.mark.asyncio
+async def test_override_does_not_invent_other_profiles(hass):
+    """Forcing SMART must not imply reservation or local auth support."""
+    cp = _mk_cp(hass, force_smart_charging=True)
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.RES not in features
+    assert Profiles.AUTH not in features
+
+
+@pytest.mark.asyncio
+async def test_detection_still_observable_with_the_override_off(hass):
+    """SMART must still be reachable by detection alone, via the real parser.
+
+    Every charger config in tests/const.py sets force_smart_charging, so now
+    that the override is honoured on 2.0.1 the integration-level feature
+    assertions in test_charge_point_v201.py are satisfied whether detection
+    works or not. This drives the actual NotifyReport parser with the
+    override off, so a regression in the SmartChargingCtrlr/Available
+    handling fails here rather than passing unnoticed.
+    """
+    cp = _mk_cp(hass, force_smart_charging=False)
+    cp._inventory = None
+    cp._wait_inventory = asyncio.Event()
+
+    cp.on_report(
+        1,
+        "2026-01-01T00:00:00Z",
+        0,
+        report_data=[
+            {
+                "component": {"name": "SmartChargingCtrlr"},
+                "variable": {"name": "Available"},
+                "variable_attribute": [{"value": "true"}],
+            }
+        ],
+    )
+
+    assert cp._inventory.smart_charging_available is True
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features


### PR DESCRIPTION
Fixes #2036.

`SmartChargingCtrlr/Available` is optional in OCPP 2.0.1, so a charger can implement smart charging and still not advertise it — the profile is then dropped, and without `SMART` the maximum current number entity is unavailable.

`force_smart_charging` exists precisely to override feature detection, but it was only implemented in the 1.6 path (`ocppv16.py` L302-304), so on 2.0.1 it silently did nothing — in the one place it is most needed. This mirrors it in `ocppv201.py:get_supported_features()`.

## Please note: a changed expectation in an existing test

`_unsupported_base_report_test` asserted `CORE|REM|FW`, but the test charger sets `CONF_FORCE_SMART_CHARGING: True` (`tests/const.py`) and answers no `GetBaseReport` at all. That expectation was encoding the old behaviour — override on, `SMART` absent. It now includes `SMART`, since for that charger the override is the only possible source. Flagging it up front so the changed assertion doesn't read as a regression.

## Tests

New `tests/test_v201_force_smart_charging.py`:

- the override restores `SMART` on a charger that does not advertise `Available`
- **control**: the same charger yields no `SMART` with the override off — without this, the first test would pass even if the override were ignored
- forcing `SMART` does not imply `RES` or `AUTH`
- detection remains observable: drives the real `on_report` parser with the override **off**, so a regression in the `SmartChargingCtrlr/Available` handling still fails

That last one is deliberate. Every charger config in `tests/const.py` sets `force_smart_charging`, so once the override is honoured the integration-level feature assertions are satisfied whether detection works or not. Driving the parser directly keeps that signal.

Mutation-checked: removing the production block fails `test_force_smart_charging_restores_the_profile`; breaking `smart_charging_available` in the parser fails `test_detection_still_observable_with_the_override_off`.

Full suite passes (173) and `pre-commit run --all-files` is clean.

## Two pre-existing issues found while working on this — not changed here

Raising them explicitly rather than leaving them implied. Happy to take either on separately if you'd like them fixed.

1. **Feature detection is lost entirely on a probe timeout.** The `UpdateFirmware` and `TriggerMessage` capability probes in `get_supported_features()` catch only `OCPPError`, but the ocpp library raises `asyncio.TimeoutError` when a charger simply never answers (`ocpp/charge_point.py`, 10s per `chargepoint.py` L239). That escapes `fetch_supported_features()` before it assigns, and `post_connect` swallows it at DEBUG — so features stay `NONE`. It affects all v201 detection, not just this override, which is why I have not folded it into this PR.

2. **`set_charge_rate` returns `None` on success on 2.0.1** (bare `return`), while the 1.6 path returns `True`. `number.py` treats a falsy return as rejection, so every successful current set logs `"Set current limit rejected by CP"`. Already reachable for chargers that advertise `Available`; this PR routes more users past it.

## Reported by

Found on a FoxESS A022KP1 (firmware `1.10,1.06`) via a controlled 1.6 → 2.0.1 → 1.6 switch: `CORE|FW|SMART|RES|REM|AUTH` on 1.6 versus `CORE|FW|REM|AUTH` on 2.0.1, with the charger reporting `SmartChargingCtrlr/ProfileStackLevel`, `RateUnit` and `PeriodsPerSchedule` but no `Available`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OCPP 2.0.1 installations can now explicitly enable Smart Charging support when the corresponding configuration option is enabled.
  - Smart Charging is detected and advertised accurately through capability reports.

- **Bug Fixes**
  - Improved handling of unsupported capability reports while preserving the correct standard profiles.
  - Prevented unrelated charging profiles from being incorrectly enabled when Smart Charging is forced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->