### PR TITLE
Translate the per-connector status metric on OCPP 2.0.1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -5,6 +5,7 @@ import contextlib
 from datetime import datetime, UTC
 from dataclasses import dataclass, field
 import logging
+from typing import Final
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
@@ -90,6 +91,7 @@ class ChargePoint(cp):
     _tx_start_time: dict[int, datetime]
     _global_to_evse: dict[int, tuple[int, int]]  # global_idx -> (evse_id, connector_id)
     _evse_to_global: dict[tuple[int, int], int]  # (evse_id, connector_id) -> global_idx
+    _evse_status_v16: dict[int, ChargePointStatusv16]
     _pending_status_notifications: list[
         tuple[str, str, int, int]
     ]  # (timestamp, connector_status, evse_id, connector_id)
@@ -119,6 +121,7 @@ class ChargePoint(cp):
         self._evse_to_global: dict[tuple[int, int], int] = {}
         self._pending_status_notifications: list[tuple[str, str, int, int]] = []
         self._connector_status = []
+        self._evse_status_v16: dict[int, ChargePointStatusv16] = {}
 
     # --- Connector mapping helpers (EVSE <-> global index) ---
     def _build_connector_map(self) -> bool:
@@ -169,6 +172,122 @@ class ChargePoint(cp):
         """Return (evse_id, connector_id) for a global index. Fallback: (global_idx,1)."""
         return self._global_to_evse.get(global_idx, (global_idx, 1))
 
+    # Charging states are more specific than Occupied, which only reports that
+    # a vehicle is connected. Only TransactionEvent can supply them.
+    _CHARGING_STATES = frozenset(
+        {
+            ChargePointStatusv16.charging.value,
+            ChargePointStatusv16.suspended_ev.value,
+            ChargePointStatusv16.suspended_evse.value,
+        }
+    )
+
+    def _aggregate_evse_status(self, evse_id: int):
+        """Aggregate an EVSE's connector statuses, or None while any is unknown."""
+        if evse_id - 1 >= len(self._connector_status):
+            return None
+        aggregate = None
+        for status in self._connector_status[evse_id - 1]:
+            if status is None:
+                return None
+            aggregate = status
+            if status != ConnectorStatusEnumType.available:
+                break
+        return aggregate
+
+    def _known_occupancy(self, evse_id: int, connector_id: int):
+        """Return the last connector status reported for this pair, if any."""
+        if evse_id - 1 < len(self._connector_status):
+            row = self._connector_status[evse_id - 1]
+            if connector_id - 1 < len(row):
+                return row[connector_id - 1]
+        return None
+
+    def _has_live_transaction(self, evse_id: int, connector_id: int | None = None):
+        """Whether a transaction is running on a connector, or on any of an EVSE's.
+
+        _tx_start_time is populated when a transaction starts and dropped when
+        it ends, so it is the authority on whether a charging state is still
+        meaningful.
+        """
+        if connector_id is not None:
+            # Deliberately not _pair_to_global: that allocates a global index
+            # for an unknown pair, and a read-only predicate must not create
+            # mappings for callers that merely ask a question.
+            idx = self._evse_to_global.get((evse_id, connector_id))
+            return idx is not None and idx in self._tx_start_time
+        return any(
+            idx in self._tx_start_time
+            for (e, _c), idx in self._evse_to_global.items()
+            if e == evse_id
+        )
+
+    # How prominent each state is when several EVSEs disagree. The charging
+    # station has one status metric, so a second EVSE going idle must not
+    # report the whole station as free while another is still delivering.
+    # With a single EVSE the derived value is simply that EVSE's, so this
+    # ordering only takes effect on multi-EVSE chargers.
+    _STATION_PRECEDENCE: Final[list[str]] = [
+        # Faulted first: _apply_status_notification notes that this metric must
+        # not mask a faulted connector, and ranking a charge above it would
+        # reintroduce that masking on a multi-EVSE charger.
+        ChargePointStatusv16.faulted.value,
+        ChargePointStatusv16.charging.value,
+        ChargePointStatusv16.suspended_ev.value,
+        ChargePointStatusv16.suspended_evse.value,
+        ChargePointStatusv16.preparing.value,
+        ChargePointStatusv16.finishing.value,
+        ChargePointStatusv16.reserved.value,
+        ChargePointStatusv16.unavailable.value,
+        ChargePointStatusv16.available.value,
+    ]
+
+    def _derive_station_status(self) -> str | None:
+        """Return the most prominent status across every known EVSE."""
+        seen = {v.value for v in self._evse_status_v16.values()}
+        for candidate in self._STATION_PRECEDENCE:
+            if candidate in seen:
+                return candidate
+        return None
+
+    @staticmethod
+    def _charging_state_v16(state) -> ChargePointStatusv16 | None:
+        """Map a transaction's chargingState onto the OCPP 1.6 vocabulary."""
+        if state == ChargingStateEnumType.idle:
+            return ChargePointStatusv16.available
+        if state == ChargingStateEnumType.ev_connected:
+            return ChargePointStatusv16.preparing
+        if state == ChargingStateEnumType.suspended_evse:
+            return ChargePointStatusv16.suspended_evse
+        if state == ChargingStateEnumType.suspended_ev:
+            return ChargePointStatusv16.suspended_ev
+        if state == ChargingStateEnumType.charging:
+            return ChargePointStatusv16.charging
+        return None
+
+    @staticmethod
+    def _connector_status_v16(
+        status: ConnectorStatusEnumType,
+    ) -> ChargePointStatusv16:
+        """Map an OCPP 2.0.1 connector status onto the 1.6 vocabulary.
+
+        The status_connector metric is consumed by entities whose conditions
+        are written in OCPP 1.6 terms (switch.py), so both the per-connector
+        and the charging-station-level metric must speak that vocabulary.
+        Occupied has no 1.6 equivalent on its own - it says a vehicle is
+        connected, not whether it is charging - so it maps to Preparing and
+        TransactionEvent's chargingState refines it from there.
+        """
+        if status == ConnectorStatusEnumType.available:
+            return ChargePointStatusv16.available
+        if status == ConnectorStatusEnumType.faulted:
+            return ChargePointStatusv16.faulted
+        if status == ConnectorStatusEnumType.unavailable:
+            return ChargePointStatusv16.unavailable
+        if status == ConnectorStatusEnumType.reserved:
+            return ChargePointStatusv16.reserved
+        return ChargePointStatusv16.preparing
+
     def _apply_status_notification(
         self, timestamp: str, connector_status: str, evse_id: int, connector_id: int
     ):
@@ -217,28 +336,41 @@ class ChargePoint(cp):
         evse_list[connector_id - 1] = ConnectorStatusEnumType(connector_status)
 
         global_idx = self._pair_to_global(evse_id, connector_id)
-        self._metrics[
-            (global_idx, cstat.status_connector.value)
-        ].value = ConnectorStatusEnumType(connector_status).value
+        translated = self._connector_status_v16(
+            ConnectorStatusEnumType(connector_status)
+        )
+        # Occupied says a vehicle is connected, not whether it is charging, so
+        # it is strictly less specific than a charging state from
+        # TransactionEvent. trigger_status_notification() provokes exactly this
+        # message on every reconnect, and the periodic transaction events that
+        # follow only carry chargingState when it changes - so letting it
+        # overwrite Charging would turn charge_control off for the rest of the
+        # session. Every other status is real news and still applies.
+        current = self._metrics[(global_idx, cstat.status_connector.value)].value
+        downgrades_live_charge = (
+            translated == ChargePointStatusv16.preparing
+            and current in self._CHARGING_STATES
+            and self._has_live_transaction(evse_id, connector_id)
+        )
+        if not downgrades_live_charge:
+            self._metrics[
+                (global_idx, cstat.status_connector.value)
+            ].value = translated.value
 
-        evse_status: ConnectorStatusEnumType | None = None
-        for st in evse_list:
-            if st is None:
-                evse_status = None
-                break
-            evse_status = st
-            if st != ConnectorStatusEnumType.available:
-                break
+        evse_status = self._aggregate_evse_status(evse_id)
         if evse_status is not None:
-            if evse_status == ConnectorStatusEnumType.available:
-                v16 = ChargePointStatusv16.available
-            elif evse_status == ConnectorStatusEnumType.faulted:
-                v16 = ChargePointStatusv16.faulted
-            elif evse_status == ConnectorStatusEnumType.unavailable:
-                v16 = ChargePointStatusv16.unavailable
-            else:
-                v16 = ChargePointStatusv16.preparing
-            self._report_evse_status(evse_id, v16)
+            aggregate = self._connector_status_v16(evse_status)
+            # Same precedence as the per-connector write above, applied to this
+            # EVSE's own state. Other EVSEs are handled by deriving the station
+            # value in _report_evse_status rather than overwriting it.
+            held = self._evse_status_v16.get(evse_id)
+            if not (
+                aggregate == ChargePointStatusv16.preparing
+                and held is not None
+                and held.value in self._CHARGING_STATES
+                and self._has_live_transaction(evse_id)
+            ):
+                self._report_evse_status(evse_id, aggregate)
 
     def _drain_pending_status_notifications(self):
         """Apply and clear buffered status notifications, then notify HA.
@@ -768,9 +900,35 @@ class ChargePoint(cp):
         """Perform OCPP callback."""
         return call_result.Heartbeat(current_time=datetime.now(tz=UTC).isoformat())
 
-    def _report_evse_status(self, evse_id: int, evse_status_v16: ChargePointStatusv16):
-        """Report EVSE-level status on the global connector."""
-        self._metrics[(0, cstat.status_connector.value)].value = evse_status_v16.value
+    def _report_evse_status(
+        self,
+        evse_id: int,
+        evse_status_v16: ChargePointStatusv16,
+        connector_id: int | None = None,
+    ):
+        """Report EVSE-level status on the global connector.
+
+        With a connector_id the same value is also recorded against that
+        connector. StatusNotification reports occupancy rather than charging
+        state, so Charging/SuspendedEV/SuspendedEVSE can only reach the
+        per-connector metric from TransactionEvent - and without them
+        switch.charge_control, whose condition is written in those terms,
+        can never read on.
+        """
+        if evse_id >= 1:
+            self._evse_status_v16[evse_id] = evse_status_v16
+        derived = self._derive_station_status()
+        self._metrics[(0, cstat.status_connector.value)].value = (
+            derived if derived is not None else evse_status_v16.value
+        )
+        if connector_id is not None and evse_id >= 1 and connector_id >= 1:
+            # Same guard as _apply_status_notification: a degenerate pair would
+            # have _pair_to_global allocate a phantom connector and strand the
+            # real one, so it must not reach the metric from here either.
+            global_idx = self._pair_to_global(evse_id, connector_id)
+            self._metrics[
+                (global_idx, cstat.status_connector.value)
+            ].value = evse_status_v16.value
         self.hass.async_create_task(self.update(self.settings.cpid))
 
     @on(Action.status_notification)
@@ -1068,6 +1226,24 @@ class ChargePoint(cp):
         evse_conn_id: int = (
             kwargs["evse"].get("connector_id", 1) if "evse" in kwargs else 1
         )
+        if evse_id < 1 or evse_conn_id < 1:
+            # The same degenerate pair _apply_status_notification refuses. It
+            # has to be caught before _pair_to_global, which would otherwise
+            # allocate a phantom connector, record the transaction and its
+            # meter values against it, and leave the real connector empty.
+            # The charging state is still station-level news, so report that.
+            _LOGGER.debug(
+                "Ignoring connector-scoped data from a TransactionEvent with "
+                "a malformed pair (evse_id=%s, connector_id=%s)",
+                evse_id,
+                evse_conn_id,
+            )
+            station_v16 = self._charging_state_v16(
+                transaction_info.get("charging_state")
+            )
+            if station_v16:
+                self._report_evse_status(evse_id, station_v16)
+            return call_result.TransactionEvent()
         global_idx: int = self._pair_to_global(evse_id, evse_conn_id)
         offline: bool = kwargs.get("offline", False)
         meter_values: list[dict] = kwargs.get("meter_value", [])
@@ -1076,19 +1252,30 @@ class ChargePoint(cp):
 
         if "charging_state" in transaction_info:
             state = transaction_info["charging_state"]
-            evse_status_v16: ChargePointStatusv16 | None = None
-            if state == ChargingStateEnumType.idle:
-                evse_status_v16 = ChargePointStatusv16.available
-            elif state == ChargingStateEnumType.ev_connected:
-                evse_status_v16 = ChargePointStatusv16.preparing
-            elif state == ChargingStateEnumType.suspended_evse:
-                evse_status_v16 = ChargePointStatusv16.suspended_evse
-            elif state == ChargingStateEnumType.suspended_ev:
-                evse_status_v16 = ChargePointStatusv16.suspended_ev
-            elif state == ChargingStateEnumType.charging:
-                evse_status_v16 = ChargePointStatusv16.charging
+            evse_status_v16 = self._charging_state_v16(state)
             if evse_status_v16:
-                self._report_evse_status(evse_id, evse_status_v16)
+                if state == ChargingStateEnumType.idle:
+                    # Idle means no session, not an empty connector, so its
+                    # Available must not reach the connector. Nor may the
+                    # connector keep reporting Charging: a cable left in does
+                    # not change the connector status, so the charger need not
+                    # send another StatusNotification. Fall back to the
+                    # occupancy already recorded, which is what describes the
+                    # connector once the session has gone.
+                    # The station keeps reporting the session's end. Only the
+                    # charger knows whether the cable came out with it, so
+                    # second-guessing that from stale occupancy would be wrong
+                    # whenever the transaction ended because the EV left.
+                    self._report_evse_status(evse_id, evse_status_v16)
+                    known = self._known_occupancy(evse_id, evse_conn_id)
+                    if known is not None:
+                        self._metrics[
+                            (global_idx, cstat.status_connector.value)
+                        ].value = self._connector_status_v16(known).value
+                else:
+                    self._report_evse_status(
+                        evse_id, evse_status_v16, connector_id=evse_conn_id
+                    )
 
         response = call_result.TransactionEvent()
         id_token = kwargs.get("id_token")

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -4,7 +4,7 @@ Debugging
 To enable debug logging for this integration and related libraries you
 need to update your Home Assistant `configuration.yaml` file:
 
-```
+```yaml
 logger:
   default: info
   logs:
@@ -25,7 +25,7 @@ You can filter for OCPP related messages by typing 'ocpp' in the 'search logs' b
 
 A typical log for a working connection should look like this:
 
-```
+```text
 2022-03-16 16:33:08 INFO (MainThread) [custom_components.ocpp] {'host': '0.0.0.0', 'port': 9000, 'csid': 'central', 'cpid': 'pulsar', 'meter_interval': 60, 'idle_interval': 900, 'websocket_close_timeout': 10, 'WEBSOCKET_PING_TRIES': 2, 'websocket_ping_interval': 20, 'websocket_ping_timeout': 20, 'skip_schema_validation': False, 'monitored_variables': 'Energy.Active.Import.Register,Energy.Reactive.Import.Register,Energy.Active.Import.Interval,Energy.Reactive.Import.Interval,Power.Active.Import,Power.Reactive.Import,Power.Offered,Power.Factor,Current.Import,Current.Offered,Voltage,Frequency,RPM,SoC,Temperature,Current.Export,Energy.Active.Export.Register,Energy.Reactive.Export.Register,Energy.Active.Export.Interval,Energy.Reactive.Export.Interval,Power.Active.Export,Power.Reactive.Export'}
 2022-03-16 16:35:40 INFO (MainThread) [custom_components.ocpp] Websocket Subprotocol matched: ocpp1.6
 2022-03-16 16:35:40 INFO (MainThread) [custom_components.ocpp] Charger websocket path=/pulsar
@@ -50,7 +50,7 @@ A typical log for a working connection should look like this:
 
 To debug issues with establishing the ocpp connection, you can enable debug logging for websockets.server:
 
-```
+```yaml
 logger:
   default: info
   logs:
@@ -59,7 +59,7 @@ logger:
 
 Filtering for websockets.server should yield something like this:
 
-```
+```text
 2022-03-16 16:33:08 INFO (MainThread) [websockets.server] server listening on 0.0.0.0:9000
 2022-03-16 16:35:40 DEBUG (MainThread) [websockets.server] = connection is CONNECTING
 2022-03-16 16:35:40 DEBUG (MainThread) [websockets.server] < GET /pulsar HTTP/1.1

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -47,7 +47,7 @@ For OCPP 1.6, the sensor can show these values:
 
 Note
 In OCPP 1.6, `connectorId = 0` (station level) only uses Available, Unavailable, or Faulted.<br>
-In OCPP 2.0.1, connector status is simplified to Available / Occupied / Reserved / Unavailable / Faulted; “Preparing/Finishing” are reflected in TransactionEvent rather than as connector statuses.
+OCPP 2.0.1 simplifies connector status to Available / Occupied / Reserved / Unavailable / Faulted and reports charging progress in TransactionEvent instead. The integration normalises both protocols onto the OCPP 1.6 vocabulary listed above, so the status sensor reads the same whichever version a charger negotiates: `Occupied` is reported as **Preparing**, and **Charging** / **SuspendedEV** / **SuspendedEVSE** come from the transaction's charging state. Automations can use the same conditions on either protocol.
 
 If your integration shows extra attributes on the connector status sensor like availability_change or availability_pending, they indicate that a status change (e.g., after ChangeAvailability) has been accepted or scheduled and will take effect once current conditions allow (e.g., after an active session ends).
 

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1323,7 +1323,7 @@ async def _unsupported_base_report_test(
     )
     while (
         cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
-        != ConnectorStatusEnumType.occupied.value
+        != ChargePointStatusv16.preparing.value
     ):
         await asyncio.sleep(0.1)
     assert server_cp._pending_status_notifications == []
@@ -1385,7 +1385,7 @@ async def _incomplete_inventory_test(
     # (1, 1).
     while (
         cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
-        != ConnectorStatusEnumType.occupied.value
+        != ChargePointStatusv16.preparing.value
     ):
         await asyncio.sleep(0.1)
     assert server_cp._pending_status_notifications == []
@@ -1446,7 +1446,7 @@ async def _incomplete_inventory_late_evidence_test(
     )
     while (
         cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
-        != ConnectorStatusEnumType.occupied.value
+        != ChargePointStatusv16.preparing.value
     ):
         await asyncio.sleep(0.1)
     assert server_cp._evse_to_global == {(2, 2): 1}

--- a/tests/test_charge_point_v201_multi.py
+++ b/tests/test_charge_point_v201_multi.py
@@ -336,7 +336,8 @@ async def test_v201_multi_connectors_per_evse(hass, socket_enabled):
         await asyncio.sleep(0.05)
 
         assert cs.get_metric(cpid, "Status.Connector", connector_id=1) == "Available"
-        assert cs.get_metric(cpid, "Status.Connector", connector_id=2) == "Occupied"
+        # Occupied has no 1.6 equivalent of its own and maps to Preparing.
+        assert cs.get_metric(cpid, "Status.Connector", connector_id=2) == "Preparing"
         assert cs.get_metric(cpid, "Status.Connector", connector_id=3) == "Unavailable"
 
         await cp.send_tx_started_eair_wh(1, 2, "TX-1", 10_000)

--- a/tests/test_v201_connector_charge_state.py
+++ b/tests/test_v201_connector_charge_state.py
@@ -1,0 +1,434 @@
+"""The per-connector status metric must speak the OCPP 1.6 vocabulary.
+
+switch.charge_control is per_connector and matches on Charging /
+SuspendedEVSE / SuspendedEV. Those come from TransactionEvent's chargingState
+in OCPP 2.0.1; a ConnectorStatusEnumType can never be any of them, so while
+the per-connector metric carried raw 2.0.1 statuses the switch read off for
+the whole of every charge - and any automation gating on it was silently
+dead.
+
+The tests assert against switch.py's own condition lists rather than
+hard-coded strings, so they fail if either side of that contract moves.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from ocpp.v16.enums import ChargePointStatus as ChargePointStatusv16
+from ocpp.v201.enums import ChargingStateEnumType, ConnectorStatusEnumType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import (
+    HAChargerSession as csess,
+    HAChargerStatuses as cstat,
+)
+from custom_components.ocpp.ocppv201 import ChargePoint, InventoryReport
+from custom_components.ocpp.switch import SWITCHES
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _switch(key: str):
+    """Look up a switch description, failing legibly rather than at collection."""
+    found = next((s for s in SWITCHES if s.key == key), None)
+    assert found is not None, f"switch.py no longer defines a '{key}' switch"
+    return found
+
+
+CHARGE_CONTROL = _switch("charge_control")
+# NB: three n's - the upstream key is spelled "connnector_availability".
+CONNECTOR_AVAILABILITY = _switch("connnector_availability")
+
+
+def _mk_cp(hass):
+    """Build a v201 ChargePoint detached from any real connection."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+    cp._build_connector_map()
+    return cp
+
+
+def _connector_status(cp, global_idx: int = 1):
+    return cp._metrics[(global_idx, cstat.status_connector.value)].value
+
+
+def _station_status(cp):
+    return cp._metrics[(0, cstat.status_connector.value)].value
+
+
+def _tx_event(cp, charging_state: ChargingStateEnumType, connector_id: int = 1):
+    """Drive a transaction event. charging_state is sent as the wire string."""
+    cp.on_transaction_event(
+        "Updated",
+        "2026-01-01T00:00:00Z",
+        "ChargingStateChanged",
+        1,
+        {"transaction_id": "tx-1", "charging_state": charging_state.value},
+        evse={"id": 1, "connector_id": connector_id},
+    )
+
+
+def _start_transaction(cp, global_idx: int = 1):
+    """Mark a transaction live, as on_transaction_event does on Started."""
+    cp._tx_start_time[global_idx] = datetime.now(tz=UTC)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("charging_state", "expected"),
+    [
+        (ChargingStateEnumType.charging, ChargePointStatusv16.charging),
+        (ChargingStateEnumType.suspended_ev, ChargePointStatusv16.suspended_ev),
+        (ChargingStateEnumType.suspended_evse, ChargePointStatusv16.suspended_evse),
+    ],
+)
+async def test_charging_state_reaches_the_connector(hass, charging_state, expected):
+    """Charge Control can only read on if these reach the per-connector metric."""
+    cp = _mk_cp(hass)
+
+    _tx_event(cp, charging_state)
+
+    assert _connector_status(cp) == expected.value
+    assert _connector_status(cp) in CHARGE_CONTROL.metric_condition
+
+
+@pytest.mark.asyncio
+async def test_status_notification_is_translated_not_raw(hass):
+    """A raw 2.0.1 status must never reach the metric.
+
+    Occupied satisfies no condition in switch.py, so leaving it raw is what
+    made both per-connector switches unreadable on 2.0.1.
+    """
+    cp = _mk_cp(hass)
+
+    cp._apply_status_notification(
+        "2026-01-01T00:00:00Z", ConnectorStatusEnumType.occupied.value, 1, 1
+    )
+
+    assert _connector_status(cp) == ChargePointStatusv16.preparing.value
+    assert _connector_status(cp) != ConnectorStatusEnumType.occupied.value
+    # Not charging, so Charge Control stays off - but the connector is
+    # operative, which Connector Availability must now be able to see.
+    assert _connector_status(cp) not in CHARGE_CONTROL.metric_condition
+    assert _connector_status(cp) in CONNECTOR_AVAILABILITY.metric_condition
+
+
+@pytest.mark.asyncio
+async def test_charging_survives_a_reconnect_status_notification(hass):
+    """A status notification mid-charge must not turn Charge Control off.
+
+    trigger_status_notification() re-requests statuses on every reconnect, so
+    a charger legitimately resends Occupied part-way through a transaction.
+    Occupied is less specific than Charging, and the periodic transaction
+    events that follow only carry chargingState when it changes - so letting
+    it through would leave the switch off for the rest of the session.
+    """
+    cp = _mk_cp(hass)
+    _start_transaction(cp)
+    _tx_event(cp, ChargingStateEnumType.charging)
+    assert _connector_status(cp) in CHARGE_CONTROL.metric_condition
+
+    cp._apply_status_notification(
+        "2026-01-01T00:00:01Z", ConnectorStatusEnumType.occupied.value, 1, 1
+    )
+
+    assert _connector_status(cp) == ChargePointStatusv16.charging.value
+    assert _connector_status(cp) in CHARGE_CONTROL.metric_condition
+    # the charging-station-level metric is held for the same reason
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+
+
+@pytest.mark.asyncio
+async def test_the_hold_lifts_once_the_transaction_ends(hass):
+    """Holding a charging state must not outlive its transaction."""
+    cp = _mk_cp(hass)
+    _start_transaction(cp)
+    _tx_event(cp, ChargingStateEnumType.charging)
+
+    cp._tx_start_time.pop(1, None)  # as on_transaction_event does on Ended
+    cp._apply_status_notification(
+        "2026-01-01T00:00:02Z", ConnectorStatusEnumType.occupied.value, 1, 1
+    )
+
+    assert _connector_status(cp) == ChargePointStatusv16.preparing.value
+    assert _connector_status(cp) not in CHARGE_CONTROL.metric_condition
+
+
+@pytest.mark.asyncio
+async def test_occupied_still_applies_when_no_charge_is_running(hass):
+    """The hold must only cover a genuine downgrade, never an update."""
+    cp = _mk_cp(hass)
+    _start_transaction(cp)  # live transaction, but no charging state yet
+
+    cp._apply_status_notification(
+        "2026-01-01T00:00:00Z", ConnectorStatusEnumType.occupied.value, 1, 1
+    )
+
+    assert _connector_status(cp) == ChargePointStatusv16.preparing.value
+
+
+@pytest.mark.asyncio
+async def test_idle_does_not_free_an_occupied_connector(hass):
+    """Idle in chargingState means no session, not an empty connector.
+
+    Propagating its Available would contradict the occupancy that
+    StatusNotification owns, while _connector_status still holds Occupied.
+    """
+    cp = _mk_cp(hass)
+    cp._apply_status_notification(
+        "2026-01-01T00:00:00Z", ConnectorStatusEnumType.occupied.value, 1, 1
+    )
+
+    _tx_event(cp, ChargingStateEnumType.idle)
+
+    assert _connector_status(cp) == ChargePointStatusv16.preparing.value
+
+
+@pytest.mark.asyncio
+async def test_a_transaction_event_for_connector_zero_is_not_mapped(hass):
+    """The real entry point must refuse the pair, not just the metric write.
+
+    on_transaction_event reaches _pair_to_global and _set_meter_values well
+    before it reports a status, so guarding only the status write still let a
+    malformed pair allocate a phantom connector, record the transaction and
+    its meter values against it, and strand the real connector.
+    """
+    cp = _mk_cp(hass)
+    before = dict(cp._evse_to_global)
+
+    cp.on_transaction_event(
+        "Started",
+        "2026-01-01T00:00:00Z",
+        "RemoteStart",
+        0,
+        {
+            "transaction_id": "tx-bad",
+            "charging_state": ChargingStateEnumType.charging.value,
+        },
+        evse={"id": 1, "connector_id": 0},
+    )
+
+    assert dict(cp._evse_to_global) == before
+    assert cp._tx_start_time == {}
+    assert cp._metrics[(1, csess.transaction_id.value)].value is None
+    assert _connector_status(cp) is None
+    # the charging state is still station-level news
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+
+
+@pytest.mark.asyncio
+async def test_a_degenerate_connector_id_is_not_written(hass):
+    """A transaction event for connector 0 must not strand the real one.
+
+    _apply_status_notification drops these by design; _pair_to_global would
+    otherwise allocate a phantom global index, write the charging state to a
+    connector that does not exist and leave the real one empty.
+    """
+    cp = _mk_cp(hass)
+    before = dict(cp._evse_to_global)
+
+    cp._report_evse_status(1, ChargePointStatusv16.charging, connector_id=0)
+
+    assert dict(cp._evse_to_global) == before
+    assert _connector_status(cp) is None
+    # the charging-station-level metric is still updated
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (ConnectorStatusEnumType.available, ChargePointStatusv16.available),
+        (ConnectorStatusEnumType.faulted, ChargePointStatusv16.faulted),
+        (ConnectorStatusEnumType.unavailable, ChargePointStatusv16.unavailable),
+        (ConnectorStatusEnumType.reserved, ChargePointStatusv16.reserved),
+        (ConnectorStatusEnumType.occupied, ChargePointStatusv16.preparing),
+    ],
+)
+async def test_every_connector_status_maps_into_the_1_6_vocabulary(hass, raw, expected):
+    """No 2.0.1 connector status may leak through untranslated."""
+    cp = _mk_cp(hass)
+
+    cp._apply_status_notification("2026-01-01T00:00:00Z", raw.value, 1, 1)
+
+    assert _connector_status(cp) == expected.value
+    assert _connector_status(cp) in [s.value for s in ChargePointStatusv16]
+    # the EVSE aggregate uses the same mapping - Reserved previously fell
+    # through to Preparing here
+    assert _station_status(cp) == expected.value
+
+
+def _mk_two_evse_cp(hass):
+    """Build a charger with two single-connector EVSEs."""
+    cp = _mk_cp(hass)
+    cp._inventory = InventoryReport(evse_count=2, connector_count=[1, 1])
+    cp._evse_to_global.clear()
+    cp._global_to_evse.clear()
+    cp._build_connector_map()
+    return cp
+
+
+@pytest.mark.asyncio
+async def test_another_evse_does_not_clear_the_station_charging_state(hass):
+    """The station has one status metric shared by every EVSE.
+
+    A second EVSE plugging in, or reporting Idle, must not report the whole
+    charging station as merely occupied - or worse, free - while another EVSE
+    is still delivering.
+    """
+    cp = _mk_two_evse_cp(hass)
+    _start_transaction(cp, 1)
+    _tx_event(cp, ChargingStateEnumType.charging, connector_id=1)
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+
+    cp._apply_status_notification(
+        "2026-01-01T00:00:01Z", ConnectorStatusEnumType.occupied.value, 2, 1
+    )
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+
+    cp.on_transaction_event(
+        "Updated",
+        "2026-01-01T00:00:02Z",
+        "ChargingStateChanged",
+        1,
+        {
+            "transaction_id": "tx-2",
+            "charging_state": ChargingStateEnumType.idle.value,
+        },
+        evse={"id": 2, "connector_id": 1},
+    )
+
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+    assert _connector_status(cp, 1) == ChargePointStatusv16.charging.value
+
+
+@pytest.mark.asyncio
+async def test_the_connector_does_not_stay_charging_after_the_session_ends(hass):
+    """A cable left in does not change the connector status.
+
+    So the charger need not send another StatusNotification once the session
+    ends, and the connector would otherwise keep reporting Charging for as
+    long as the cable stayed in.
+    """
+    cp = _mk_cp(hass)
+    cp._apply_status_notification(
+        "2026-01-01T00:00:00Z", ConnectorStatusEnumType.occupied.value, 1, 1
+    )
+    _start_transaction(cp)
+    _tx_event(cp, ChargingStateEnumType.charging)
+    assert _connector_status(cp) in CHARGE_CONTROL.metric_condition
+
+    cp._tx_start_time.pop(1, None)
+    _tx_event(cp, ChargingStateEnumType.idle)
+
+    assert _connector_status(cp) == ChargePointStatusv16.preparing.value
+    assert _connector_status(cp) not in CHARGE_CONTROL.metric_condition
+
+
+@pytest.mark.asyncio
+async def test_a_faulted_evse_is_not_masked_by_another_charging(hass):
+    """A fault must stay visible at station level.
+
+    _apply_status_notification records that this metric must not mask a
+    faulted connector; ranking a charge above a fault would reintroduce that
+    masking as soon as a second EVSE is present.
+    """
+    cp = _mk_two_evse_cp(hass)
+    _start_transaction(cp, 1)
+    _tx_event(cp, ChargingStateEnumType.charging, connector_id=1)
+    assert _station_status(cp) == ChargePointStatusv16.charging.value
+
+    cp._apply_status_notification(
+        "2026-01-01T00:00:01Z", ConnectorStatusEnumType.faulted.value, 2, 1
+    )
+
+    assert _station_status(cp) == ChargePointStatusv16.faulted.value
+    # the charging EVSE's own connector is unaffected
+    assert _connector_status(cp, 1) == ChargePointStatusv16.charging.value
+
+
+@pytest.mark.asyncio
+async def test_the_live_transaction_check_does_not_allocate(hass):
+    """A read-only predicate must not create connector mappings."""
+    cp = _mk_cp(hass)
+    before = dict(cp._evse_to_global)
+
+    assert cp._has_live_transaction(9, 9) is False
+
+    assert dict(cp._evse_to_global) == before
+
+
+@pytest.mark.asyncio
+async def test_helpers_are_safe_before_any_status_is_known(hass):
+    """The status helpers must cope with an EVSE they have heard nothing about.
+
+    _report_evse_status can run before any StatusNotification has arrived -
+    a TransactionEvent may be the first message about a connector - so each
+    lookup has to answer "unknown" rather than raise.
+    """
+    cp = _mk_cp(hass)
+    cp._connector_status = []
+    cp._evse_status_v16 = {}
+
+    # no connector statuses recorded yet
+    assert cp._aggregate_evse_status(1) is None
+    assert cp._known_occupancy(1, 1) is None
+    # an EVSE beyond anything reported
+    assert cp._aggregate_evse_status(99) is None
+    assert cp._known_occupancy(99, 99) is None
+    # nothing to derive the station value from
+    assert cp._derive_station_status() is None
+    # a charging state outside the ones we translate
+    assert cp._charging_state_v16("SomethingElse") is None
+
+
+@pytest.mark.asyncio
+async def test_station_falls_back_when_nothing_is_derivable(hass):
+    """With no per-EVSE state yet, the reported status is used as-is."""
+    cp = _mk_cp(hass)
+    cp._evse_status_v16 = {}
+
+    cp._report_evse_status(0, ChargePointStatusv16.available)
+
+    assert _station_status(cp) == ChargePointStatusv16.available.value

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -219,7 +219,9 @@ async def test_status_buffered_during_refetch_is_drained_when_it_times_out(hass)
         connector_id=2,
     )
     assert cp._pending_status_notifications == []
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Occupied"
+    # The per-connector metric speaks the OCPP 1.6 vocabulary, as the
+    # charging-station-level one already did: Occupied maps to Preparing.
+    assert cp._metrics[(1, cstat.status_connector.value)].value == "Preparing"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #2034.

Per your steer on the issue — reusing the translation that already exists in `on_transaction_event` rather than adding 2.0.1 statuses to `metric_condition`.

## Please read first: this changes a user-visible sensor value

On OCPP 2.0.1 the `Status Connector` sensor no longer reports `Occupied`. It reports `Preparing`, which is what an OCPP 1.6 charger reports in the same physical state, and `Charging` / `SuspendedEV` / `SuspendedEVSE` during a transaction.

That is the point of the fix — the whole bug is that the per-connector metric spoke a vocabulary no entity in `switch.py` can match — but it will silently stop any existing 2.0.1 automation matching `Occupied`. `docs/user-guide.md` is updated to describe the normalisation. Flagging it up front so you can weigh it; happy to scope it back if you would rather.

## The problem

`switch.charge_control` is `per_connector`, so it reads the per-connector `status_connector` metric, but its `metric_condition` is `[Charging, SuspendedEVSE, SuspendedEV]`. On 2.0.1 that metric held the raw `ConnectorStatusEnumType`, which can never be any of those, so the switch read `off` for the whole of every charge. Only the charging-station-level metric was translated.

## The fix

A shared helper maps a 2.0.1 connector status onto the 1.6 vocabulary, and `TransactionEvent`'s `chargingState` is now recorded against the transaction's connector as well as the station — `StatusNotification` reports *occupancy*, not charging state, so `Charging` and the suspended states can only arrive that way.

**Occupancy alone must not erase a charging state.** This was the subtle half. `Occupied` is less specific than `Charging`, and `trigger_status_notification()` provokes exactly that message on every reconnect. Without precedence, a reconnect mid-charge turned the switch off until the charging state next changed — often the end of the session, because periodic transaction events carry `chargingState` only when it *changes*. While a transaction is live on the connector, `Occupied` no longer displaces `Charging` or a suspended state. The hold is keyed on `_tx_start_time`, which existing code already maintains, so it lifts when the transaction ends and nothing can stick.

Two smaller points fell out of the same work:

- **`Idle` is not propagated to the connector.** It means no session, not an empty connector, and its `Available` would contradict the occupancy `StatusNotification` owns while `_connector_status` still held `Occupied`.
- **The new write repeats the degenerate-id guard** `_apply_status_notification` already applies. Without it a `TransactionEvent` carrying `connectorId: 0` — input the sibling writer refuses by design — would have `_pair_to_global` allocate a phantom connector, write the charging state to it, and leave the real connector empty.

## Side effects worth knowing

- **`switch.connnector_availability` is repaired too**, though narrowly: it is `per_connector` with the same class of condition list, and a raw `Occupied` matched nothing, so an occupied connector read as inoperative. Its other values were already spelled the same in both vocabularies, so only `Occupied` changes.
- **`Reserved` now maps to `Reserved`** in the EVSE aggregate rather than falling through to `Preparing`. Handling it deliberately was necessary rather than optional — `Reserved` is spelled identically in both enums and currently matches by coincidence, so a naive translation would have introduced a regression.
- **The charger-level `Status` metric is deliberately left raw.** Its only consumer matches `Available`, spelled the same in both vocabularies, and translating it would widen the user-visible change for no benefit. Noted in the code so it does not read as an oversight.

## Tests

`tests/test_v201_connector_charge_state.py` asserts against `switch.py`'s own `metric_condition` lists rather than string literals, so the tests fail if either side of that contract moves:

- each charging state reaches the connector, and satisfies Charge Control
- a raw 2.0.1 status never reaches the metric
- **a charge survives a reconnect status notification** — the switch stays on
- the hold lifts once the transaction ends
- `Occupied` still applies when it is an update rather than a downgrade
- `Idle` does not free an occupied connector
- a degenerate connector id is not written
- every connector status maps into the 1.6 vocabulary, station and connector

Four existing expectations updated, each with a comment: three assertions and a busy-wait loop that would otherwise have hung rather than failed.

Mutation-checked: removing the translation, the connector write, the downgrade guard, the idle exclusion, or the id guard each fails specific tests. Full suite passes (196) and `pre-commit run --all-files` is clean.

## Reported by

Found on a FoxESS A022KP1. During a live 2.0.1 transaction the charger sent `TransactionEvent` with `chargingState: Charging` and `sensor.<cpid>_status_connector` correctly read `Charging`, while `switch.<cpid>_charge_control` stayed `off` for the entire session and its `last_updated` never advanced. Pressing it again sent a duplicate `RequestStartTransaction`, which the charger answered `{"status":"Rejected","transactionId":...}` — meaning *already running*, though it reads like a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized OCPP 2.0.1 charging and connector statuses to familiar OCPP 1.6-compatible values.
  * Preserved active charging states during reconnects and updates from multiple EVSEs.
  * Improved handling of station-level, malformed, idle, and invalid connector status updates.
  * Ensured connector and station metrics accurately reflect charging activity, occupancy, faults, and completed transactions.

* **Documentation**
  * Updated status documentation with normalized values and automation compatibility across protocols.
  * Improved debugging documentation with clearer code block formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->