### PR TITLE
Probe for smart charging when the charger omits Available on OCPP 2.0.1

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -70,7 +70,11 @@ class InventoryReport:
 
     evse_count: int = 0
     connector_count: list[int] = field(default_factory=list)
-    smart_charging_available: bool = False
+    # None means the charger never reported SmartChargingCtrlr/Available.
+    # The variable is optional in OCPP 2.0.1, so its absence is "unknown"
+    # rather than "no" - the two are told apart here so that only the
+    # unknown case is resolved by probing. An explicit false stands.
+    smart_charging_available: bool | None = None
     reservation_available: bool = False
     local_auth_available: bool = False
     tx_updated_measurands: list[MeasurandEnumType] = field(default_factory=list)
@@ -597,6 +601,29 @@ class ChargePoint(cp):
         if self.settings.force_smart_charging:
             _LOGGER.warning("Force Smart Charging feature profile")
             features |= Profiles.SMART
+
+        # SmartChargingCtrlr/Available is optional, so a charger can implement
+        # smart charging and never advertise it - the FoxESS A-series reports
+        # ProfileStackLevel, RateUnit and PeriodsPerSchedule but no Available.
+        # Absence is not a denial, so resolve it by asking. GetCompositeSchedule
+        # is read-only, unlike SetChargingProfile, which would mutate charger
+        # state on every connect. Any answer at all proves the message is
+        # implemented: Rejected is a legitimate reply to a schedule request the
+        # charger cannot compute, and says nothing about support. Only a
+        # CallError, which is how an unimplemented message comes back, denies it.
+        if (Profiles.SMART not in features) and (
+            self._inventory is None or self._inventory.smart_charging_available is None
+        ):
+            schedule_req = call.GetCompositeSchedule(60, 0)
+            try:
+                await self.call(schedule_req)
+                features |= Profiles.SMART
+            except OCPPError as e:
+                _LOGGER.info("Smart charging not supported: %s", e)
+            except TimeoutError:
+                _LOGGER.warning(
+                    "No response to GetCompositeSchedule probe, assuming no SMART"
+                )
 
         fw_req = call.UpdateFirmware(
             1,

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -606,11 +606,19 @@ class ChargePoint(cp):
                 "signature": "☺",
             },
         )
+        # A probe that goes unanswered has to cost only its own profile. The
+        # ocpp library raises asyncio.TimeoutError rather than an OCPPError
+        # when a charger never replies, so catching OCPPError alone let that
+        # escape get_supported_features, past the assignment in
+        # fetch_supported_features, into post_connect's bare handler - leaving
+        # every profile off, including SMART, and no feature metric at all.
         try:
             await self.call(fw_req)
             features |= Profiles.FW
         except OCPPError as e:
             _LOGGER.info("Firmware update not supported: %s", e)
+        except TimeoutError:
+            _LOGGER.warning("No response to UpdateFirmware probe, assuming no FW")
 
         trigger_req = call.TriggerMessage("StatusNotification")
         try:
@@ -618,6 +626,8 @@ class ChargePoint(cp):
             features |= Profiles.REM
         except OCPPError as e:
             _LOGGER.info("TriggerMessage not supported: %s", e)
+        except TimeoutError:
+            _LOGGER.warning("No response to TriggerMessage probe, assuming no REM")
 
         return features
 

--- a/tests/test_v201_probe_timeout.py
+++ b/tests/test_v201_probe_timeout.py
@@ -1,0 +1,227 @@
+"""A capability probe that goes unanswered must cost only its own profile.
+
+get_supported_features probes the charger with UpdateFirmware and
+TriggerMessage. The ocpp library raises asyncio.TimeoutError - not an
+OCPPError - when a charger accepts the call and then never replies, so
+catching OCPPError alone let the timeout escape get_supported_features and
+skip the assignment in fetch_supported_features. post_connect swallowed it
+at DEBUG, so a charger that ignored one optional probe ended up with no
+feature profiles at all and no feature metric, after a silent 10s stall.
+
+SMART is the consequence that bites: without it number.<cpid>_maximum_current
+is never created, so charge current cannot be set.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from ocpp.exceptions import OCPPError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.exceptions import ConnectionClosedError
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import HAChargerDetails as cdet
+from custom_components.ocpp.enums import Profiles
+from custom_components.ocpp.ocppv201 import ChargePoint, InventoryReport
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+# What ocpp.charge_point.ChargePoint.call raises when a charger accepts the
+# request and never answers it. The library names it asyncio.TimeoutError,
+# which has been an alias of the builtin since Python 3.11.
+_TIMEOUT = TimeoutError("Waited 10s for response on ...")
+
+
+def _mk_cp(hass, stalls_on=(), raises=None):
+    """Build a v201 ChargePoint whose charger stalls on the named probes.
+
+    `stalls_on` holds request class names that never get a reply; `raises`
+    replaces the timeout with another exception, to check the handler is not
+    wider than it should be.
+    """
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    # Seeding the inventory short-circuits _get_inventory, so the only calls
+    # made are the two capability probes. SMART and AUTH come from the report,
+    # and are what a probe timeout used to take down with it.
+    cp._inventory = InventoryReport(
+        evse_count=1,
+        connector_count=[1],
+        smart_charging_available=True,
+        local_auth_available=True,
+    )
+
+    async def answer(req):
+        if type(req).__name__ in stalls_on:
+            raise raises if raises is not None else _TIMEOUT
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = answer
+    return cp
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_firmware_probe_costs_only_that_profile(hass):
+    """FW is the probed capability, so FW is all that may be lost."""
+    cp = _mk_cp(hass, stalls_on=["UpdateFirmware"])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.FW not in features
+    assert Profiles.REM in features
+    assert Profiles.SMART in features
+    assert Profiles.AUTH in features
+    assert Profiles.CORE in features
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_trigger_probe_costs_only_that_profile(hass):
+    """The second probe has to be independent of the first."""
+    cp = _mk_cp(hass, stalls_on=["TriggerMessage"])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.REM not in features
+    assert Profiles.FW in features
+    assert Profiles.SMART in features
+
+
+@pytest.mark.asyncio
+async def test_both_probes_stalling_still_yields_the_detected_profiles(hass):
+    """A charger answering neither probe keeps what the report established."""
+    cp = _mk_cp(hass, stalls_on=["UpdateFirmware", "TriggerMessage"])
+
+    features = await cp.get_supported_features()
+
+    assert features == Profiles.CORE | Profiles.SMART | Profiles.AUTH
+
+
+@pytest.mark.asyncio
+async def test_the_feature_metric_is_still_written(hass):
+    """The user-visible damage was here, not in get_supported_features.
+
+    The exception escaped before the assignment in fetch_supported_features,
+    so sensor.<cpid>_features stayed empty and _attr_supported_features stayed
+    NONE - and post_connect logged it at DEBUG, so nothing said why.
+    """
+    cp = _mk_cp(hass, stalls_on=["UpdateFirmware"])
+
+    await cp.fetch_supported_features()
+
+    assert cp._attr_supported_features == cp._metrics[(0, cdet.features.value)].value
+    assert Profiles.SMART in cp._attr_supported_features
+
+
+@pytest.mark.asyncio
+async def test_post_connect_is_not_aborted_by_a_stalled_probe(hass):
+    """post_connect must get past features to the rest of its setup.
+
+    It catches Exception and logs at DEBUG, so an escaping timeout left the
+    connector count uninitialised too - visible as missing connector entities
+    rather than as an error.
+    """
+    cp = _mk_cp(hass, stalls_on=["UpdateFirmware"])
+
+    await cp.post_connect()
+
+    assert cp.post_connect_success is True
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_is_still_handled(hass):
+    """Control: a charger that answers "not supported" behaved correctly.
+
+    This is the path that already worked, and the new handler must not be
+    reached for it - a refusal is a definite no, not a stall.
+    """
+    cp = _mk_cp(hass, stalls_on=["UpdateFirmware"], raises=OCPPError("not supported"))
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.FW not in features
+    assert Profiles.REM in features
+
+
+@pytest.mark.asyncio
+async def test_a_stall_is_logged_louder_than_a_refusal(hass, caplog):
+    """Silence was half the bug: 10s of nothing, then a DEBUG line.
+
+    A refusal is a definite answer and stays at INFO. A stall is a different
+    event - the charger is unwell, or the probe is unsupported in a way it
+    will not admit to - and the dropped profile has real consequences, so it
+    warrants a warning that names what was lost.
+    """
+    cp = _mk_cp(hass, stalls_on=["UpdateFirmware"])
+
+    with caplog.at_level("INFO", logger="custom_components.ocpp"):
+        await cp.get_supported_features()
+
+    stalls = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(stalls) == 1
+    assert "UpdateFirmware" in stalls[0].getMessage()
+
+    caplog.clear()
+    refusing = _mk_cp(
+        hass, stalls_on=["UpdateFirmware"], raises=OCPPError("not supported")
+    )
+
+    with caplog.at_level("INFO", logger="custom_components.ocpp"):
+        await refusing.get_supported_features()
+
+    assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+@pytest.mark.asyncio
+async def test_a_closed_connection_still_propagates(hass):
+    """The handler is widened for stalls only, deliberately.
+
+    A dropped websocket means every later call fails too, so there is nothing
+    to be gained by carrying on and recording a feature set derived from a
+    charger that has gone. Pinning this keeps the fix from being generalised
+    into a bare except that would hide it.
+    """
+    cp = _mk_cp(
+        hass,
+        stalls_on=["UpdateFirmware"],
+        raises=ConnectionClosedError(None, None),
+    )
+
+    with pytest.raises(ConnectionClosedError):
+        await cp.get_supported_features()

--- a/tests/test_v201_smart_charging_probe.py
+++ b/tests/test_v201_smart_charging_probe.py
@@ -1,0 +1,279 @@
+"""SmartCharging detection when the charger omits the optional Available flag.
+
+SmartChargingCtrlr/Available is optional in OCPP 2.0.1. Treating its absence
+as a denial dropped the SMART profile for chargers that plainly do implement
+smart charging - the FoxESS A-series reports ProfileStackLevel, RateUnit and
+PeriodsPerSchedule, and no Available - which in turn leaves
+number.<cpid>_maximum_current uncreated, so charge current cannot be set.
+
+Absence means unknown, so it is resolved by asking: GetCompositeSchedule is
+read-only, where SetChargingProfile would mutate charger state on every
+connect. An explicit false is a definite answer and is left alone.
+
+Reservation is deliberately untouched: ReservationCtrlr is absent from such a
+report entirely rather than merely missing Available, there is no read-only
+probe for it (ReserveNow would create a reservation), and an absent component
+is fair evidence the feature is genuinely unsupported.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from ocpp.exceptions import NotSupportedError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import Profiles
+from custom_components.ocpp.ocppv201 import ChargePoint, InventoryReport
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _mk_cp(hass, force_smart_charging=False, refuses=(), answers=None):
+    """Build a v201 ChargePoint with a scriptable charger.
+
+    `refuses` holds request class names answered with a CallError, as an
+    unimplemented message comes back; `answers` overrides the reply for a
+    named request, to check a non-Accepted status still counts.
+    """
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=force_smart_charging,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    cp = ChargePoint("CP_A", conn, hass, entry, central, charger)
+    cp.sent = []
+
+    async def answer(req):
+        name = type(req).__name__
+        cp.sent.append(req)
+        if name in refuses:
+            raise NotSupportedError("not implemented")
+        if answers and name in answers:
+            return answers[name]
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = answer
+    return cp
+
+
+def _sent(cp):
+    """Return the request types sent, so the probe is visible."""
+    return [type(r).__name__ for r in cp.sent]
+
+
+@pytest.mark.asyncio
+async def test_an_unreported_flag_is_resolved_by_probing(hass):
+    """The reported case: the component is there, Available is not."""
+    cp = _mk_cp(hass)
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+    assert "GetCompositeSchedule" in _sent(cp)
+
+
+@pytest.mark.asyncio
+async def test_a_charger_refusing_the_probe_gets_no_smart(hass):
+    """Control: the probe has to be capable of saying no.
+
+    Without this the test above would pass even if SMART were simply assumed
+    whenever the flag was absent - which is the behaviour rejected on #2035.
+    """
+    cp = _mk_cp(hass, refuses=["GetCompositeSchedule"])
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART not in features
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_schedule_still_proves_support(hass):
+    """Rejected answers the schedule request, not the question of support.
+
+    A charger may legitimately decline to compute a schedule - no profile
+    installed, or no grid-connection total for evseId 0 - while implementing
+    smart charging perfectly well. Only a CallError denies the message.
+    """
+    cp = _mk_cp(
+        hass,
+        answers={"GetCompositeSchedule": SimpleNamespace(status="Rejected")},
+    )
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_false_is_respected_without_probing(hass):
+    """A charger that says no has answered; do not talk over it."""
+    cp = _mk_cp(hass)
+    cp._inventory = InventoryReport(
+        evse_count=1, connector_count=[1], smart_charging_available=False
+    )
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART not in features
+    assert "GetCompositeSchedule" not in _sent(cp)
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_true_is_taken_without_probing(hass):
+    """Detection that already worked must not gain a round trip."""
+    cp = _mk_cp(hass)
+    cp._inventory = InventoryReport(
+        evse_count=1, connector_count=[1], smart_charging_available=True
+    )
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+    assert "GetCompositeSchedule" not in _sent(cp)
+
+
+@pytest.mark.asyncio
+async def test_the_override_still_skips_the_probe(hass):
+    """force_smart_charging already settles it, so asking is wasted."""
+    cp = _mk_cp(hass, force_smart_charging=True)
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+    assert "GetCompositeSchedule" not in _sent(cp)
+
+
+@pytest.mark.asyncio
+async def test_the_override_still_rescues_a_charger_refusing_the_probe(hass):
+    """The escape hatch has to outrank a probe that says no."""
+    cp = _mk_cp(hass, force_smart_charging=True, refuses=["GetCompositeSchedule"])
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_probe_costs_only_smart(hass):
+    """Consistent with the other two probes: a stall drops its own profile.
+
+    This probe is added after the timeout handling in #2039, so it must not
+    reintroduce the escape that fix closed.
+    """
+    cp = _mk_cp(hass)
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    async def stall(req):
+        cp.sent.append(req)
+        if type(req).__name__ == "GetCompositeSchedule":
+            raise TimeoutError("Waited 10s for response on ...")
+        return SimpleNamespace(status="Accepted")
+
+    cp.call = stall
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART not in features
+    assert Profiles.FW in features
+    assert Profiles.REM in features
+
+
+@pytest.mark.asyncio
+async def test_a_missing_inventory_is_still_probed(hass):
+    """No report at all is the same kind of unknown, not a denial."""
+    cp = _mk_cp(hass)
+    cp._inventory = None
+    cp._wait_inventory = asyncio.Event()
+    cp._wait_inventory.set()
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART in features
+
+
+@pytest.mark.asyncio
+async def test_reservation_is_left_alone(hass):
+    """RES stays keyed on the flag: no probe, and no assumption either.
+
+    ReservationCtrlr is absent from these reports entirely, and there is no
+    read-only way to test for it. Scoped this way on #2035.
+    """
+    cp = _mk_cp(hass)
+    cp._inventory = InventoryReport(evse_count=1, connector_count=[1])
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.RES not in features
+    assert "ReserveNow" not in _sent(cp)
+
+
+@pytest.mark.asyncio
+async def test_detection_from_a_real_report_still_short_circuits(hass):
+    """Drive the actual parser, so the tri-state does not rot.
+
+    smart_charging_available carries three states now. A regression that made
+    the parser leave it None on an explicit "false" would be invisible above,
+    because the probe would then answer and SMART would appear anyway.
+    """
+    cp = _mk_cp(hass)
+    cp._inventory = None
+    cp._wait_inventory = asyncio.Event()
+
+    cp.on_report(
+        1,
+        "2026-01-01T00:00:00Z",
+        0,
+        report_data=[
+            {
+                "component": {"name": "SmartChargingCtrlr"},
+                "variable": {"name": "Available"},
+                "variable_attribute": [{"value": "false"}],
+            }
+        ],
+    )
+
+    assert cp._inventory.smart_charging_available is False
+
+    features = await cp.get_supported_features()
+
+    assert Profiles.SMART not in features
+    assert "GetCompositeSchedule" not in _sent(cp)


### PR DESCRIPTION
Closes #2035, scoped to SmartCharging only per your call on the issue.

> I'd simply go with 1, the reservation feature is very rarely used

**This is stacked on #2045** (the `asyncio.TimeoutError` fix for #2039) and will show that commit until it merges — happy to rebase onto `main` the moment it does. The reason for stacking rather than branching from `main`: this PR adds a *third* capability probe, and without #2045 an unanswered one takes the whole feature set down with it. Landing them the other way round would mean knowingly shipping a probe with that hole in it.

## The change

`SmartChargingCtrlr/Available` is optional, so absence is *unknown*, not *no*. The flag becomes tri-state so the two can be told apart, and only the unknown case is resolved by probing with `GetCompositeSchedule` — read-only, where `SetChargingProfile` would mutate charger state on every connect, as agreed on the issue.

An explicit `false` is a definite answer and is left alone, with no probe sent. So is an explicit `true`, and so is `force_smart_charging` — none of them gain a round trip.

## Any answer counts, not just Accepted

`Rejected` is a legitimate reply to a schedule request the charger cannot compute — no profile installed, or no grid-connection total for `evseId 0` — and says nothing about whether smart charging is implemented. Only a `CallError`, which is how an unimplemented message comes back, denies it. This also matches how the existing `UpdateFirmware` and `TriggerMessage` probes read their results.

## Reservation deliberately untouched

`ReservationCtrlr` is absent from these reports **entirely**, rather than present-but-missing `Available`, so there is nothing to resolve. There is no read-only probe for it either — `ReserveNow` would create a reservation. A test pins RES to the flag so this doesn't get quietly generalised later.

## Testing

11 tests in `tests/test_v201_smart_charging_probe.py`; 234 pass overall.

Verified by mutation — each of these fails the tests that should catch it:

| Mutation | Tests failed |
|---|---|
| tri-state collapsed back to `bool` (absence == no) | 2 |
| assume available when absent — the option you rejected | 3 |
| require `Accepted` rather than any answer | 1 |
| probe on an explicit `false` too | 2 |
| guard dropped, probe unconditionally | 4 |

## Caveat

Not yet confirmed against hardware: I know my FoxESS omits `Available`, but I haven't yet checked that it *answers* `GetCompositeSchedule`. I can put this build on the live charger and report back before you merge, if you'd rather wait for that — the whole point is that it fixes a charger I can actually test on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart-charging capability detection when charger information is unavailable or explicitly reports unsupported.
  * Prevented firmware and remote-status probe timeouts from interrupting connection setup or removing unrelated capabilities.
  * Improved handling and logging of capability probe timeouts, refusals, and closed connections.

* **Tests**
  * Added comprehensive coverage for smart-charging detection and capability probe timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->