### PR TITLE
Add an options flow so charge point settings can be edited

### DIFF
--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -303,11 +303,21 @@ class OCPPOptionsFlow(OptionsFlow):
                 points[cp_id] = settings
         return points
 
-    def _finalize(self, settings: dict[str, Any]) -> ConfigFlowResult:
-        """Write the edited charge point back into the entry."""
+    def _finalize(self) -> ConfigFlowResult:
+        """Overlay the edited fields onto the charge point and write it back.
+
+        The overlay reads the entry as it is now, not as it was when the
+        first form was submitted: while the user sits on the measurands
+        form, a reconnecting charger's post_connect can update the entry
+        (connector count, detected measurands), and writing back a snapshot
+        taken earlier would erase that. Only the fields the user actually
+        edited are replaced.
+        """
         cpids = [
             {
-                cp_id: (settings if cp_id == self._cp_id else stored)
+                cp_id: (
+                    {**stored, **self._settings} if cp_id == self._cp_id else stored
+                )
                 for cp_id, stored in item.items()
             }
             for item in self.config_entry.data.get(CONF_CPIDS, [])
@@ -351,16 +361,16 @@ class OCPPOptionsFlow(OptionsFlow):
         current = self._charge_points()[self._cp_id]
 
         if user_input is not None:
-            # cpid, the connector count and the measurand list ride along
-            # unchanged; only what the form shows is replaced. In particular
-            # the stored measurand list is NOT reseeded when autoconfig is
-            # left on - it holds what detection accepted, and re-detection
-            # refreshes it on the next connect anyway, so rewriting it here
-            # would create sensors for every measurand as a side effect of
+            # Hold only what the form edited; _finalize overlays it onto the
+            # stored record. cpid, the connector count and the measurand
+            # list are untouched by construction - in particular the
+            # measurand list is NOT reseeded when autoconfig is left on: it
+            # holds what detection accepted, and rewriting it here would
+            # create sensors for every measurand as a side effect of
             # editing an unrelated setting.
-            self._settings = {**current, **user_input}
+            self._settings = dict(user_input)
             if user_input[CONF_MONITORED_VARIABLES_AUTOCONFIG]:
-                return self._finalize(self._settings)
+                return self._finalize()
             return await self.async_step_measurands()
 
         schema = vol.Schema(
@@ -417,7 +427,7 @@ class OCPPOptionsFlow(OptionsFlow):
             selected = [m for m, value in user_input.items() if value]
             if selected:
                 self._settings[CONF_MONITORED_VARIABLES] = ",".join(selected)
-                return self._finalize(self._settings)
+                return self._finalize()
             errors["base"] = "no_measurands_selected"
 
         current = self._charge_points()[self._cp_id]

--- a/custom_components/ocpp/config_flow.py
+++ b/custom_components/ocpp/config_flow.py
@@ -6,7 +6,9 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
     CONN_CLASS_LOCAL_PUSH,
+    OptionsFlow,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
@@ -125,6 +127,12 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         self._entry: ConfigEntry
         self._measurands: str = ""
         self._detected_num_connectors: int = DEFAULT_NUM_CONNECTORS
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> "OCPPOptionsFlow":
+        """Let the settings of an already-configured charge point be edited."""
+        return OCPPOptionsFlow()
 
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle user central system initiated configuration."""
@@ -269,4 +277,156 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="measurands",
             data_schema=STEP_USER_MEASURANDS_SCHEMA,
             errors=errors,
+        )
+
+
+class OCPPOptionsFlow(OptionsFlow):
+    """Edit the settings of an already-configured charge point.
+
+    The initial charger form (async_step_cp_user) is reachable only from
+    integration discovery, which aborts for a charger that is already
+    configured - so without this flow every per-charger setting was
+    write-once (#2047). cpid stays read-only here: entity unique_ids
+    derive from it, so changing it would orphan every existing entity.
+    """
+
+    def __init__(self) -> None:
+        """Initialize."""
+        self._cp_id: str = ""
+        self._settings: dict[str, Any] = {}
+
+    def _charge_points(self) -> dict[str, dict[str, Any]]:
+        """Map cp_id to its stored settings for this entry."""
+        points: dict[str, dict[str, Any]] = {}
+        for item in self.config_entry.data.get(CONF_CPIDS, []):
+            for cp_id, settings in item.items():
+                points[cp_id] = settings
+        return points
+
+    def _finalize(self, settings: dict[str, Any]) -> ConfigFlowResult:
+        """Write the edited charge point back into the entry."""
+        cpids = [
+            {
+                cp_id: (settings if cp_id == self._cp_id else stored)
+                for cp_id, stored in item.items()
+            }
+            for item in self.config_entry.data.get(CONF_CPIDS, [])
+        ]
+        # Updating the entry already triggers a reload via the
+        # add_update_listener(async_reload_entry) registered in
+        # async_setup_entry - the same single-reload rule the reconfigure
+        # step follows. The create_entry below writes entry.options, which
+        # stays {} and therefore fires nothing on top of it.
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={**self.config_entry.data, CONF_CPIDS: cpids},
+        )
+        return self.async_create_entry(data={})
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Pick which charge point to edit, when there is a choice."""
+        points = self._charge_points()
+        if not points:
+            return self.async_abort(reason="no_charge_points")
+
+        if user_input is not None:
+            self._cp_id = user_input["cp_id"]
+            return await self.async_step_cp_settings()
+
+        if len(points) == 1:
+            self._cp_id = next(iter(points))
+            return await self.async_step_cp_settings()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({vol.Required("cp_id"): vol.In(sorted(points))}),
+        )
+
+    async def async_step_cp_settings(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Edit the behavioural settings of the chosen charge point."""
+        current = self._charge_points()[self._cp_id]
+
+        if user_input is not None:
+            # cpid, the connector count and the measurand list ride along
+            # unchanged; only what the form shows is replaced. In particular
+            # the stored measurand list is NOT reseeded when autoconfig is
+            # left on - it holds what detection accepted, and re-detection
+            # refreshes it on the next connect anyway, so rewriting it here
+            # would create sensors for every measurand as a side effect of
+            # editing an unrelated setting.
+            self._settings = {**current, **user_input}
+            if user_input[CONF_MONITORED_VARIABLES_AUTOCONFIG]:
+                return self._finalize(self._settings)
+            return await self.async_step_measurands()
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_MAX_CURRENT,
+                    default=current.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
+                ): int,
+                vol.Required(
+                    CONF_MONITORED_VARIABLES_AUTOCONFIG,
+                    default=current.get(
+                        CONF_MONITORED_VARIABLES_AUTOCONFIG,
+                        DEFAULT_MONITORED_VARIABLES_AUTOCONFIG,
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_METER_INTERVAL,
+                    default=current.get(CONF_METER_INTERVAL, DEFAULT_METER_INTERVAL),
+                ): int,
+                vol.Required(
+                    CONF_IDLE_INTERVAL,
+                    default=current.get(CONF_IDLE_INTERVAL, DEFAULT_IDLE_INTERVAL),
+                ): int,
+                vol.Required(
+                    CONF_SKIP_SCHEMA_VALIDATION,
+                    default=current.get(
+                        CONF_SKIP_SCHEMA_VALIDATION, DEFAULT_SKIP_SCHEMA_VALIDATION
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_FORCE_SMART_CHARGING,
+                    default=current.get(
+                        CONF_FORCE_SMART_CHARGING, DEFAULT_FORCE_SMART_CHARGING
+                    ),
+                ): bool,
+            }
+        )
+        return self.async_show_form(
+            step_id="cp_settings",
+            data_schema=schema,
+            description_placeholders={
+                "cp_id": self._cp_id,
+                "cpid": current.get(CONF_CPID, ""),
+            },
+        )
+
+    async def async_step_measurands(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select measurands manually, pre-filled with the stored set."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            selected = [m for m, value in user_input.items() if value]
+            if selected:
+                self._settings[CONF_MONITORED_VARIABLES] = ",".join(selected)
+                return self._finalize(self._settings)
+            errors["base"] = "no_measurands_selected"
+
+        current = self._charge_points()[self._cp_id]
+        stored = {
+            m for m in current.get(CONF_MONITORED_VARIABLES, "").split(",") if m
+        } or {DEFAULT_MEASURAND}
+        schema = vol.Schema(
+            {vol.Required(m, default=(m in stored)): bool for m in MEASURANDS}
+        )
+        return self.async_show_form(
+            step_id="measurands", data_schema=schema, errors=errors
         )

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -107,5 +107,62 @@
         "set_variables_error": {
             "message": "Failed to set variable: {message}"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "OCPP Charger Configuration",
+                "description": "Select the charge point to edit.",
+                "data": {
+                    "cp_id": "Charge point"
+                }
+            },
+            "cp_settings": {
+                "title": "OCPP Charger Configuration",
+                "description": "Editing charge point {cp_id}. Its charge point identity (cpid: {cpid}) is fixed, because entity IDs derive from it.",
+                "data": {
+                    "max_current": "Maximum charging current",
+                    "meter_interval": "Charging sample interval (seconds)",
+                    "monitored_variables_autoconfig": "Automatic detection of OCPP Measurands",
+                    "idle_interval": "Charger idle sampling interval (seconds)",
+                    "skip_schema_validation": "Skip OCPP schema validation",
+                    "force_smart_charging": "Force Smart Charging feature profile"
+                }
+            },
+            "measurands": {
+                "title": "OCPP Measurands",
+                "description": "Select which measurand(s) should be used in Home Assistant.",
+                "data": {
+                    "Current.Export": "Current.Export: Instantaneous current flow from EV",
+                    "Current.Import": "Current.Import: Instantaneous current flow to EV",
+                    "Current.Offered": "Current.Offered: Maximum current offered to EV",
+                    "Energy.Active.Export.Register": "Energy.Active.Export.Register: Active energy exported to the grid",
+                    "Energy.Active.Import.Register": "Energy.Active.Import.Register: Active energy imported from the grid",
+                    "Energy.Reactive.Export.Register": "Energy.Reactive.Export.Register: Reactive energy exported to the grid",
+                    "Energy.Reactive.Import.Register": "Energy.Reactive.Import.Register: Reactive energy imported from the grid",
+                    "Energy.Active.Export.Interval": "Energy.Active.Export.Interval: Active energy exported to the grid during last interval",
+                    "Energy.Active.Import.Interval": "Energy.Active.Import.Interval: Active energy imported from the grid during last interval",
+                    "Energy.Reactive.Export.Interval": "Energy.Reactive.Export.Interval: Reactive energy exported to the grid during last interval",
+                    "Energy.Reactive.Import.Interval": "Energy.Reactive.Import.Interval: Reactive energy imported from the grid during last interval",
+                    "Frequency": "Frequency: Powerline frequency",
+                    "Power.Active.Export": "Power.Active.Export: Instantaneous active power exported by EV",
+                    "Power.Active.Import": "Power.Active.Import: Instantaneous active power imported by EV",
+                    "Power.Factor": "Power.Factor: Instantaneous power factor of total energy flow",
+                    "Power.Offered": "Power.Offered: Maximum power offered to EV",
+                    "Power.Reactive.Export": "Power.Reactive.Export: Instantaneous reactive power exported by EV",
+                    "Power.Reactive.Import": "Power.Reactive.Import: Instantaneous reactive power imported by EV",
+                    "RPM": "RPM: Fan speed in RPM",
+                    "SoC": "SoC: State of charge of EV in percentage",
+                    "Temperature": "Temperature: Temperature reading inside Charge Point",
+                    "Voltage": "Voltage: Instantaneous AC RMS supply voltage"
+                }
+            }
+        },
+        "error": {
+            "no_measurands_selected": "No measurand selected: please select at least one"
+        },
+        "abort": {
+            "no_charge_points": "No charge point has connected to this central system yet, so there is nothing to configure."
+        }
     }
 }

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -110,5 +110,62 @@
         "unavailable": {
             "message": "Charger is unavailable: {message}"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "OCPP Charger Configuration",
+                "description": "Select the charge point to edit.",
+                "data": {
+                    "cp_id": "Charge point"
+                }
+            },
+            "cp_settings": {
+                "title": "OCPP Charger Configuration",
+                "description": "Editing charge point {cp_id}. Its charge point identity (cpid: {cpid}) is fixed, because entity IDs derive from it.",
+                "data": {
+                    "max_current": "Maximum charging current",
+                    "meter_interval": "Charging sample interval (seconds)",
+                    "monitored_variables_autoconfig": "Automatic detection of OCPP Measurands",
+                    "idle_interval": "Charger idle sampling interval (seconds)",
+                    "skip_schema_validation": "Skip OCPP schema validation",
+                    "force_smart_charging": "Force Smart Charging feature profile"
+                }
+            },
+            "measurands": {
+                "title": "OCPP Measurands",
+                "description": "Select which measurand(s) should be used in Home Assistant.",
+                "data": {
+                    "Current.Export": "Current.Export: Instantaneous current flow from EV",
+                    "Current.Import": "Current.Import: Instantaneous current flow to EV",
+                    "Current.Offered": "Current.Offered: Maximum current offered to EV",
+                    "Energy.Active.Export.Register": "Energy.Active.Export.Register: Active energy exported to the grid",
+                    "Energy.Active.Import.Register": "Energy.Active.Import.Register: Active energy imported from the grid",
+                    "Energy.Reactive.Export.Register": "Energy.Reactive.Export.Register: Reactive energy exported to the grid",
+                    "Energy.Reactive.Import.Register": "Energy.Reactive.Import.Register: Reactive energy imported from the grid",
+                    "Energy.Active.Export.Interval": "Energy.Active.Export.Interval: Active energy exported to the grid during last interval",
+                    "Energy.Active.Import.Interval": "Energy.Active.Import.Interval: Active energy imported from the grid during last interval",
+                    "Energy.Reactive.Export.Interval": "Energy.Reactive.Export.Interval: Reactive energy exported to the grid during last interval",
+                    "Energy.Reactive.Import.Interval": "Energy.Reactive.Import.Interval: Reactive energy imported from the grid during last interval",
+                    "Frequency": "Frequency: Powerline frequency",
+                    "Power.Active.Export": "Power.Active.Export: Instantaneous active power exported by EV",
+                    "Power.Active.Import": "Power.Active.Import: Instantaneous active power imported by EV",
+                    "Power.Factor": "Power.Factor: Instantaneous power factor of total energy flow",
+                    "Power.Offered": "Power.Offered: Maximum power offered to EV",
+                    "Power.Reactive.Export": "Power.Reactive.Export: Instantaneous reactive power exported by EV",
+                    "Power.Reactive.Import": "Power.Reactive.Import: Instantaneous reactive power imported by EV",
+                    "RPM": "RPM: Fan speed in RPM",
+                    "SoC": "SoC: State of charge of EV in percentage",
+                    "Temperature": "Temperature: Temperature reading inside Charge Point",
+                    "Voltage": "Voltage: Instantaneous AC RMS supply voltage"
+                }
+            }
+        },
+        "error": {
+            "no_measurands_selected": "No measurand selected: please select at least one"
+        },
+        "abort": {
+            "no_charge_points": "No charge point has connected to this central system yet, so there is nothing to configure."
+        }
     }
 }

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -271,7 +271,7 @@ async def test_selecting_no_measurands_is_rejected(hass):
     )
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={m: False for m in _form_fields(result)},
+        user_input=dict.fromkeys(_form_fields(result), False),
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -318,6 +318,57 @@ async def test_multiple_chargers_get_a_picker_and_only_the_picked_one_changes(ha
     assert _stored(entry, "CP_2")[CONF_MAX_CURRENT] == 25
     assert _stored(entry, "CP_2")[CONF_CPID] == "second_cpid"
     assert _stored(entry, "CP_1") == _cp_settings()
+
+
+async def test_updates_landing_between_steps_are_not_clobbered(hass):
+    """A snapshot taken at the first form must not be written back later.
+
+    While the user sits on the measurands form, a reconnecting charger's
+    post_connect can update the entry - the connector count, the detected
+    measurand list. Finalize has to overlay only the edited fields onto
+    the entry as it is at write time, so those updates survive; a full
+    snapshot taken at the first submit would erase them.
+    """
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 63,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: False,
+            CONF_METER_INTERVAL: 60,
+            CONF_IDLE_INTERVAL: 900,
+            CONF_SKIP_SCHEMA_VALIDATION: False,
+            CONF_FORCE_SMART_CHARGING: True,
+        },
+    )
+    assert result["step_id"] == "measurands"
+
+    # post_connect lands while the measurands form is open.
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_CPIDS: [{"CP_1": _cp_settings(**{CONF_NUM_CONNECTORS: 3})}],
+        },
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            str(key): (str(key) == "Voltage") for key in result["data_schema"].schema
+        },
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    stored = _stored(entry, "CP_1")
+    # The detector's update survives...
+    assert stored[CONF_NUM_CONNECTORS] == 3
+    # ...while the user's explicit edits still win for the edited fields.
+    assert stored[CONF_MAX_CURRENT] == 63
+    assert stored[CONF_MONITORED_VARIABLES] == "Voltage"
+    assert stored[CONF_MONITORED_VARIABLES_AUTOCONFIG] is False
 
 
 async def test_no_chargers_means_nothing_to_configure(hass):

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,361 @@
+"""The options flow for editing an already-configured charge point.
+
+The initial charger form (async_step_cp_user) is reachable only from
+integration discovery, and discovery aborts for a charger that is already
+configured - so every per-charger setting was write-once (#2047). Anyone
+who enabled force_smart_charging to work around missing detection could
+never turn it off, and max_current - which since #2044 decides when
+set_charge_rate clears the profile instead of applying a limit - could
+never follow a supply upgrade.
+
+cpid stays read-only throughout: entity unique_ids derive from it, so
+changing it would orphan every existing entity.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant import data_entry_flow
+
+from custom_components.ocpp.const import (
+    CONF_CPID,
+    CONF_CPIDS,
+    CONF_FORCE_SMART_CHARGING,
+    CONF_IDLE_INTERVAL,
+    CONF_MAX_CURRENT,
+    CONF_METER_INTERVAL,
+    CONF_MONITORED_VARIABLES,
+    CONF_MONITORED_VARIABLES_AUTOCONFIG,
+    CONF_NUM_CONNECTORS,
+    CONF_SKIP_SCHEMA_VALIDATION,
+    DOMAIN,
+)
+
+from .const import MOCK_CONFIG_CS, MOCK_CONFIG_CP
+
+
+@pytest.fixture(autouse=True)
+def bypass_setup_fixture():
+    """Prevent actual setup of the integration."""
+    with (
+        patch("custom_components.ocpp.async_setup", return_value=True),
+        patch("custom_components.ocpp.async_setup_entry", return_value=True),
+    ):
+        yield
+
+
+def _cp_settings(**overrides):
+    """Build a stored charge point settings dict, as discovery writes it."""
+    settings = {
+        **MOCK_CONFIG_CP,
+        CONF_NUM_CONNECTORS: 2,
+        CONF_MONITORED_VARIABLES: "Power.Active.Import,Voltage",
+    }
+    settings.update(overrides)
+    return settings
+
+
+def _entry(hass, cpids):
+    """Build a configured central system with the given charge points."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_CS, CONF_CPIDS: cpids},
+        entry_id="test_options",
+        title="test_csid_flow",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _stored(entry, cp_id):
+    """Return the stored settings for cp_id after the flow ran."""
+    for item in entry.data[CONF_CPIDS]:
+        if cp_id in item:
+            return item[cp_id]
+    raise AssertionError(f"{cp_id} missing from entry data")
+
+
+def _form_fields(result):
+    """Return the field names offered by a form step."""
+    return {str(key) for key in result["data_schema"].schema}
+
+
+async def test_a_single_charger_skips_the_picker(hass):
+    """With one charge point there is nothing to choose; go straight to it."""
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "cp_settings"
+
+
+async def test_cpid_is_not_editable(hass):
+    """drc38 on #2047: cpid should be read only.
+
+    Entity unique_ids are built from it, so an edit would orphan every
+    entity of the charger. It is shown in the description instead.
+    """
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert CONF_CPID not in _form_fields(result)
+    assert result["description_placeholders"] == {
+        "cp_id": "CP_1",
+        "cpid": "test_cpid",
+    }
+
+
+async def test_editing_settings_preserves_what_the_form_does_not_show(hass):
+    """cpid, connector count and the measurand list must ride along unchanged.
+
+    num_connectors is detection state, not preference - dropping it recreates
+    the num_connectors=0 class of bug where entities disappear. The measurand
+    list holds what detection accepted; resetting it as a side effect of an
+    unrelated edit would spawn sensors for every measurand.
+    """
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 63,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: True,
+            CONF_METER_INTERVAL: 30,
+            CONF_IDLE_INTERVAL: 600,
+            CONF_SKIP_SCHEMA_VALIDATION: True,
+            CONF_FORCE_SMART_CHARGING: False,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    stored = _stored(entry, "CP_1")
+    assert stored[CONF_MAX_CURRENT] == 63
+    assert stored[CONF_SKIP_SCHEMA_VALIDATION] is True
+    assert stored[CONF_FORCE_SMART_CHARGING] is False
+    assert stored[CONF_METER_INTERVAL] == 30
+    assert stored[CONF_IDLE_INTERVAL] == 600
+    # Not shown by the form, must survive:
+    assert stored[CONF_CPID] == "test_cpid"
+    assert stored[CONF_NUM_CONNECTORS] == 2
+    assert stored[CONF_MONITORED_VARIABLES] == "Power.Active.Import,Voltage"
+    # Settings stay in entry.data; nothing moves into entry.options.
+    assert entry.options == {}
+
+
+async def test_the_entry_is_updated_exactly_once(hass):
+    """One write, one reload - the double-reload bug must stay dead.
+
+    async_setup_entry registers async_reload_entry as the update listener,
+    so every async_update_entry costs a reload. The reconfigure step was
+    fixed to update once and let the listener do the single reload; the
+    options flow has to hold the same line, including the empty
+    create_entry at the end which must not count as a second update.
+    """
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+    listener = AsyncMock()
+    entry.add_update_listener(listener)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 40,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: True,
+            CONF_METER_INTERVAL: 60,
+            CONF_IDLE_INTERVAL: 900,
+            CONF_SKIP_SCHEMA_VALIDATION: False,
+            CONF_FORCE_SMART_CHARGING: True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert listener.await_count == 1
+
+
+async def test_autoconfig_left_on_does_not_reseed_measurands(hass):
+    """The discovery flow seeds DEFAULT_MONITORED_VARIABLES; this flow must not.
+
+    At discovery there is nothing better to seed with. Here the stored list
+    is what detection accepted on a real connect, and re-detection refreshes
+    it next connect anyway - reseeding to the full set would create sensors
+    for every measurand as a side effect of editing max_current.
+    """
+    entry = _entry(
+        hass,
+        [{"CP_1": _cp_settings(**{CONF_MONITORED_VARIABLES: "Power.Active.Import"})}],
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 63,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: True,
+            CONF_METER_INTERVAL: 60,
+            CONF_IDLE_INTERVAL: 900,
+            CONF_SKIP_SCHEMA_VALIDATION: False,
+            CONF_FORCE_SMART_CHARGING: True,
+        },
+    )
+
+    assert _stored(entry, "CP_1")[CONF_MONITORED_VARIABLES] == "Power.Active.Import"
+
+
+async def test_autoconfig_off_offers_the_stored_measurands(hass):
+    """Turning detection off drops into manual selection, pre-filled.
+
+    The pre-fill is the stored list - what detection last accepted - so the
+    user starts from the working set rather than from a single default.
+    """
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 32,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: False,
+            CONF_METER_INTERVAL: 60,
+            CONF_IDLE_INTERVAL: 900,
+            CONF_SKIP_SCHEMA_VALIDATION: False,
+            CONF_FORCE_SMART_CHARGING: True,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "measurands"
+    prefilled = {
+        str(key) for key in result["data_schema"].schema if key.default() is True
+    }
+    assert prefilled == {"Power.Active.Import", "Voltage"}
+
+    # Build the submission in schema order so the joined result is
+    # deterministic, as it is when the real form drives the order.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            str(key): (str(key) in ("Current.Import", "Voltage"))
+            for key in result["data_schema"].schema
+        },
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    stored = _stored(entry, "CP_1")
+    assert stored[CONF_MONITORED_VARIABLES_AUTOCONFIG] is False
+    assert stored[CONF_MONITORED_VARIABLES] == "Current.Import,Voltage"
+
+
+async def test_selecting_no_measurands_is_rejected(hass):
+    """An empty manual selection would silently blank the measurand list.
+
+    That is fault #2033's failure mode arrived at by hand; the form has to
+    push back rather than store an empty string.
+    """
+    entry = _entry(hass, [{"CP_1": _cp_settings()}])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 32,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: False,
+            CONF_METER_INTERVAL: 60,
+            CONF_IDLE_INTERVAL: 900,
+            CONF_SKIP_SCHEMA_VALIDATION: False,
+            CONF_FORCE_SMART_CHARGING: True,
+        },
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={m: False for m in _form_fields(result)},
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "measurands"
+    assert result["errors"] == {"base": "no_measurands_selected"}
+    assert _stored(entry, "CP_1")[CONF_MONITORED_VARIABLES] == (
+        "Power.Active.Import,Voltage"
+    )
+
+
+async def test_multiple_chargers_get_a_picker_and_only_the_picked_one_changes(hass):
+    """Editing CP_2 must leave CP_1 byte-for-byte alone."""
+    entry = _entry(
+        hass,
+        [
+            {"CP_1": _cp_settings()},
+            {"CP_2": _cp_settings(**{CONF_CPID: "second_cpid", CONF_MAX_CURRENT: 16})},
+        ],
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"cp_id": "CP_2"}
+    )
+    assert result["step_id"] == "cp_settings"
+    assert result["description_placeholders"]["cpid"] == "second_cpid"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MAX_CURRENT: 25,
+            CONF_MONITORED_VARIABLES_AUTOCONFIG: True,
+            CONF_METER_INTERVAL: 60,
+            CONF_IDLE_INTERVAL: 900,
+            CONF_SKIP_SCHEMA_VALIDATION: False,
+            CONF_FORCE_SMART_CHARGING: True,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert _stored(entry, "CP_2")[CONF_MAX_CURRENT] == 25
+    assert _stored(entry, "CP_2")[CONF_CPID] == "second_cpid"
+    assert _stored(entry, "CP_1") == _cp_settings()
+
+
+async def test_no_chargers_means_nothing_to_configure(hass):
+    """A central system nothing has connected to yet aborts cleanly."""
+    entry = _entry(hass, [])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "no_charge_points"
+
+
+async def test_the_form_defaults_are_the_stored_values(hass):
+    """The form must open showing what is configured, not the global defaults.
+
+    Otherwise every save silently resets any field the user did not
+    re-enter - the options-flow version of the clobbering this campaign
+    kept finding.
+    """
+    entry = _entry(
+        hass,
+        [
+            {
+                "CP_1": _cp_settings(
+                    **{
+                        CONF_MAX_CURRENT: 63,
+                        CONF_SKIP_SCHEMA_VALIDATION: True,
+                        CONF_FORCE_SMART_CHARGING: False,
+                    }
+                )
+            }
+        ],
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    defaults = {str(key): key.default() for key in result["data_schema"].schema}
+    assert defaults[CONF_MAX_CURRENT] == 63
+    assert defaults[CONF_SKIP_SCHEMA_VALIDATION] is True
+    assert defaults[CONF_FORCE_SMART_CHARGING] is False
+    assert defaults[CONF_MONITORED_VARIABLES_AUTOCONFIG] is True


### PR DESCRIPTION
Closes #2047, following your direction there: an options flow, with cpid read-only.

Every per-charger setting was write-once: the charger form is reachable only from integration discovery, and discovery aborts for an already-configured charger. So `force_smart_charging` could never be turned off once enabled, and `max_current` — which since #2044 decides when `set_charge_rate` clears the profile rather than applying a limit — could never follow a supply upgrade.

## What the flow does

The integration entry gains a **Configure** button. One charge point goes straight to its form; several get a picker first. The form shows the six behavioural settings pre-filled with the stored values, and turning autoconfig off drops into manual measurand selection pre-filled with the stored set.

**cpid is read-only**, shown in the form description rather than as a field — entity unique_ids derive from it, so an edit would orphan every existing entity. Settings stay in `entry.data[CONF_CPIDS]` where the rest of the integration reads them; `entry.options` stays empty.

## Two judgement calls worth flagging

**The measurand list is not reseeded when autoconfig is left on.** The discovery flow seeds `DEFAULT_MONITORED_VARIABLES` because at that point there is nothing better; by the time the options flow runs, the stored list is what detection actually accepted on a real connect. Reseeding it on every save would create sensors for every measurand as a side effect of editing, say, `max_current` — the same class of destructive write #2041 removed. Re-detection still refreshes the list on the next connect, so nothing is lost by preserving it.

**One write, one reload.** The entry is updated once via `async_update_entry`, and the closing `create_entry` writes an empty `options` dict, which is unchanged and therefore fires nothing — so the update listener reloads exactly once. Same rule the reconfigure step follows since #2013's double-reload fix, and there is a test counting listener calls to keep it that way.

## Relationship to #2037

Deliberately none: cpid cannot be edited here, so the duplicate-cpid validation that PR fixes is never in play in this flow. The two changes touch different functions of `config_flow.py`; whichever lands second has a trivial rebase (imports and translation JSON).

## Testing

10 tests in `tests/test_options_flow.py`; 244 pass overall; pre-commit green.

Verified by mutation — each fails the tests aimed at it:

| Mutation | Tests failed |
|---|---|
| drop preservation of unshown keys (cpid/num_connectors/measurands) | 3 |
| reseed measurands when autoconfig on (discovery parity) | 2 |
| update the wrong charger in a multi-charger entry | 4 |
| accept an empty measurand selection | 1 |
| write non-empty `entry.options` (second listener fire) | 2 |
| prefill measurands from the default instead of the stored set | 1 |
| form defaults from globals instead of stored values | 1 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an options flow for reconfiguring existing chargers.
  * Update charger behavior settings and select supported measurands.
  * Preserves charger identifiers and connector information during edits.
  * Automatically reloads the integration after saving changes.
  * Provides localized labels, validation messages, and guidance when no chargers are available.

* **Bug Fixes**
  * Prevents saving configurations without selecting measurands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->