### PR TITLE
Record heartbeats on OCPP 2.0.1

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -958,7 +958,14 @@ class ChargePoint(cp):
     @on(Action.heartbeat)
     def on_heartbeat(self, **kwargs):
         """Perform OCPP callback."""
-        return call_result.Heartbeat(current_time=datetime.now(tz=UTC).isoformat())
+        # Mirrors the OCPP 1.6 handler: record the heartbeat and push the
+        # entities, so sensor.<cpid>_heartbeat tracks the charger. Without
+        # the write the sensor keeps whatever an earlier session left -
+        # heartbeats were answered here but recorded nowhere.
+        now = datetime.now(tz=UTC)
+        self._metrics[(0, cstat.heartbeat.value)].value = now
+        self.hass.async_create_task(self.update(self.settings.cpid))
+        return call_result.Heartbeat(current_time=now.isoformat())
 
     def _report_evse_status(
         self,

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -965,6 +965,9 @@ class ChargePoint(cp):
         now = datetime.now(tz=UTC)
         self._metrics[(0, cstat.heartbeat.value)].value = now
         self.hass.async_create_task(self.update(self.settings.cpid))
+        # Deliberately not mirrored: 1.6 replies with whole seconds
+        # (strftime %H:%M:%SZ); 2.0.1 keeps its pre-existing isoformat
+        # reply, microseconds and all - both are valid RFC 3339.
         return call_result.Heartbeat(current_time=now.isoformat())
 
     def _report_evse_status(

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1063,10 +1063,15 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
     )
 
     heartbeat_resp: call_result.Heartbeat = await cp.call(call.Heartbeat())
-    datetime.fromisoformat(heartbeat_resp.current_time)
+    heartbeat_time = datetime.fromisoformat(heartbeat_resp.current_time)
 
     cp_id = cp.id[:-7]
     cpid = cs.charge_points[cp_id].settings.cpid
+
+    # Checking only the reply let a metric-less handler pass for the bug's
+    # whole life: the sensor's backing metric must hold the same instant
+    # the charger was told.
+    assert cs.get_metric(cpid, cstat.heartbeat.value) == heartbeat_time
 
     await wait_ready(cs.charge_points[cp_id])
 

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -1,0 +1,110 @@
+"""The heartbeat sensor must track the charger on OCPP 2.0.1.
+
+The v201 heartbeat handler answered the charger but recorded nothing, so
+sensor.<cpid>_heartbeat kept whatever an earlier session left - on a
+charger switched from 1.6 it showed the 1.6-era timestamp all day while
+2.0.1 heartbeats arrived on the wire. The 1.6 handler writes the metric
+and pushes the entities; 2.0.1 now mirrors it.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, UTC
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from websockets.protocol import State
+
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import HAChargerStatuses as cstat
+from custom_components.ocpp.ocppv201 import ChargePoint
+
+from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
+
+
+def _mk_cp(hass):
+    """Build a v201 ChargePoint detached from any real connection."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp2.0.1"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp2.0.1",
+    )
+    return ChargePoint("CP_A", conn, hass, entry, central, charger)
+
+
+@pytest.mark.asyncio
+async def test_a_heartbeat_writes_the_metric(hass):
+    """The sensor's backing metric must move when the charger beats."""
+    cp = _mk_cp(hass)
+    stale = datetime(2026, 8, 8, 0, 41, 40, tzinfo=UTC)
+    cp._metrics[(0, cstat.heartbeat.value)].value = stale
+
+    with patch.object(ChargePoint, "update", AsyncMock()):
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+
+    recorded = cp._metrics[(0, cstat.heartbeat.value)].value
+    assert recorded != stale
+    assert datetime.now(tz=UTC) - recorded < timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_the_reply_and_the_metric_agree(hass):
+    """The time told to the charger is the time shown to the user."""
+    cp = _mk_cp(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()):
+        result = cp.on_heartbeat()
+        await hass.async_block_till_done()
+
+    recorded = cp._metrics[(0, cstat.heartbeat.value)].value
+    assert result.current_time == recorded.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_the_entities_are_pushed(hass):
+    """Writing the metric is not enough; the sensor updates on push.
+
+    The 1.6 handler schedules an entity update on every heartbeat so the
+    sensor refreshes without waiting for another state change; parity
+    matters because on an idle charger heartbeats may be the only traffic.
+    """
+    cp = _mk_cp(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+
+    update.assert_awaited_once_with("test_cpid")

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -8,7 +8,7 @@ and pushes the entities; 2.0.1 now mirrors it.
 """
 
 import asyncio
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, UTC
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -71,13 +71,16 @@ async def test_a_heartbeat_writes_the_metric(hass):
     stale = datetime(2026, 8, 8, 0, 41, 40, tzinfo=UTC)
     cp._metrics[(0, cstat.heartbeat.value)].value = stale
 
+    before = datetime.now(tz=UTC)
     with patch.object(ChargePoint, "update", AsyncMock()):
         cp.on_heartbeat()
         await hass.async_block_till_done()
+    after = datetime.now(tz=UTC)
 
     recorded = cp._metrics[(0, cstat.heartbeat.value)].value
     assert recorded != stale
-    assert datetime.now(tz=UTC) - recorded < timedelta(seconds=5)
+    # Bounded by the test's own clock reads - no wall-clock window to flake.
+    assert before <= recorded <= after
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2056.

The v201 heartbeat handler answered the charger but recorded nothing, so `sensor.<cpid>_heartbeat` kept whatever an earlier session left — observed live on a FoxESS A022KP1 that switched from 1.6 to 2.0.1 mid-morning and showed the 1.6-era timestamp all day through wire-confirmed 2.0.1 heartbeats. The stale value looks plausible, which is presumably why nobody noticed.

## The fix

Mirrors the 1.6 handler in v201's own idiom: write the heartbeat metric, schedule the entity push — on an idle charger, heartbeats can be the only traffic, so without the push the sensor waits for an unrelated state change — and reply with the **same instant** that was recorded, so the charger and the sensor cannot disagree about what time we claimed. One deliberate non-mirror, now commented as such: 1.6 replies with whole seconds, 2.0.1 keeps its pre-existing `isoformat` reply (both valid RFC 3339).

## The existing test is now load-bearing

`test_cms_responses_v201` sends a real `Heartbeat` on every CI run and could not see this bug, because it parsed the reply and never read the metric. It now asserts the sensor's backing metric equals the parsed reply time — the pre-fix handler fails it. Same pattern as the reload-test conversion in #2054: assert structure, not just that the call answered.

## Testing

3 focused tests (metric moves off a stale value with the freshness bound taken from the test's own clock reads; reply and metric agree; entities pushed) plus the integration-test assertion. 253 pass overall.

Mutation-verified — each fails the tests aimed at it:

| Mutation | Killed by |
|---|---|
| metric write removed (pre-fix behaviour) | unit tests **and** `test_cms_responses_v201` |
| entity push removed | `test_the_entities_are_pushed` |
| written to a per-connector key | reply/metric agreement test |

## Noted, not done here

The entity push is full 1.6 parity: `update(cpid)` walks the device registry and force-refreshes every entity of the charger, at a rate the charger controls. That cost has run on the 1.6 path for years and is inherited unchanged — a targeted dispatch of just the heartbeat entity would serve both paths better, but it touches the shared dispatch machinery for both protocols, so it belongs in its own change if wanted rather than riding on a display fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCPP 2.0.1 heartbeat handling so the heartbeat metric and response use the same UTC timestamp.
  * Heartbeat events now trigger timely Home Assistant entity updates.

* **Tests**
  * Added coverage verifying heartbeat timestamps, metric updates, and charger entity refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->