### PR TITLE
Unload platforms based on what setup did, not on who is connected

### DIFF
--- a/custom_components/ocpp/__init__.py
+++ b/custom_components/ocpp/__init__.py
@@ -132,6 +132,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         central_sys.platforms_forwarded = True
 
+    # Registered after the forward deliberately: a discovery-driven
+    # entry update must not be able to trigger a reload in the window
+    # between the platforms being forwarded and the flag being set.
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
@@ -257,7 +260,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 unloaded = await hass.config_entries.async_unload_platforms(
                     entry, PLATFORMS
                 )
+                _LOGGER.debug(
+                    "Unloaded entity platforms for %s: %s", entry.title, unloaded
+                )
             else:
+                # Setup never forwarded them (no charger was configured),
+                # so there is nothing to tear down - and asking Home
+                # Assistant to unload never-forwarded platforms fails.
+                _LOGGER.debug(
+                    "No entity platforms were forwarded for %s; skipping unload",
+                    entry.title,
+                )
                 unloaded = True
             # Remove entry
             if unloaded:

--- a/custom_components/ocpp/__init__.py
+++ b/custom_components/ocpp/__init__.py
@@ -130,6 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if entry.data[CONF_CPIDS]:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        central_sys.platforms_forwarded = True
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -245,13 +246,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # print(hass.services.async_services_for_domain(DOMAIN))
             for service in hass.services.async_services_for_domain(DOMAIN):
                 hass.services.async_remove(DOMAIN, service)
-            # Unload platforms if a charger connected
-            if central_sys.connections == 0:
-                unloaded = True
-            else:
+            # Unload the platforms if - and only if - setup forwarded them.
+            # Deciding from the live connection count skipped the unload
+            # whenever every configured charger happened to be offline, and
+            # the next setup's forward then collided ("has already been
+            # setup!"), killing every entity platform until Core restarted.
+            # A reload with the charger offline is exactly the reconfigure-
+            # to-fix-the-connection case, so the two met constantly.
+            if central_sys.platforms_forwarded:
                 unloaded = await hass.config_entries.async_unload_platforms(
                     entry, PLATFORMS
                 )
+            else:
+                unloaded = True
             # Remove entry
             if unloaded:
                 hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -110,6 +110,11 @@ class CentralSystem:
         self.charge_points = {}  # uses cp_id as reference to charger instance
         self.cpids = {}  # dict of {cpid:cp_id}
         self.connections = 0
+        # Whether async_setup_entry forwarded the entity platforms. Unload
+        # has to mirror that exact decision - deriving it from anything
+        # live (connection count, current entry data) diverges from what
+        # setup actually did whenever state changed in between.
+        self.platforms_forwarded = False
 
         # Register custom services with home assistant
         self.hass.services.async_register(

--- a/tests/test_reload_offline_charger.py
+++ b/tests/test_reload_offline_charger.py
@@ -1,0 +1,192 @@
+"""Reloading the entry while the charger is offline must not kill the platforms.
+
+async_setup_entry forwards the entity platforms when a charger is
+*configured* (CONF_CPIDS non-empty); async_unload_entry tore them down only
+when one was *connected* (connections != 0). The two predicates diverge
+exactly when every configured charger is offline at reload time: unload
+skipped the teardown but claimed success, the next setup's forward collided
+with the still-registered platforms ("has already been setup!"), and every
+entity platform was dead until Core restarted - while the entry reported
+loaded and the websocket server listened, so nothing looked wrong.
+
+A reload with the charger offline is not an edge case. It is precisely the
+reconfigure-to-fix-the-connection scenario the reconfigure flow exists for,
+and it is how the live incident happened: a protocol mismatch kept the
+charger in a refused-handshake loop, and submitting the corrected settings
+bricked the integration instead of fixing it.
+
+Home Assistant swallows the per-platform ValueError into an
+"Error setting up entry" log line and setup still returns True, which is
+why the pre-existing reload test passed for years while stepping on this
+on every run. These tests assert on the log and the platform bookkeeping,
+not on hass.data shape.
+"""
+
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ocpp.const import CONF_CPIDS, DOMAIN
+
+from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_DATA_1, MOCK_CONFIG_CP_APPEND
+
+PLATFORM_DOMAINS = ("sensor", "switch", "number", "button")
+
+
+async def _load_platform_components(hass):
+    """Load the platform integrations globally, as any real install has.
+
+    Without this the harness lets an over-eager unload off the hook: core
+    short-circuits unloading a platform whose component is not loaded at
+    all, a state that does not exist on a live system.
+    """
+    for domain in PLATFORM_DOMAINS:
+        assert await async_setup_component(hass, domain, {})
+    await hass.async_block_till_done()
+
+
+def _setup_errors(caplog):
+    """Return the swallowed platform-collision log records."""
+    return [
+        record
+        for record in caplog.records
+        if "Error setting up entry" in record.getMessage()
+        or "has already been setup" in record.getMessage()
+    ]
+
+
+def _platforms_holding(hass, entry_id):
+    """Return which entity platforms currently hold this entry."""
+    components = hass.data.get("entity_components", {})
+    return {
+        domain
+        for domain in PLATFORM_DOMAINS
+        if domain in components and entry_id in components[domain]._platforms
+    }
+
+
+async def test_reload_with_charger_offline_keeps_every_platform(
+    hass, bypass_get_data, caplog
+):
+    """The live incident: configured charger, zero connections, one reload."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA_1,
+        entry_id="test_offline_reload",
+        title="test_offline_reload",
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _setup_errors(caplog) == []
+    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+    # The slider must exist and belong to the live platforms, not linger as
+    # an orphan of the pre-reload ones.
+    assert hass.states.get("number.test_cpid_9001_connector_1_maximum_current")
+
+
+async def test_a_second_offline_reload_is_also_clean(hass, bypass_get_data, caplog):
+    """Users retry: reconfigure, still not connecting, reconfigure again.
+
+    The first reload used to leave the stale platforms registered, so every
+    further reload collided the same way. Two consecutive reloads pin that
+    the bookkeeping stays consistent, not just that one pass survives.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA_1,
+        entry_id="test_offline_reload_twice",
+        title="test_offline_reload_twice",
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _setup_errors(caplog) == []
+    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+
+
+async def test_reload_of_a_chargerless_entry_stays_clean(hass, bypass_get_data, caplog):
+    """A fresh central system with no charger yet forwards no platforms.
+
+    Unloading platforms that were never forwarded raises inside Home
+    Assistant ("Config entry was never loaded!"), so the unload path must
+    skip them here - the flag has to track what setup did, in both
+    directions.
+    """
+    await _load_platform_components(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA},
+        entry_id="test_fresh_reload",
+        title="test_fresh_reload",
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert _platforms_holding(hass, entry.entry_id) == set()
+
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _setup_errors(caplog) == []
+    assert not [
+        r for r in caplog.records if "Config entry was never loaded" in r.getMessage()
+    ]
+
+
+async def test_first_charger_discovery_reload_transitions_cleanly(
+    hass, bypass_get_data, caplog
+):
+    """The growth edge: setup ran with no chargers, then the first arrives.
+
+    Discovery appends the charger to CONF_CPIDS and the update listener
+    reloads. At that moment the entry data says "charger configured" but
+    the running setup never forwarded platforms - so an unload predicate
+    reading the entry data would try to unload platforms that do not
+    exist. The flag records what this setup actually did instead.
+    """
+    await _load_platform_components(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA},
+        entry_id="test_growth_reload",
+        title="test_growth_reload",
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_CPIDS: [{"CP_new": {**MOCK_CONFIG_CP_APPEND}}]},
+    )
+    await hass.async_block_till_done()
+
+    assert _setup_errors(caplog) == []
+    assert not [
+        r for r in caplog.records if "Config entry was never loaded" in r.getMessage()
+    ]
+    # The reload's fresh setup saw the charger and forwarded the platforms.
+    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)

--- a/tests/test_reload_offline_charger.py
+++ b/tests/test_reload_offline_charger.py
@@ -18,10 +18,18 @@ bricked the integration instead of fixing it.
 Home Assistant swallows the per-platform ValueError into an
 "Error setting up entry" log line and setup still returns True, which is
 why the pre-existing reload test passed for years while stepping on this
-on every run. These tests assert on the log and the platform bookkeeping,
-not on hass.data shape.
+on every run. The load-bearing assertion here is therefore structural -
+the entity object must be a fresh instance created by the post-reload
+platforms, because the bug's signature is the OLD platforms surviving
+with their old entities. The log check is a secondary signal only, and
+tracks Home Assistant core wording.
 """
 
+import asyncio
+from unittest.mock import patch
+
+import pytest
+import websockets.asyncio.server
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -30,6 +38,26 @@ from custom_components.ocpp.const import CONF_CPIDS, DOMAIN
 from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_DATA_1, MOCK_CONFIG_CP_APPEND
 
 PLATFORM_DOMAINS = ("sensor", "switch", "number", "button")
+
+
+@pytest.fixture(name="bypass_websockets")
+def bypass_websockets_fixture():
+    """Stub only the websocket server, unlike conftest's bypass_get_data.
+
+    That fixture also patches StateMachine.get to always return a State,
+    which poisons core's duplicate-entity check on reload: every re-added
+    entity looks like a live duplicate and is silently discarded, so a
+    genuinely clean reload appears broken. These tests are about reload
+    correctness, so they must run against the real state machine.
+    """
+    future = asyncio.Future()
+    future.set_result(websockets.asyncio.server.Server)
+    with (
+        patch("websockets.asyncio.server.serve", return_value=future),
+        patch("websockets.asyncio.server.Server.close"),
+        patch("websockets.asyncio.server.Server.wait_closed"),
+    ):
+        yield
 
 
 async def _load_platform_components(hass):
@@ -55,7 +83,13 @@ def _setup_errors(caplog):
 
 
 def _platforms_holding(hass, entry_id):
-    """Return which entity platforms currently hold this entry."""
+    """Return which entity platforms currently hold this entry.
+
+    Reads EntityComponent._platforms, which is core-private: a rename
+    breaks this helper loudly (KeyError), not silently. Accepted because
+    the public surface has no way to ask "who holds this entry", and the
+    freshness assertions below do not depend on it.
+    """
     components = hass.data.get("entity_components", {})
     return {
         domain
@@ -64,8 +98,13 @@ def _platforms_holding(hass, entry_id):
     }
 
 
+def _live_entity(hass, entity_id):
+    """Return the entity object the number platform currently owns."""
+    return hass.data["entity_components"]["number"].get_entity(entity_id)
+
+
 async def test_reload_with_charger_offline_keeps_every_platform(
-    hass, bypass_get_data, caplog
+    hass, bypass_websockets, caplog
 ):
     """The live incident: configured charger, zero connections, one reload."""
     entry = MockConfigEntry(
@@ -81,18 +120,25 @@ async def test_reload_with_charger_offline_keeps_every_platform(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+    eid = "number.test_cpid_9001_connector_1_maximum_current"
+    entity_before = _live_entity(hass, eid)
+    assert entity_before is not None
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
 
+    # The structural check: a clean reload tears the platforms down and
+    # builds new ones, so the entity must be a fresh object. The broken
+    # path leaves the pre-reload platforms - and this exact entity
+    # instance - in place, whatever the logs say.
+    entity_after = _live_entity(hass, eid)
+    assert entity_after is not None
+    assert entity_after is not entity_before
     assert _setup_errors(caplog) == []
     assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
-    # The slider must exist and belong to the live platforms, not linger as
-    # an orphan of the pre-reload ones.
-    assert hass.states.get("number.test_cpid_9001_connector_1_maximum_current")
 
 
-async def test_a_second_offline_reload_is_also_clean(hass, bypass_get_data, caplog):
+async def test_a_second_offline_reload_is_also_clean(hass, bypass_websockets, caplog):
     """Users retry: reconfigure, still not connecting, reconfigure again.
 
     The first reload used to leave the stale platforms registered, so every
@@ -111,17 +157,25 @@ async def test_a_second_offline_reload_is_also_clean(hass, bypass_get_data, capl
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    eid = "number.test_cpid_9001_connector_1_maximum_current"
+    entity_start = _live_entity(hass, eid)
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
+    entity_mid = _live_entity(hass, eid)
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
+    entity_end = _live_entity(hass, eid)
 
+    assert entity_start is not entity_mid
+    assert entity_mid is not entity_end
     assert _setup_errors(caplog) == []
     assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
 
 
-async def test_reload_of_a_chargerless_entry_stays_clean(hass, bypass_get_data, caplog):
+async def test_reload_of_a_chargerless_entry_stays_clean(
+    hass, bypass_websockets, caplog
+):
     """A fresh central system with no charger yet forwards no platforms.
 
     Unloading platforms that were never forwarded raises inside Home
@@ -132,7 +186,11 @@ async def test_reload_of_a_chargerless_entry_stays_clean(hass, bypass_get_data, 
     await _load_platform_components(hass)
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA},
+        # CONF_CPIDS pinned to empty explicitly: conftest's
+        # setup_config_entry fixture shallow-copies MOCK_CONFIG_DATA and
+        # appends to the shared CONF_CPIDS list, so by this point in a full
+        # run the module-level constant is no longer chargerless.
+        data={**MOCK_CONFIG_DATA, CONF_CPIDS: []},
         entry_id="test_fresh_reload",
         title="test_fresh_reload",
         version=2,
@@ -154,7 +212,7 @@ async def test_reload_of_a_chargerless_entry_stays_clean(hass, bypass_get_data, 
 
 
 async def test_first_charger_discovery_reload_transitions_cleanly(
-    hass, bypass_get_data, caplog
+    hass, bypass_websockets, caplog
 ):
     """The growth edge: setup ran with no chargers, then the first arrives.
 
@@ -167,7 +225,7 @@ async def test_first_charger_discovery_reload_transitions_cleanly(
     await _load_platform_components(hass)
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA},
+        data={**MOCK_CONFIG_DATA, CONF_CPIDS: []},
         entry_id="test_growth_reload",
         title="test_growth_reload",
         version=2,


### PR DESCRIPTION
Closes #2053.

Setup forwards the entity platforms when a charger is **configured** (`CONF_CPIDS` non-empty); unload tore them down only when one was **connected** (`connections != 0`). Reload while every configured charger is offline and the teardown is skipped but reported successful — the next setup's forward then collides with the still-registered platforms (`ValueError: … has already been setup!`, once per platform), Home Assistant swallows the errors, and the entry sits there looking loaded with every entity dead until Core restarts. Found live: reconfiguring a charger that was stuck in a connection loop bricked the integration instead of fixing it. Full mechanism, wire capture and the reason CI never saw it are in the issue.

## The fix

Record on the central system whether setup actually forwarded the platforms, and unload exactly when it did:

```python
if entry.data[CONF_CPIDS]:
    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
    central_sys.platforms_forwarded = True
...
if central_sys.platforms_forwarded:
    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
else:
    unloaded = True
```

Both "obvious" one-line fixes fail an edge, and the regression tests pin each:

* **Keep the connection count** → this bug (offline charger skips the teardown).
* **Read `entry.data[CONF_CPIDS]` at unload time** → the first-discovery reload breaks: discovery appends the charger and reloads, so the entry data says "configured" while the running setup never forwarded — unloading never-forwarded platforms raises `Config entry was never loaded!` inside HA. A bare test harness hides this because core short-circuits when the platform component isn't globally loaded, so the tests load `sensor`/`switch`/`number`/`button` globally first, as any real install has.

The update listener stays registered *after* the forward, and that ordering is now commented as load-bearing: a discovery-driven entry update must not be able to reload in the window between the forward and the flag.

Incidental improvements for free: entry removal and HA shutdown with an offline charger now tear the platforms down properly too.

## Tests are structural, not log-shaped

The bug's signature is the *old* platforms surviving with their old entities, so the load-bearing assertion is entity object identity across the reload — a fresh instance proves the platforms were genuinely rebuilt, whatever the logs say. Verified by running the pre-fix code with the log-matching helper removed entirely: the identity assertion fails it on its own. The log check remains as a secondary signal and is commented as tracking HA core wording.

Four tests: the live incident shape, a retry (two consecutive offline reloads), a chargerless entry (unload must skip), and the first-discovery transition (unload must skip, the reload's fresh setup must forward). 254 pass overall.

Mutation-verified — each fails the tests aimed at it:

| Mutation | Killed by |
|---|---|
| pre-fix predicate (`connections == 0` skips) | both offline-reload tests |
| flag never set on forward | both offline-reload tests |
| unload reads `entry.data[CONF_CPIDS]` instead | first-discovery test |
| always unload regardless | chargerless + first-discovery tests |
| pre-fix predicate **with the log matcher deleted** | offline-reload tests, via identity alone |

## Two pre-existing test-infrastructure traps, worked around here, raised separately

Writing structural tests flushed out two conftest issues that mask this whole class of failure (filed as their own issue so they get a proper look rather than drive-by edits):

* `bypass_get_data` patches `StateMachine.get` to always return a State, which poisons core's duplicate-entity check on reload — every re-added entity looks like a live duplicate and is silently dropped. These tests use a websockets-only stub instead.
* `setup_config_entry` shallow-copies `MOCK_CONFIG_DATA` and appends to the shared `CONF_CPIDS` list, so the "chargerless" constant stops being chargerless partway through a full run. The chargerless tests pin `CONF_CPIDS: []` explicitly.

One residual window, deliberately not handled: if `async_forward_entry_setups` itself raises (cancellation mid-setup), platforms can be left registered with no unload possible — but HA core skips an integration's `async_unload_entry` entirely for a not-LOADED entry, so no code in this integration can run to clean it up. That window belongs to core's lifecycle, not this repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reloading for offline chargers so their entities are recreated reliably.
  * Prevented platform conflicts during repeated reloads.
  * Improved handling when entries have no active charger connections.
  * Ensured platform setup transitions safely when a charger is discovered after initial setup.

* **Tests**
  * Added coverage for offline reloads, repeated reloads, chargerless entries, and first-charger discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->