### PR TITLE
Do not clear or narrow TxUpdatedMeasurands on OCPP 2.0.1

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -72,6 +72,13 @@ class InventoryReport:
     reservation_available: bool = False
     local_auth_available: bool = False
     tx_updated_measurands: list[MeasurandEnumType] = field(default_factory=list)
+    # Precedence of the resolved list, so a later report entry cannot
+    # silently narrow a better-scoped one:
+    #   2 = advertised valuesList, charging-station level - authoritative
+    #   1 = advertised valuesList, EVSE-scoped - may be narrower than the
+    #       station, so it is reported but never written back
+    #   0 = derived from the current value, or entries were dropped
+    tx_updated_measurands_rank: int = 0
 
 
 class ChargePoint(cp):
@@ -400,6 +407,32 @@ class ChargePoint(cp):
             measurands: str = ",".join(
                 measurand.value for measurand in self._inventory.tx_updated_measurands
             )
+            if not measurands:
+                # Nothing to go on. Writing an empty list would clear whatever
+                # the charger is configured to report, disabling every meter
+                # value inside TransactionEvent, and it persists on the
+                # charger. Return the configured value unchanged so the config
+                # entry is not overwritten either - post_connect stores this
+                # result in monitored_variables and reloads the entry when it
+                # differs, and sensor.py builds no measurand sensors from "".
+                _LOGGER.warning(
+                    "No measurands could be resolved for '%s'; leaving the "
+                    "charger and the configured measurands untouched",
+                    self.id,
+                )
+                return self.settings.monitored_variables or ""
+            if self._inventory.tx_updated_measurands_rank < 2:
+                # Anything short of a charging-station-level advertised list
+                # describes either the charger's current configuration or a
+                # single EVSE, while this SetVariables targets the station.
+                # Writing it back could only narrow the station's settings.
+                # Report it to Home Assistant, but leave the charger alone.
+                _LOGGER.debug(
+                    "Measurands for '%s' came from the charger's current "
+                    "configuration; not writing them back",
+                    self.id,
+                )
+                return measurands
             req = call.SetVariables(
                 [
                     {
@@ -883,13 +916,46 @@ class ChargePoint(cp):
                 characteristics: dict = (
                     report_data.get("variable_characteristics", {}) or {}
                 )
+                # valuesList is optional in OCPP 2.0.1, so a charger need not
+                # advertise the measurands it supports. Fall back to the ones
+                # it is currently configured to report - the variable's actual
+                # value, which arrives in this same report - rather than
+                # treating the omission as "no measurands".
                 values: str = str(characteristics.get("values_list", "") or "")
+                advertised: bool = bool(values.strip())
+                if not advertised:
+                    values = str(value or "")
                 meas_list = [
                     s.strip() for s in values.split(",") if s is not None and s.strip()
                 ]
-                self._inventory.tx_updated_measurands = [
-                    MeasurandEnumType(s) for s in meas_list
-                ]
+                parsed: list[MeasurandEnumType] = []
+                for s in meas_list:
+                    try:
+                        parsed.append(MeasurandEnumType(s))
+                    except ValueError:
+                        # Two sources feed this list, so a value the enum does
+                        # not know must not abort the whole report. Dropping it
+                        # does mean the list no longer describes the charger,
+                        # which is why it is not authoritative below.
+                        _LOGGER.debug(
+                            "Ignoring unknown measurand '%s' from '%s'", s, self.id
+                        )
+                # Only an advertised valuesList we understood in full may be
+                # written back. A list derived from the current value is the
+                # charger's own configuration - writing it back is a no-op at
+                # best - and a list that lost entries would narrow it.
+                understood: bool = advertised and len(parsed) == len(meas_list)
+                rank: int = 0
+                if understood:
+                    rank = 1 if "evse" in component else 2
+                # SampledDataCtrlr is reportable per-EVSE and reports may be
+                # chunked, so entries can arrive more than once and in any
+                # order. Take a new list only when it is at least as
+                # well-scoped, so ordering alone cannot decide what we hold -
+                # or, via rank 2 below, what we write to the charger.
+                if rank >= self._inventory.tx_updated_measurands_rank:
+                    self._inventory.tx_updated_measurands = parsed
+                    self._inventory.tx_updated_measurands_rank = rank
                 continue
 
         if not kwargs.get("tbc", False):

--- a/tests/test_v201_measurands_fallback.py
+++ b/tests/test_v201_measurands_fallback.py
@@ -1,0 +1,289 @@
+"""Measurand resolution for OCPP 2.0.1 chargers that omit valuesList.
+
+variableCharacteristics.valuesList is optional in OCPP 2.0.1. Reading only
+that field left the measurand list empty for any charger that omits it, and
+get_supported_measurands then wrote that empty list back with SetVariables -
+clearing whatever the charger was configured to report, and disabling every
+meter value inside TransactionEvent. The write persists on the charger, so
+the damage outlives the session.
+
+Only an advertised valuesList understood in full is written back. Anything
+else describes the charger's own configuration rather than its capabilities,
+so writing it back could only narrow it.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from ocpp.v201.enums import MeasurandEnumType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.ocppv201 import ChargePoint
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+ENERGY = MeasurandEnumType.energy_active_import_register.value
+POWER = MeasurandEnumType.power_active_import.value
+VENDOR = "Vendor.Custom.Thing"  # spec-legal, and not in MeasurandEnumType
+
+
+def _mk_cp(hass, monitored_variables: str = ""):
+    """Build a v201 ChargePoint that records the requests it sends."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables=monitored_variables,
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    cp.sent = []
+
+    async def record(req):
+        cp.sent.append(req)
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = record
+    return cp
+
+
+def _entry(*, values_list=None, current_value=None, evse=None):
+    """Build one SampledDataCtrlr/TxUpdatedMeasurands report entry."""
+    characteristics = {"data_type": "string", "supports_monitoring": False}
+    if values_list is not None:
+        characteristics["values_list"] = values_list
+    component = {"name": "SampledDataCtrlr"}
+    if evse is not None:
+        component["evse"] = evse
+    out = {
+        "component": component,
+        "variable": {"name": "TxUpdatedMeasurands"},
+        "variable_characteristics": characteristics,
+    }
+    if current_value is not None:
+        out["variable_attribute"] = [{"value": current_value}]
+    return out
+
+
+def _report(cp, *entries):
+    """Feed report entries through the real inventory parser."""
+    cp._inventory = None
+    cp._wait_inventory = asyncio.Event()
+    cp.on_report(1, "2026-01-01T00:00:00Z", 0, report_data=list(entries))
+
+
+def _measurand_writes(cp):
+    """Return the TxUpdatedMeasurands values written back to the charger."""
+    out = []
+    for req in cp.sent:
+        for item in getattr(req, "set_variable_data", None) or []:
+            if item.get("variable", {}).get("name") == "TxUpdatedMeasurands":
+                out.append(item.get("attribute_value"))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_current_value_used_when_valueslist_is_absent(hass):
+    """A charger that omits valuesList keeps the measurands it already has."""
+    cp = _mk_cp(hass)
+
+    _report(cp, _entry(current_value=f"{ENERGY},{POWER}"))
+
+    assert cp._inventory.tx_updated_measurands == [
+        MeasurandEnumType(ENERGY),
+        MeasurandEnumType(POWER),
+    ]
+
+    accepted = await cp.get_supported_measurands()
+
+    # Reported to Home Assistant so the sensors exist...
+    assert accepted == f"{ENERGY},{POWER}"
+    # ...but this is the charger's own configuration, so nothing is written.
+    assert cp.sent == []
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_written_when_there_is_nothing_to_go_on(hass):
+    """With no valuesList and no current value, nothing is touched.
+
+    The empty list was previously written back, clearing the charger's
+    configuration and silencing all meter values. The configured measurands
+    are returned unchanged so post_connect does not overwrite them with ""
+    and reload the config entry.
+    """
+    cp = _mk_cp(hass, monitored_variables=f"{ENERGY},{POWER}")
+
+    _report(cp, _entry(current_value=""))
+
+    assert cp._inventory.tx_updated_measurands == []
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == f"{ENERGY},{POWER}"
+    assert cp.sent == []
+
+
+@pytest.mark.asyncio
+async def test_valueslist_still_wins_and_is_written_back(hass):
+    """Unchanged behaviour: a fully understood valuesList is authoritative."""
+    cp = _mk_cp(hass)
+
+    _report(cp, _entry(values_list=f"{ENERGY},{POWER}", current_value=ENERGY))
+
+    assert cp._inventory.tx_updated_measurands_rank == 2
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == f"{ENERGY},{POWER}"
+    assert _measurand_writes(cp) == [f"{ENERGY},{POWER}"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_measurand_is_skipped_not_raised(hass):
+    """An unrecognised measurand must not abort the whole inventory report."""
+    cp = _mk_cp(hass)
+
+    _report(cp, _entry(current_value=f"{ENERGY},{VENDOR},{POWER}"))
+
+    assert cp._inventory.tx_updated_measurands == [
+        MeasurandEnumType(ENERGY),
+        MeasurandEnumType(POWER),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_measurand_is_never_written_back(hass):
+    """Losing an entry we cannot parse must not narrow the charger's config.
+
+    Vendor.* measurands are permitted by OCPP 2.0.1 and are not in
+    MeasurandEnumType. Writing the surviving subset back would delete the
+    vendor measurand from the charger permanently - the same damage class
+    this module exists to prevent, just partial rather than total.
+    """
+    cp = _mk_cp(hass)
+
+    _report(cp, _entry(values_list=f"{ENERGY},{VENDOR}"))
+
+    assert cp._inventory.tx_updated_measurands_rank == 0
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == ENERGY
+    assert cp.sent == []
+
+
+@pytest.mark.asyncio
+async def test_a_weaker_entry_does_not_displace_an_advertised_list(hass):
+    """SampledDataCtrlr is reportable per-EVSE, so entries can repeat.
+
+    An EVSE-scoped entry carrying only the current value must not replace a
+    station-level valuesList that arrived first, or message ordering alone
+    would decide what gets written back to the charger.
+    """
+    cp = _mk_cp(hass)
+
+    _report(
+        cp,
+        _entry(values_list=f"{ENERGY},{POWER}"),
+        _entry(current_value=ENERGY, evse={"id": 1}),
+    )
+
+    assert cp._inventory.tx_updated_measurands == [
+        MeasurandEnumType(ENERGY),
+        MeasurandEnumType(POWER),
+    ]
+    assert cp._inventory.tx_updated_measurands_rank == 2
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == f"{ENERGY},{POWER}"
+    assert _measurand_writes(cp) == [f"{ENERGY},{POWER}"]
+
+
+@pytest.mark.asyncio
+async def test_evse_scoped_list_does_not_replace_the_station_list(hass):
+    """A per-EVSE valuesList may be narrower than the charging station's.
+
+    SetVariables here targets the station-level SampledDataCtrlr, so adopting
+    one EVSE's list and writing it back would narrow the station's settings.
+    """
+    cp = _mk_cp(hass)
+
+    _report(
+        cp,
+        _entry(values_list=f"{ENERGY},{POWER}"),
+        _entry(values_list=ENERGY, evse={"id": 1}),
+    )
+
+    assert cp._inventory.tx_updated_measurands_rank == 2
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == f"{ENERGY},{POWER}"
+    assert _measurand_writes(cp) == [f"{ENERGY},{POWER}"]
+
+
+@pytest.mark.asyncio
+async def test_station_list_wins_even_when_it_arrives_last(hass):
+    """Precedence must be by scope, not by arrival order."""
+    cp = _mk_cp(hass)
+
+    _report(
+        cp,
+        _entry(values_list=ENERGY, evse={"id": 1}),
+        _entry(values_list=f"{ENERGY},{POWER}"),
+    )
+
+    assert cp._inventory.tx_updated_measurands_rank == 2
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == f"{ENERGY},{POWER}"
+    assert _measurand_writes(cp) == [f"{ENERGY},{POWER}"]
+
+
+@pytest.mark.asyncio
+async def test_evse_only_list_is_reported_but_not_written(hass):
+    """With no station-level entry, report the EVSE list but do not write it."""
+    cp = _mk_cp(hass)
+
+    _report(cp, _entry(values_list=f"{ENERGY},{POWER}", evse={"id": 1}))
+
+    assert cp._inventory.tx_updated_measurands_rank == 1
+
+    accepted = await cp.get_supported_measurands()
+
+    assert accepted == f"{ENERGY},{POWER}"
+    assert cp.sent == []


### PR DESCRIPTION
Fixes #2033.

Per your steer on the issue — *"given it is in the same report I would use the charger's current variableAttribute"* — with option 1 (never write a destructive list) alongside it.

## The problem

`variableCharacteristics.valuesList` is optional in OCPP 2.0.1, but it was the only source the inventory parser read. A charger that omits it left the measurand list empty, and `get_supported_measurands()` then wrote that empty list back with `SetVariables` — clearing whatever the charger was configured to report and silencing every meter value inside `TransactionEvent`. Because the write lands on the charger, the damage outlives the session.

## The fix

**Fall back to the current value.** When `valuesList` is absent, use the measurands the charger is already configured to report — the variable's actual value, which arrives in the same report and was already being extracted a few lines above.

**Only write back an advertised list understood in full.** A new `tx_updated_measurands_advertised` flag records provenance:

- from a `valuesList` we parsed completely → authoritative, written back as before
- from the current value → that *is* the charger's configuration; writing it back is a no-op at best
- from a `valuesList` that lost entries → writing the survivors would narrow it

That last case is worth spelling out. `Vendor.*` measurands are permitted by the spec and are not in `MeasurandEnumType`. Unknown entries are now skipped rather than raising — two sources feed this list, and one unrecognised value should not abort the whole inventory report — but skipping means the list no longer describes the charger, so it must not be written back. Without that guard a charger advertising `Energy.Active.Import.Register,Vendor.Custom.Thing` would have the vendor measurand silently deleted on first connect.

**Provenance also fixes an ordering bug.** `SampledDataCtrlr` is reportable per-EVSE and reports may be chunked, so entries can arrive more than once. The assignment was unconditional, so an EVSE-scoped entry carrying only the current value could displace a station-level `valuesList` purely by arriving second — and then be written to the charger. A weaker entry can no longer displace an advertised one.

**Nothing to go on → nothing is touched.** The configured measurands are returned unchanged rather than `""`. `post_connect` stores this result in `monitored_variables` and reloads the config entry when it differs, and `sensor.py` creates no measurand sensors from an empty string — so returning `""` moved the damage from the charger to Home Assistant instead of removing it. This path also logs at WARNING; previously an unrecognised measurand raised out of `on_report`, which was crude but at least visible.

## Tests

`tests/test_v201_measurands_fallback.py`, driving the real `on_report` parser:

- current value used when `valuesList` is absent — reported to HA, **not** written back
- nothing resolvable — charger untouched *and* configured measurands preserved
- advertised `valuesList` still wins and is still written (unchanged behaviour)
- an unknown measurand is skipped, not raised
- a dropped measurand is never written back (the `Vendor.*` narrowing case)
- a weaker per-EVSE entry does not displace an advertised list

Full suite passes (175) and `pre-commit run --all-files` is clean.

## One consequence worth flagging

`on_transaction_event` iterates `tx_updated_measurands` at transaction end and zeroes any non-`Energy*` measurand not seen at `Transaction.End`. For the chargers this PR targets that list was always empty, so the loop never ran; it now does. I believe that is the intended behaviour finally working rather than a regression, but it is a real behaviour change and I would rather name it than have it turn up later. Happy to add coverage for it if you would like it in this PR.

## Not included

The integration-level charger in `tests/test_charge_point_v201.py` always sends a populated `values_list`, so the no-`valuesList` path is not exercised end-to-end. The key names are already proven through the real path by the existing tests, so this is a coverage gap rather than a correctness risk — happy to add a variant if you want it.

## Note on ordering

This and #2038 are siblings off `33721c0`, not stacked. Both touch `ocppv201.py` but the hunks do not overlap, so they auto-merge; they do land in the same `post_connect` sequence, so worth exercising together whichever order they go in.

## Reported by

Found on a FoxESS A022KP1 (firmware `1.10,1.06`), which reports `TxUpdatedMeasurands` with `{"dataType":"string","supportsMonitoring":false}` and no `valuesList`. Its value read `Energy.Active.Import.Register` before the first 2.0.1 connection and was empty for three days afterwards, while the neighbouring `TxStartedMeasurands` and `TxEndedMeasurands` — which the integration never writes — kept theirs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved measurand handling when charger capability lists are missing, incomplete, duplicated, or contain unknown values.
  * Preserved authoritative supported-measurand information across inventory reports, including reports received in different orders.
  * Prevented empty, incomplete, or lower-priority capability data from overwriting existing charger configuration.
  * Continued reporting current measurand values safely when capability details are unavailable.

* **Tests**
  * Added coverage for fallback behavior, partial lists, unknown measurands, duplicate reports, report ordering, and configuration preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->