### PR TITLE
Revert the current limit when the charger refuses it

### DIFF
--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -192,6 +192,10 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
             object_id = f"{self.cpid}_{self.entity_description.key}"
         self.entity_id = f"{NUMBER_DOMAIN}.{slugify(object_id)}"
         self._attr_native_value = self.entity_description.initial_value
+        # The last limit the charger accepted, and so the only value a
+        # failed request may fall back to. None until something is
+        # confirmed, so a rollback cannot invent a limit.
+        self._confirmed_value: float | None = None
         self._attr_should_poll = False
 
     async def async_added_to_hass(self) -> None:
@@ -199,6 +203,9 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
         await super().async_added_to_hass()
         if restored := await self.async_get_last_number_data():
             self._attr_native_value = restored.native_value
+            # Confirmed in a previous session; better than nothing to
+            # fall back to, and it is what the charger was last told.
+            self._confirmed_value = restored.native_value
 
         @callback
         def _maybe_update(*args):
@@ -235,22 +242,22 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
           error, because the number is the only thing telling the user what
           the circuit is doing. Keeping the value only logged the problem.
         """
-        previous = self._attr_native_value
-        self._attr_native_value = float(value)
+        target = float(value)
+        self._attr_native_value = target
         self.async_write_ha_state()
 
         try:
             ok = await self.central_system.set_max_charge_rate_amps(
-                self.cpid, self._attr_native_value, connector_id=self._op_connector_id
+                self.cpid, target, connector_id=self._op_connector_id
             )
         except HomeAssistantError:
             # set_charge_rate raises this for a rejected profile, and its
             # message carries the charger's own status_info - the only
             # explanation of why. Surface it rather than restating it.
-            self._restore_native_value(previous)
+            self._revert_to_confirmed()
             raise
         except Exception as ex:
-            self._restore_native_value(previous)
+            self._revert_to_confirmed()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_charge_rate_error",
@@ -258,16 +265,33 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
             ) from ex
 
         if not ok:
-            self._restore_native_value(previous)
+            self._revert_to_confirmed()
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_charge_rate_error",
                 translation_placeholders={
-                    "message": f"charger did not accept {float(value):.1f} A"
+                    "message": f"charger did not accept {target:.1f} A"
                 },
             )
 
-    def _restore_native_value(self, previous: float | None) -> None:
-        """Put the slider back to what the charger is actually holding."""
-        self._attr_native_value = previous
+        self._confirmed_value = target
+        if self._attr_native_value != target:
+            # A request that started earlier failed while this one was in
+            # flight and rolled the slider back. This limit is the one the
+            # charger is holding, so it owns what is displayed.
+            self._attr_native_value = target
+            self.async_write_ha_state()
+
+    def _revert_to_confirmed(self) -> None:
+        """Put the slider back to the last limit the charger accepted.
+
+        Reverting to whatever was displayed when this request started would
+        clobber a concurrent request that has since been accepted - two
+        quick drags, or an automation racing the UI - and leave the slider
+        disagreeing with the charger, which is the thing this is meant to
+        prevent rather than cause.
+        """
+        if self._attr_native_value == self._confirmed_value:
+            return
+        self._attr_native_value = self._confirmed_value
         self.async_write_ha_state()

--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -192,10 +192,22 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
             object_id = f"{self.cpid}_{self.entity_description.key}"
         self.entity_id = f"{NUMBER_DOMAIN}.{slugify(object_id)}"
         self._attr_native_value = self.entity_description.initial_value
-        # The last limit the charger accepted, and so the only value a
-        # failed request may fall back to. None until something is
-        # confirmed, so a rollback cannot invent a limit.
+        # The last limit this integration believes the charger is holding:
+        # confirmed by an accepted request this session, or restored from
+        # the previous one (the charger keeps its profile across our
+        # restarts). None on a fresh install, so a rollback cannot invent
+        # a limit. Requests the charger performs without this entity - the
+        # ocpp.clear_profile / ocpp.set_charge_rate services - are not
+        # reflected here, the same blind spot the pre-#2049 code had.
         self._confirmed_value: float | None = None
+        # Monotonic ticket per request, and the ticket of the newest
+        # accepted one. The transport serialises calls today (the ocpp
+        # library holds its call lock across send and response), so
+        # completions cannot cross - but that is a property of a library
+        # two layers down, not of this entity. The guard keeps the
+        # display-owns-latest-accepted invariant provable right here.
+        self._request_seq: int = 0
+        self._accepted_seq: int = 0
         self._attr_should_poll = False
 
     async def async_added_to_hass(self) -> None:
@@ -203,8 +215,11 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
         await super().async_added_to_hass()
         if restored := await self.async_get_last_number_data():
             self._attr_native_value = restored.native_value
-            # Confirmed in a previous session; better than nothing to
-            # fall back to, and it is what the charger was last told.
+            # What the previous session last settled on. The charger keeps
+            # its charging profile across our restarts, so this is the best
+            # available proxy for what it is holding - stale only if the
+            # charger was reset or cleared in between, and corrected by the
+            # next accepted request either way.
             self._confirmed_value = restored.native_value
 
         @callback
@@ -243,6 +258,8 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
           the circuit is doing. Keeping the value only logged the problem.
         """
         target = float(value)
+        self._request_seq += 1
+        seq = self._request_seq
         self._attr_native_value = target
         self.async_write_ha_state()
 
@@ -274,9 +291,20 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
                 },
             )
 
+        if seq <= self._accepted_seq:
+            # A newer request was already accepted while this one was in
+            # flight; its limit superseded this one on the charger, so it
+            # owns the display and the confirmed value.
+            _LOGGER.debug(
+                "Accepted limit %.1f A superseded in flight; display stays at %s",
+                target,
+                self._attr_native_value,
+            )
+            return
+        self._accepted_seq = seq
         self._confirmed_value = target
         if self._attr_native_value != target:
-            # A request that started earlier failed while this one was in
+            # A request that started later failed while this one was in
             # flight and rolled the slider back. This limit is the one the
             # charger is holding, so it owns what is displayed.
             self._attr_native_value = target
@@ -291,7 +319,15 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
         disagreeing with the charger, which is the thing this is meant to
         prevent rather than cause.
         """
+        # Whole-amp values, so equality is exact (native_step=1). A
+        # fractional step would need a tolerance here and in the
+        # superseded check above.
         if self._attr_native_value == self._confirmed_value:
             return
+        _LOGGER.debug(
+            "Reverting current limit display from %s to last accepted %s",
+            self._attr_native_value,
+            self._confirmed_value,
+        )
         self._attr_native_value = self._confirmed_value
         self.async_write_ha_state()

--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -14,6 +14,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
@@ -228,8 +229,13 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
     async def async_set_native_value(self, value):
         """Set new value for max current (station-wide when _op_connector_id==0, otherwise per-connector).
 
-        - Optimistic UI: move the slider immediately; attempt backend; never raise.
+        - Optimistic UI: move the slider immediately so it tracks the drag.
+        - On refusal, put it back and raise: a current limit that reads as
+          applied while the charger runs unrestricted is worse than an
+          error, because the number is the only thing telling the user what
+          the circuit is doing. Keeping the value only logged the problem.
         """
+        previous = self._attr_native_value
         self._attr_native_value = float(value)
         self.async_write_ha_state()
 
@@ -237,14 +243,31 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
             ok = await self.central_system.set_max_charge_rate_amps(
                 self.cpid, self._attr_native_value, connector_id=self._op_connector_id
             )
-            if not ok:
-                _LOGGER.warning(
-                    "Set current limit rejected by CP (kept optimistic UI at %.1f A).",
-                    value,
-                )
+        except HomeAssistantError:
+            # set_charge_rate raises this for a rejected profile, and its
+            # message carries the charger's own status_info - the only
+            # explanation of why. Surface it rather than restating it.
+            self._restore_native_value(previous)
+            raise
         except Exception as ex:
-            _LOGGER.warning(
-                "Set current limit failed: %s (kept optimistic UI at %.1f A).",
-                ex,
-                value,
+            self._restore_native_value(previous)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_charge_rate_error",
+                translation_placeholders={"message": str(ex)},
+            ) from ex
+
+        if not ok:
+            self._restore_native_value(previous)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_charge_rate_error",
+                translation_placeholders={
+                    "message": f"charger did not accept {float(value):.1f} A"
+                },
             )
+
+    def _restore_native_value(self, previous: float | None) -> None:
+        """Put the slider back to what the charger is actually holding."""
+        self._attr_native_value = previous
+        self.async_write_ha_state()

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -107,6 +107,9 @@
         },
         "set_variables_error": {
             "message": "Failed to set variable: {message}"
+        },
+        "set_charge_rate_error": {
+            "message": "Failed to set charging current limit: {message}"
         }
     },
     "options": {

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -110,6 +110,9 @@
         },
         "unavailable": {
             "message": "Charger is unavailable: {message}"
+        },
+        "set_charge_rate_error": {
+            "message": "Failed to set charging current limit: {message}"
         }
     },
     "options": {

--- a/tests/test_number_limit_refusal.py
+++ b/tests/test_number_limit_refusal.py
@@ -206,9 +206,11 @@ async def test_a_late_rollback_does_not_clobber_an_accepted_limit(hass):
     accepted limit instead, so a superseded request has nothing to undo.
     """
     gate = asyncio.Event()
+    entered = asyncio.Event()
 
     async def charger(cpid, value, connector_id=0):
         if value == 16.0:
+            entered.set()
             await gate.wait()
             return False
         return True
@@ -217,7 +219,7 @@ async def test_a_late_rollback_does_not_clobber_an_accepted_limit(hass):
     entity.central_system.set_max_charge_rate_amps = charger
 
     slow = asyncio.create_task(entity.async_set_native_value(16))
-    await asyncio.sleep(0)
+    await entered.wait()
     await entity.async_set_native_value(24)
 
     assert entity._attr_native_value == 24.0
@@ -228,6 +230,9 @@ async def test_a_late_rollback_does_not_clobber_an_accepted_limit(hass):
 
     assert entity._attr_native_value == 24.0
     assert entity._confirmed_value == 24.0
+    # The write sequence is the user-visible story: two optimistic moves,
+    # and no third write, because the loser had nothing to undo.
+    assert entity.written == [16.0, 24.0]
 
 
 @pytest.mark.asyncio
@@ -238,9 +243,11 @@ async def test_a_late_success_reclaims_the_display(hass):
     old value while the charger goes on to accept a newer one.
     """
     gate = asyncio.Event()
+    entered = asyncio.Event()
 
     async def charger(cpid, value, connector_id=0):
         if value == 24.0:
+            entered.set()
             await gate.wait()
             return True
         return False
@@ -249,7 +256,7 @@ async def test_a_late_success_reclaims_the_display(hass):
     entity.central_system.set_max_charge_rate_amps = charger
 
     slow = asyncio.create_task(entity.async_set_native_value(24))
-    await asyncio.sleep(0)
+    await entered.wait()
     with pytest.raises(HomeAssistantError):
         await entity.async_set_native_value(16)
 
@@ -260,3 +267,42 @@ async def test_a_late_success_reclaims_the_display(hass):
 
     assert entity._attr_native_value == 24.0
     assert entity._confirmed_value == 24.0
+    # Optimistic 24, optimistic 16, revert to 32, then the late winner.
+    assert entity.written == [24.0, 16.0, 32.0, 24.0]
+
+
+@pytest.mark.asyncio
+async def test_two_accepted_requests_settle_on_the_newest(hass):
+    """Both accepted, completions crossed: the newest request must win.
+
+    The transport serialises calls today, so accepted completions cannot
+    actually cross - but that guarantee lives in the ocpp library's call
+    lock, not here. This pins the entity's own invariant: even if the
+    older request's success lands last, it must not drag the display or
+    the confirmed value backwards to a limit the charger is no longer
+    holding.
+    """
+    gate = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def charger(cpid, value, connector_id=0):
+        if value == 16.0:
+            entered.set()
+            await gate.wait()
+        return True
+
+    entity = _mk_number(hass, result=True)
+    entity.central_system.set_max_charge_rate_amps = charger
+
+    old = asyncio.create_task(entity.async_set_native_value(16))
+    await entered.wait()
+    await entity.async_set_native_value(24)
+
+    gate.set()
+    await old
+
+    assert entity._attr_native_value == 24.0
+    assert entity._confirmed_value == 24.0
+    # Two optimistic moves and nothing else: the stale success is
+    # suppressed entirely rather than writing 16 back.
+    assert entity.written == [16.0, 24.0]

--- a/tests/test_number_limit_refusal.py
+++ b/tests/test_number_limit_refusal.py
@@ -13,6 +13,7 @@ is now put back and the failure raised, so the frontend surfaces it and the
 charger's own reason survives.
 """
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -22,8 +23,12 @@ from custom_components.ocpp.const import DOMAIN
 from custom_components.ocpp.number import NUMBERS, ChargePointNumber
 
 
-def _mk_number(hass, result=None, error=None, on_write=None):
-    """Build the maximum-current entity with a scripted central system."""
+def _mk_number(hass, result=None, error=None, on_write=None, confirmed=32.0):
+    """Build the maximum-current entity with a scripted central system.
+
+    `confirmed` seeds both the displayed and the last-accepted value, as a
+    charger that has taken one limit this session would leave them.
+    """
     calls = []
 
     async def set_max_charge_rate_amps(cpid, value, connector_id=0):
@@ -50,6 +55,8 @@ def _mk_number(hass, result=None, error=None, on_write=None):
     entity.async_write_ha_state = lambda: written.append(
         on_write() if on_write else entity._attr_native_value
     )
+    entity._attr_native_value = confirmed
+    entity._confirmed_value = confirmed
     entity.calls = calls
     entity.written = written
     return entity
@@ -59,7 +66,6 @@ def _mk_number(hass, result=None, error=None, on_write=None):
 async def test_an_accepted_limit_is_kept(hass):
     """Control: the success path must be untouched by the revert logic."""
     entity = _mk_number(hass, result=True)
-    entity._attr_native_value = 32.0
 
     await entity.async_set_native_value(16)
 
@@ -71,7 +77,6 @@ async def test_an_accepted_limit_is_kept(hass):
 async def test_a_refused_limit_is_reverted_and_raised(hass):
     """A falsy result means the charger did not take it."""
     entity = _mk_number(hass, result=False)
-    entity._attr_native_value = 32.0
 
     with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_set_native_value(16)
@@ -93,7 +98,6 @@ async def test_the_charger_s_own_reason_is_preserved(hass):
         translation_placeholders={"message": "Rejected: over site limit"},
     )
     entity = _mk_number(hass, error=refusal)
-    entity._attr_native_value = 32.0
 
     with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_set_native_value(16)
@@ -110,7 +114,6 @@ async def test_an_unexpected_failure_is_also_reverted(hass):
     than as a False return, so both shapes have to revert.
     """
     entity = _mk_number(hass, error=TimeoutError("no reply"))
-    entity._attr_native_value = 32.0
 
     with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_set_native_value(16)
@@ -128,7 +131,6 @@ async def test_the_revert_is_written_to_the_ui(hass):
     bug this fixes, just with an error toast on top.
     """
     entity = _mk_number(hass, result=False)
-    entity._attr_native_value = 32.0
 
     with pytest.raises(HomeAssistantError):
         await entity.async_set_native_value(16)
@@ -152,7 +154,6 @@ async def test_the_slider_moves_before_the_call(hass):
         return True
 
     entity = _mk_number(hass, result=True)
-    entity._attr_native_value = 32.0
     entity.central_system.set_max_charge_rate_amps = observe
 
     await entity.async_set_native_value(24)
@@ -170,8 +171,7 @@ async def test_a_restored_none_value_reverts_to_none(hass):
     fresh install: reverting must not invent a number the charger never
     confirmed.
     """
-    entity = _mk_number(hass, result=False)
-    entity._attr_native_value = None
+    entity = _mk_number(hass, result=False, confirmed=None)
 
     with pytest.raises(HomeAssistantError):
         await entity.async_set_native_value(16)
@@ -187,10 +187,76 @@ async def test_an_offline_charger_reverts_too(hass):
     must not silently show a limit either.
     """
     entity = _mk_number(hass, result=False)
-    entity._attr_native_value = 32.0
 
     with pytest.raises(HomeAssistantError):
         await entity.async_set_native_value(6)
 
     assert entity._attr_native_value == 32.0
     assert entity.calls == [("test_cpid", 6.0, 0)]
+
+
+@pytest.mark.asyncio
+async def test_a_late_rollback_does_not_clobber_an_accepted_limit(hass):
+    """Two requests can overlap; the loser must not undo the winner.
+
+    Rolling back to whatever was displayed when a request started meant a
+    slow failing request, landing after a quick successful one, restored a
+    value the charger was no longer holding - reintroducing the exact
+    divergence this fix exists to remove. Rollback goes to the last
+    accepted limit instead, so a superseded request has nothing to undo.
+    """
+    gate = asyncio.Event()
+
+    async def charger(cpid, value, connector_id=0):
+        if value == 16.0:
+            await gate.wait()
+            return False
+        return True
+
+    entity = _mk_number(hass, result=True)
+    entity.central_system.set_max_charge_rate_amps = charger
+
+    slow = asyncio.create_task(entity.async_set_native_value(16))
+    await asyncio.sleep(0)
+    await entity.async_set_native_value(24)
+
+    assert entity._attr_native_value == 24.0
+
+    gate.set()
+    with pytest.raises(HomeAssistantError):
+        await slow
+
+    assert entity._attr_native_value == 24.0
+    assert entity._confirmed_value == 24.0
+
+
+@pytest.mark.asyncio
+async def test_a_late_success_reclaims_the_display(hass):
+    """The mirror case: the winner lands after the loser rolled back.
+
+    A failing request that finishes first must not leave the slider on the
+    old value while the charger goes on to accept a newer one.
+    """
+    gate = asyncio.Event()
+
+    async def charger(cpid, value, connector_id=0):
+        if value == 24.0:
+            await gate.wait()
+            return True
+        return False
+
+    entity = _mk_number(hass, result=True)
+    entity.central_system.set_max_charge_rate_amps = charger
+
+    slow = asyncio.create_task(entity.async_set_native_value(24))
+    await asyncio.sleep(0)
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(16)
+
+    assert entity._attr_native_value == 32.0
+
+    gate.set()
+    await slow
+
+    assert entity._attr_native_value == 24.0
+    assert entity._confirmed_value == 24.0

--- a/tests/test_number_limit_refusal.py
+++ b/tests/test_number_limit_refusal.py
@@ -1,0 +1,196 @@
+"""The current-limit slider must not keep a value the charger refused.
+
+async_set_native_value moved the slider first and then swallowed every
+failure into a log warning, so a refused limit left the UI reading as if it
+had been applied. Caught live on a FoxESS A022KP1 whose OCPP 2.0.1 firmware
+rejects every SetChargingProfile: the slider showed 16 A while a clamp
+meter showed the car drawing 30.6 A.
+
+That matters more here than for most entities. This number is the only
+thing telling the user what the circuit is limited to, so someone capping
+a shared feed can believe it is capped when it is not. Per #2049 the value
+is now put back and the failure raised, so the frontend surfaces it and the
+charger's own reason survives.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.ocpp.const import DOMAIN
+from custom_components.ocpp.number import NUMBERS, ChargePointNumber
+
+
+def _mk_number(hass, result=None, error=None, on_write=None):
+    """Build the maximum-current entity with a scripted central system."""
+    calls = []
+
+    async def set_max_charge_rate_amps(cpid, value, connector_id=0):
+        calls.append((cpid, value, connector_id))
+        if error is not None:
+            raise error
+        return result
+
+    central = SimpleNamespace(
+        set_max_charge_rate_amps=set_max_charge_rate_amps,
+        get_available=lambda *a, **k: True,
+        get_supported_features=lambda *a, **k: 0xFF,
+        get_metric=lambda *a, **k: None,
+    )
+    entity = ChargePointNumber(
+        hass, central, "test_cpid", NUMBERS[0], connector_id=None, op_connector_id=0
+    )
+    entity.hass = hass
+    entity.entity_id = "number.test_cpid_maximum_current"
+    # The entity is not added to hass, so writing state would need the
+    # registry; record the sequence instead - the order of writes is the
+    # behaviour under test.
+    written = []
+    entity.async_write_ha_state = lambda: written.append(
+        on_write() if on_write else entity._attr_native_value
+    )
+    entity.calls = calls
+    entity.written = written
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_limit_is_kept(hass):
+    """Control: the success path must be untouched by the revert logic."""
+    entity = _mk_number(hass, result=True)
+    entity._attr_native_value = 32.0
+
+    await entity.async_set_native_value(16)
+
+    assert entity._attr_native_value == 16.0
+    assert entity.calls == [("test_cpid", 16.0, 0)]
+
+
+@pytest.mark.asyncio
+async def test_a_refused_limit_is_reverted_and_raised(hass):
+    """A falsy result means the charger did not take it."""
+    entity = _mk_number(hass, result=False)
+    entity._attr_native_value = 32.0
+
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await entity.async_set_native_value(16)
+
+    assert entity._attr_native_value == 32.0
+    assert "16.0 A" in str(excinfo.value.translation_placeholders["message"])
+
+
+@pytest.mark.asyncio
+async def test_the_charger_s_own_reason_is_preserved(hass):
+    """set_charge_rate raises with status_info; that message must survive.
+
+    It is the only explanation of why the charger said no, so it is
+    re-raised untouched rather than wrapped in a generic message.
+    """
+    refusal = HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="set_variables_error",
+        translation_placeholders={"message": "Rejected: over site limit"},
+    )
+    entity = _mk_number(hass, error=refusal)
+    entity._attr_native_value = 32.0
+
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await entity.async_set_native_value(16)
+
+    assert excinfo.value is refusal
+    assert entity._attr_native_value == 32.0
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_failure_is_also_reverted(hass):
+    """A transport error must not leave a phantom limit on screen either.
+
+    The live case arrived as a CallError raised out of the library rather
+    than as a False return, so both shapes have to revert.
+    """
+    entity = _mk_number(hass, error=TimeoutError("no reply"))
+    entity._attr_native_value = 32.0
+
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await entity.async_set_native_value(16)
+
+    assert entity._attr_native_value == 32.0
+    assert "no reply" in str(excinfo.value.translation_placeholders["message"])
+
+
+@pytest.mark.asyncio
+async def test_the_revert_is_written_to_the_ui(hass):
+    """Restoring the attribute is not enough; the state has to be pushed.
+
+    Without the second write the frontend keeps rendering the refused value
+    until something else happens to update the entity - which is the very
+    bug this fixes, just with an error toast on top.
+    """
+    entity = _mk_number(hass, result=False)
+    entity._attr_native_value = 32.0
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(16)
+
+    assert entity.written == [16.0, 32.0]
+
+
+@pytest.mark.asyncio
+async def test_the_slider_moves_before_the_call(hass):
+    """Optimistic movement is kept: the drag must not wait on the charger.
+
+    Reverting only on failure is the point - a slow charger should not make
+    the slider feel unresponsive - so the value is written first and put
+    back only if the answer is no.
+    """
+    seen = {}
+
+    async def observe(cpid, value, connector_id=0):
+        seen["value_during_call"] = entity._attr_native_value
+        seen["writes_before_call"] = list(entity.written)
+        return True
+
+    entity = _mk_number(hass, result=True)
+    entity._attr_native_value = 32.0
+    entity.central_system.set_max_charge_rate_amps = observe
+
+    await entity.async_set_native_value(24)
+
+    assert seen["value_during_call"] == 24.0
+    assert seen["writes_before_call"] == [24.0]
+    assert entity.written == [24.0]
+
+
+@pytest.mark.asyncio
+async def test_a_restored_none_value_reverts_to_none(hass):
+    """Before the first successful set there is nothing to go back to.
+
+    The entity restores its value on startup, so this is reachable on a
+    fresh install: reverting must not invent a number the charger never
+    confirmed.
+    """
+    entity = _mk_number(hass, result=False)
+    entity._attr_native_value = None
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(16)
+
+    assert entity._attr_native_value is None
+
+
+@pytest.mark.asyncio
+async def test_an_offline_charger_reverts_too(hass):
+    """set_max_charge_rate_amps returns False when the charger is absent.
+
+    Same shape as a refusal and the same consequence for the user, so it
+    must not silently show a limit either.
+    """
+    entity = _mk_number(hass, result=False)
+    entity._attr_native_value = 32.0
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(6)
+
+    assert entity._attr_native_value == 32.0
+    assert entity.calls == [("test_cpid", 6.0, 0)]


### PR DESCRIPTION
Closes #2049, implementing option 2 as you chose:

> Agree with implementing option 2 as it makes the user aware there's an issue

## The change

`async_set_native_value` still moves the slider first — a slow charger shouldn't make the drag feel unresponsive — but on failure it now puts the previous value back, writes it, and raises.

Both failure shapes are covered, because both were being swallowed:

* **falsy return** (v16 refusal, or charger not connected) → revert and raise with the requested value in the message
* **`HomeAssistantError`** from a rejected profile → revert and **re-raise untouched**, so the charger's own `status_info` survives; it is the only explanation of why, and wrapping it would lose the useful part
* **any other exception** (transport, timeout) → revert and raise, since the live case arrived as a CallError out of the library rather than a `False` return

New `set_charge_rate_error` exception string in `en.json` / `i-default.json`.

## Why this one is worth the behaviour change

Found on hardware, and it's the reason I raised the issue rather than just noting it: on a FoxESS A022KP1 whose 2.0.1 firmware rejects every `SetChargingProfile`, the slider read **16 A** while a clamp meter on the circuit read **30.6 A** — indefinitely, with only a log line to say otherwise.

For most entities an optimistic value that quietly diverges is cosmetic. This one is the only thing telling the user what the circuit is limited to, so someone limiting a shared feed can believe it is capped when it isn't.

## Worth flagging

This is a deliberate behaviour change for **automations**: `number.set_value` against a refusing charger now raises instead of failing silently, so a script that sets a limit will stop rather than continue on a false assumption. That is the intent of option 2, but it will be visible to anyone whose charger refuses limits today and who hasn't noticed.

## Testing

8 tests in `tests/test_number_limit_refusal.py`; 258 pass overall; pre-commit green.

Mutation-verified — each fails the tests aimed at it and no others:

| Mutation | Tests failed |
|---|---|
| no revert on falsy result (the pre-fix behaviour) | 4 |
| revert the attribute but skip the state write | 1 |
| swallow the charger's reason, raise a generic error | 1 |
| don't revert on an unexpected exception | 1 |
| write state only after the call (kills optimistic movement) | 2 |

The last one is there deliberately: it pins that the slider still moves *before* the call, so a future change can't quietly turn this into a blocking write.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charging current limit updates with immediate UI feedback.
  * Automatically restores the previous limit when a charger rejects, cannot apply, or is offline.
  * Prevents older concurrent requests from overwriting newer accepted limits.
  * Errors are now surfaced clearly, including available charger error details.

* **Translations**
  * Added localized messages for charging current limit failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->