### PR TITLE
Report what set_charge_rate actually did on OCPP 2.0.1

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -37,6 +37,7 @@ from ocpp.v201.enums import (
     ChargingRateUnitEnumType,
     ChargingProfileKindEnumType,
     ChargingProfileStatusEnumType,
+    ClearChargingProfileStatusEnumType,
 )
 
 from .chargepoint import (
@@ -634,15 +635,25 @@ class ChargePoint(cp):
                 )
                 await self.call(req)
 
-    async def clear_profile(self):
-        """Clear all charging profiles."""
+    async def clear_profile(self) -> bool:
+        """Clear all charging profiles.
+
+        Returns True when the charger accepted, or reported it had nothing to
+        clear - Unknown means the end state we wanted already holds. Mirrors
+        ocppv16.clear_profile, and lets set_charge_rate avoid claiming success
+        for a clear the charger refused.
+        """
         req: call.ClearChargingProfile = call.ClearChargingProfile(
             None,
             {
                 "charging_profile_purpose": ChargingProfilePurposeEnumType.charging_station_max_profile.value
             },
         )
-        await self.call(req)
+        resp: call_result.ClearChargingProfile = await self.call(req)
+        return resp.status in (
+            ClearChargingProfileStatusEnumType.accepted,
+            ClearChargingProfileStatusEnumType.unknown,
+        )
 
     async def set_charge_rate(
         self,
@@ -650,11 +661,18 @@ class ChargePoint(cp):
         limit_watts: int | None = None,
         conn_id: int = 0,
         profile: dict | None = None,
-    ):
+    ) -> bool:
         """Set a charging profile with defined limit (OCPP 2.x).
 
         - conn_id=0 (default) targets the Charging Station (evse_id=0).
         - conn_id>0 targets the specific EVSE corresponding to the global connector index.
+
+        Returns whether the charger honoured the request. Callers treat the
+        result as a success flag - number.py logs a rejection when it is
+        falsy - so a path that succeeded must say so, and one that cleared a
+        profile must report what the charger made of that rather than assume.
+        A refused SetChargingProfile still raises HomeAssistantError, which
+        carries the charger's own status message.
         """
 
         evse_target = 0
@@ -672,27 +690,31 @@ class ChargePoint(cp):
                         "message": f"{str(resp.status)}: {str(resp.status_info)}"
                     },
                 )
-            return
+            return True
 
+        # Removing the limit is a successful outcome too: a request at or above
+        # the maximum means "no restriction", not a failure to apply one. The
+        # amp threshold has to be the configured maximum rather than a literal
+        # 32, because that is what bounds number.<cpid>_maximum_current - with
+        # a higher max_current every request in between was turned into a bare
+        # profile clear, so the charger ran unrestricted while the slider
+        # showed the figure the user had asked for.
         if limit_watts is not None:
             if float(limit_watts) >= 22000:
-                await self.clear_profile()
-                return
+                return await self.clear_profile()
             period_limit = int(limit_watts)
             unit_value = ChargingRateUnitEnumType.watts.value
 
         elif limit_amps is not None:
-            if float(limit_amps) >= 32:
-                await self.clear_profile()
-                return
+            if float(limit_amps) >= float(self.settings.max_current):
+                return await self.clear_profile()
             period_limit = (
                 int(limit_amps) if float(limit_amps).is_integer() else float(limit_amps)
             )
             unit_value = ChargingRateUnitEnumType.amps.value
 
         else:
-            await self.clear_profile()
-            return
+            return await self.clear_profile()
 
         schedule: dict = {
             "id": 1,
@@ -720,6 +742,7 @@ class ChargePoint(cp):
                     "message": f"{str(resp.status)}: {str(resp.status_info)}"
                 },
             )
+        return True
 
     async def set_availability(self, state: bool = True, connector_id: int | None = 0):
         """Change availability."""

--- a/tests/test_v201_set_charge_rate_return.py
+++ b/tests/test_v201_set_charge_rate_return.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 from ocpp.v201.enums import (
+    ChargingProfilePurposeEnumType,
     ChargingProfileStatusEnumType,
     ClearChargingProfileStatusEnumType,
 )
@@ -121,11 +122,21 @@ async def test_an_explicit_profile_reports_success(hass):
     ],
 )
 async def test_clearing_the_limit_reports_success(hass, kwargs):
-    """Removing a limit is a successful outcome, not a failure to apply one."""
+    """Removing a limit is a successful outcome, not a failure to apply one.
+
+    The clear also has to stay scoped to the profile this integration owns.
+    Now that every request at or above max_current reaches it, an unfiltered
+    ClearChargingProfile would take TxProfile and TxDefaultProfile entries
+    installed by the charger or another system down with it.
+    """
     cp = _mk_cp(hass)
 
     assert await cp.set_charge_rate(**kwargs) is True
     assert _sent(cp) == ["ClearChargingProfile"]
+    assert cp.sent[0].charging_profile_id is None
+    assert cp.sent[0].charging_profile_criteria == {
+        "charging_profile_purpose": ChargingProfilePurposeEnumType.charging_station_max_profile.value
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_v201_set_charge_rate_return.py
+++ b/tests/test_v201_set_charge_rate_return.py
@@ -1,0 +1,192 @@
+"""set_charge_rate must report what the charger actually did, on OCPP 2.0.1.
+
+Every exit path returned None, while the OCPP 1.6 implementation returns
+True/False and api.set_max_charge_rate_amps passes that straight through.
+number.py treats a falsy result as a rejection, so every successful current
+change logged "Set current limit rejected by CP" even though the charger had
+accepted the profile - and a real rejection was indistinguishable from it.
+
+Reporting success is only half of it: a path that clears the profile has to
+report what the charger made of the clear, and the threshold for clearing has
+to be the configured maximum rather than a literal 32, or every request in
+between silently applies no limit at all.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+from ocpp.v201.enums import (
+    ChargingProfileStatusEnumType,
+    ClearChargingProfileStatusEnumType,
+)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.ocppv201 import ChargePoint
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _mk_cp(hass, status=ChargingProfileStatusEnumType.accepted, max_current=32):
+    """Build a v201 ChargePoint whose charger answers with `status`."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=max_current,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    cp.sent = []
+
+    async def record(req):
+        cp.sent.append(req)
+        return SimpleNamespace(status=status, status_info="charger said no")
+
+    cp.call = record
+    return cp
+
+
+def _sent(cp):
+    """Return the request types sent, so 'applied' and 'cleared' are distinct."""
+    return [type(r).__name__ for r in cp.sent]
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_amp_limit_reports_success(hass):
+    """The common case: number.py must not log a rejection for this."""
+    cp = _mk_cp(hass)
+
+    assert await cp.set_charge_rate(limit_amps=16) is True
+    assert _sent(cp) == ["SetChargingProfile"]
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_watt_limit_reports_success(hass):
+    """The watt path shares the same exit."""
+    cp = _mk_cp(hass)
+
+    assert await cp.set_charge_rate(limit_watts=5000) is True
+    assert _sent(cp) == ["SetChargingProfile"]
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_profile_reports_success(hass):
+    """A caller-supplied profile returns through its own exit."""
+    cp = _mk_cp(hass)
+
+    assert await cp.set_charge_rate(profile={"id": 1}) is True
+    assert _sent(cp) == ["SetChargingProfile"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"limit_amps": 32},  # at the configured maximum
+        {"limit_watts": 22000},  # at the maximum
+        {},  # no limit given at all
+    ],
+)
+async def test_clearing_the_limit_reports_success(hass, kwargs):
+    """Removing a limit is a successful outcome, not a failure to apply one."""
+    cp = _mk_cp(hass)
+
+    assert await cp.set_charge_rate(**kwargs) is True
+    assert _sent(cp) == ["ClearChargingProfile"]
+
+
+@pytest.mark.asyncio
+async def test_a_limit_below_a_raised_maximum_is_applied_not_cleared(hass):
+    """The clear threshold has to follow the configured maximum.
+
+    number.<cpid>_maximum_current is bounded by max_current, which the config
+    flow accepts as an unbounded int. Against a literal 32 every request in
+    the 32..max_current band became a bare profile clear: the charger ran
+    unrestricted while the slider showed the figure the user had asked for.
+    """
+    cp = _mk_cp(hass, max_current=63)
+
+    assert await cp.set_charge_rate(limit_amps=40) is True
+    assert _sent(cp) == ["SetChargingProfile"]
+
+
+@pytest.mark.asyncio
+async def test_a_request_at_a_raised_maximum_still_clears(hass):
+    """At the maximum the request genuinely means "no restriction"."""
+    cp = _mk_cp(hass, max_current=63)
+
+    assert await cp.set_charge_rate(limit_amps=63) is True
+    assert _sent(cp) == ["ClearChargingProfile"]
+
+
+@pytest.mark.asyncio
+async def test_a_refused_clear_is_not_reported_as_success(hass):
+    """Clearing is a request like any other, and can be refused."""
+    cp = _mk_cp(hass, status=ChargingProfileStatusEnumType.rejected)
+
+    assert await cp.set_charge_rate(limit_amps=32) is False
+    assert _sent(cp) == ["ClearChargingProfile"]
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_clear_counts_as_success(hass):
+    """Unknown means no such profile, which is the end state we wanted."""
+    cp = _mk_cp(hass, status=ClearChargingProfileStatusEnumType.unknown)
+
+    assert await cp.set_charge_rate(limit_amps=32) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"limit_amps": 16},  # the built-profile path
+        {"profile": {"id": 1}},  # the caller-supplied path
+    ],
+)
+async def test_a_rejected_profile_still_raises(hass, kwargs):
+    """A refusal must keep surfacing the charger's own status message.
+
+    number.py catches this and warns; converting it to a False return would
+    lose the reason the charger gave, which is the whole argument for raising
+    here rather than returning False.
+    """
+    cp = _mk_cp(hass, status=ChargingProfileStatusEnumType.rejected)
+
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await cp.set_charge_rate(**kwargs)
+
+    assert "charger said no" in str(excinfo.value.translation_placeholders)


### PR DESCRIPTION
Fixes #2040.

## The reported problem

Every exit path in `set_charge_rate` returned `None`, while the OCPP 1.6 implementation returns `True`/`False` and `CentralSystem.set_max_charge_rate_amps` passes that result straight through. `number.py` treats a falsy result as a rejection, so **every successful current change logged `Set current limit rejected by CP`** even though the charger had accepted the profile — and a genuine rejection was indistinguishable from a success.

## Two things found while fixing it

Reporting success turned out to be only half of it, and both of these are worth more than the original symptom.

**`clear_profile` discarded the charger's response.** The three paths that clear a profile could not know whether it had been honoured, so a charger answering `Rejected` still produced a confident success. It now returns whether the charger accepted, treating `Unknown` as success because that means there was no such profile and the end state we wanted already holds — mirroring `ocppv16.clear_profile`. `set_charge_rate` propagates it instead of assuming.

**The threshold for clearing rather than limiting was a literal `32`.** But `number.<cpid>_maximum_current` is bounded by the configured `max_current`, which the config flow accepts as an unbounded `int`. On a charger configured higher, every request in the `32..max_current` band became a bare `ClearChargingProfile`:

```
max_current=63, user asks for 40 A
  before:  sent ClearChargingProfile   - no limit applied, charger unrestricted
  after:   sent SetChargingProfile     - the requested 40 A limit is applied
```

The optimistic slider went on showing 40 A the whole time. It now compares against `max_current`, so the band works rather than silently doing nothing.

A refused `SetChargingProfile` still raises `HomeAssistantError`, which carries the charger's own status message — `number.py` surfaces that through its exception handler, and returning `False` instead would lose the reason.

## Deliberately not included

The 1.6 path returns `False` when `SMART` is absent from `supported_features` (`ocppv16.py:433-435`) and 2.0.1 has no equivalent. I have **not** added it, because #2035 means SMART is currently not detected for chargers that omit `SmartChargingCtrlr/Available` — adding the guard now would make `set_charge_rate` refuse outright on exactly that hardware, turning a working feature off. It belongs after #2035, not before.

## Tests

`tests/test_v201_set_charge_rate_return.py` asserts the request type sent, not just the return value, so "applied a limit" and "silently cleared it" are distinguishable:

- each accepted path reports success and sends `SetChargingProfile`
- clearing at the maximum reports success and sends `ClearChargingProfile`
- a limit below a raised maximum is **applied**, not cleared
- a request at a raised maximum still clears
- a refused clear is not reported as success
- `Unknown` counts as success
- a rejected profile raises, on both the built and caller-supplied paths, and the charger's message survives

Mutation-checked: restoring the literal `32` fails one, ignoring the clear status fails one, reverting to bare returns fails eleven. Full suite passes (215) and `pre-commit run --all-files` is clean.

## Reported by

Found on a FoxESS A022KP1 while working through #2038 — that PR makes the max-current entity available to more users, which is what brought the bogus warning to the surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for clearing station-level charging profiles.
  * Charging-rate updates now report whether the requested limit was applied successfully.
  * Removing charging limits now uses the configured maximum current.

* **Bug Fixes**
  * Improved handling of accepted, unknown, and refused profile-clear responses.
  * Rejected charging profiles now correctly surface errors.

* **Tests**
  * Added coverage for current-, power-, and explicit-profile charging requests and clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->