### PR TITLE
Refresh only the sensors a write actually touched

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -65,6 +65,7 @@ from .const import (
     HA_ENERGY_UNIT,
     HA_POWER_UNIT,
     UNITS_OCCP_TO_HA,
+    sensor_unique_id,
 )
 
 TIME_MINUTES = UnitOfTime.MINUTES
@@ -509,6 +510,11 @@ class ChargePoint(cp):
                 )
                 self._metrics[(0, cstat.latency_ping.value)].value = latency_ping
                 self._metrics[(0, cstat.latency_pong.value)].value = latency_pong
+                # This loop is these sensors' only publisher: nothing
+                # message-driven republishes them on an idle charger.
+                self._async_refresh_metric_entities(
+                    [cstat.latency_ping.value, cstat.latency_pong.value]
+                )
 
             except TimeoutError as timeout_exception:
                 timeout_counter += 1
@@ -518,6 +524,9 @@ class ChargePoint(cp):
                 )
                 self._metrics[(0, cstat.latency_ping.value)].value = latency_ping
                 self._metrics[(0, cstat.latency_pong.value)].value = latency_pong
+                self._async_refresh_metric_entities(
+                    [cstat.latency_ping.value, cstat.latency_pong.value]
+                )
 
                 if timeout_counter > self.cs_settings.websocket_ping_tries:
                     _LOGGER.debug(
@@ -610,29 +619,30 @@ class ChargePoint(cp):
             if not self.post_connect_success:
                 self.hass.async_create_task(self.post_connect())
 
-    def _async_refresh_heartbeat_entity(self) -> None:
-        """Refresh only the heartbeat sensor.
+    def _async_refresh_metric_entities(self, metrics: list[str]) -> None:
+        """Refresh only the sensors backing the given charger-level metrics.
 
-        A heartbeat changes exactly one metric, at whatever rate the
-        charger chooses; the full update() walks the device registry and
-        force-refreshes every entity of this charger, which is a lot of
-        work for one timestamp on an otherwise idle system. Resolve the
-        heartbeat sensor through the entity registry - rename-proof, the
-        dispatcher filter matches on current entity_id - and dispatch it
-        alone. Falls back to the full update when the entity is not
-        registered yet, as the first heartbeat can arrive before the
-        platforms finish adding entities.
+        High-rate writers - heartbeats arriving at whatever rate the
+        charger chooses, the latency ping loop every ping interval - must
+        not pay for the full update(), which walks the device registry and
+        force-refreshes every entity of this charger for a change to one
+        or two values. Each sensor is resolved through the entity registry
+        by its canonical unique_id - rename-proof, since the dispatcher
+        filter matches on current entity_id - and only those entities are
+        dispatched. Falls back to the full update when any sensor is not
+        registered yet, as the first write can arrive before the platforms
+        finish adding entities.
         """
         er = entity_registry.async_get(self.hass)
-        # Mirrors the sensor's unique_id construction: the description key
-        # is the metric name lowercased with dots replaced.
-        key = cstat.heartbeat.value.lower().replace(".", "_")
-        uid = ".".join([DOMAIN, self.settings.cpid, key, SENSOR_DOMAIN])
-        entity_id = er.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, uid)
-        if entity_id is None:
-            self.hass.async_create_task(self.update(self.settings.cpid))
-            return
-        async_dispatcher_send(self.hass, DATA_UPDATED, {entity_id})
+        entity_ids: set[str] = set()
+        for metric in metrics:
+            uid = sensor_unique_id(self.settings.cpid, metric)
+            entity_id = er.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, uid)
+            if entity_id is None:
+                self.hass.async_create_task(self.update(self.settings.cpid))
+                return
+            entity_ids.add(entity_id)
+        async_dispatcher_send(self.hass, DATA_UPDATED, entity_ids)
 
     async def update(self, cpid: str):
         """Update sensors values in HA (charger + connector child devices)."""

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_OK, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.const import UnitOfTime
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from websockets.asyncio.server import ServerConnection
@@ -608,6 +609,30 @@ class ChargePoint(cp):
             self.hass.async_create_task(self.notify_ha(f"Charger {self.id} rebooted"))
             if not self.post_connect_success:
                 self.hass.async_create_task(self.post_connect())
+
+    def _async_refresh_heartbeat_entity(self) -> None:
+        """Refresh only the heartbeat sensor.
+
+        A heartbeat changes exactly one metric, at whatever rate the
+        charger chooses; the full update() walks the device registry and
+        force-refreshes every entity of this charger, which is a lot of
+        work for one timestamp on an otherwise idle system. Resolve the
+        heartbeat sensor through the entity registry - rename-proof, the
+        dispatcher filter matches on current entity_id - and dispatch it
+        alone. Falls back to the full update when the entity is not
+        registered yet, as the first heartbeat can arrive before the
+        platforms finish adding entities.
+        """
+        er = entity_registry.async_get(self.hass)
+        # Mirrors the sensor's unique_id construction: the description key
+        # is the metric name lowercased with dots replaced.
+        key = cstat.heartbeat.value.lower().replace(".", "_")
+        uid = ".".join([DOMAIN, self.settings.cpid, key, SENSOR_DOMAIN])
+        entity_id = er.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, uid)
+        if entity_id is None:
+            self.hass.async_create_task(self.update(self.settings.cpid))
+            return
+        async_dispatcher_send(self.hass, DATA_UPDATED, {entity_id})
 
     async def update(self, cpid: str):
         """Update sensors values in HA (charger + connector child devices)."""

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -275,6 +275,9 @@ class ChargePoint(cp):
         self.triggered_boot_notification = False
         self.received_boot_notification = False
         self.post_connect_success = False
+        # Set once every sensor requested by a targeted refresh has
+        # resolved; bounds the full-update fallback to the startup window.
+        self._targeted_refresh_ready = False
         self.tasks = None
         self._charger_reports_session_energy = False
 
@@ -647,6 +650,12 @@ class ChargePoint(cp):
         resolve - the next tick republishes anyway, and falling back at
         ping rate would run the full registry walk more often than the
         behaviour this replaces.
+
+        The fallback is bounded to that startup window: once every
+        requested sensor has resolved, a later miss means the entity was
+        removed from the registry, and there is nothing to refresh for a
+        deleted entity - falling back there would silently reinstate the
+        full walk at the writer's rate, forever.
         """
         er = entity_registry.async_get(self.hass)
         entity_ids: set[str] = set()
@@ -658,9 +667,12 @@ class ChargePoint(cp):
                 missing = True
             else:
                 entity_ids.add(entity_id)
-        if missing and fallback_to_full_update:
-            self.hass.async_create_task(self.update(self.settings.cpid))
-            return
+        if missing:
+            if fallback_to_full_update and not self._targeted_refresh_ready:
+                self.hass.async_create_task(self.update(self.settings.cpid))
+                return
+        else:
+            self._targeted_refresh_ready = True
         if entity_ids:
             async_dispatcher_send(self.hass, DATA_UPDATED, entity_ids)
 

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -71,6 +71,11 @@ from .const import (
 TIME_MINUTES = UnitOfTime.MINUTES
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+# Seconds before monitor_connection starts post_connect for chargers that
+# never send a boot notification. Module-level so tests can shrink it
+# without monkeypatching asyncio.sleep globally.
+MONITOR_BACKSTOP_DELAY = 10
+
 
 class Metric:
     """Metric class."""
@@ -481,7 +486,7 @@ class ChargePoint(cp):
 
         # Add backstop to start post connect for non-compliant chargers
         # after 10s to allow for when a boot notification has not been received
-        await asyncio.sleep(10)
+        await asyncio.sleep(MONITOR_BACKSTOP_DELAY)
         if not self.post_connect_success:
             self.hass.async_create_task(self.post_connect())
 
@@ -513,7 +518,8 @@ class ChargePoint(cp):
                 # This loop is these sensors' only publisher: nothing
                 # message-driven republishes them on an idle charger.
                 self._async_refresh_metric_entities(
-                    [cstat.latency_ping.value, cstat.latency_pong.value]
+                    [cstat.latency_ping.value, cstat.latency_pong.value],
+                    fallback_to_full_update=False,
                 )
 
             except TimeoutError as timeout_exception:
@@ -525,7 +531,8 @@ class ChargePoint(cp):
                 self._metrics[(0, cstat.latency_ping.value)].value = latency_ping
                 self._metrics[(0, cstat.latency_pong.value)].value = latency_pong
                 self._async_refresh_metric_entities(
-                    [cstat.latency_ping.value, cstat.latency_pong.value]
+                    [cstat.latency_ping.value, cstat.latency_pong.value],
+                    fallback_to_full_update=False,
                 )
 
                 if timeout_counter > self.cs_settings.websocket_ping_tries:
@@ -619,7 +626,9 @@ class ChargePoint(cp):
             if not self.post_connect_success:
                 self.hass.async_create_task(self.post_connect())
 
-    def _async_refresh_metric_entities(self, metrics: list[str]) -> None:
+    def _async_refresh_metric_entities(
+        self, metrics: list[str], *, fallback_to_full_update: bool = True
+    ) -> None:
         """Refresh only the sensors backing the given charger-level metrics.
 
         High-rate writers - heartbeats arriving at whatever rate the
@@ -629,20 +638,31 @@ class ChargePoint(cp):
         or two values. Each sensor is resolved through the entity registry
         by its canonical unique_id - rename-proof, since the dispatcher
         filter matches on current entity_id - and only those entities are
-        dispatched. Falls back to the full update when any sensor is not
-        registered yet, as the first write can arrive before the platforms
-        finish adding entities.
+        dispatched.
+
+        A sensor can be unregistered when the first write beats the
+        platforms to it. Event-driven callers fall back to the full update
+        so the write is not lost; periodic callers pass
+        fallback_to_full_update=False and simply dispatch whatever did
+        resolve - the next tick republishes anyway, and falling back at
+        ping rate would run the full registry walk more often than the
+        behaviour this replaces.
         """
         er = entity_registry.async_get(self.hass)
         entity_ids: set[str] = set()
+        missing = False
         for metric in metrics:
             uid = sensor_unique_id(self.settings.cpid, metric)
             entity_id = er.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, uid)
             if entity_id is None:
-                self.hass.async_create_task(self.update(self.settings.cpid))
-                return
-            entity_ids.add(entity_id)
-        async_dispatcher_send(self.hass, DATA_UPDATED, entity_ids)
+                missing = True
+            else:
+                entity_ids.add(entity_id)
+        if missing and fallback_to_full_update:
+            self.hass.async_create_task(self.update(self.settings.cpid))
+            return
+        if entity_ids:
+            async_dispatcher_send(self.hass, DATA_UPDATED, entity_ids)
 
     async def update(self, cpid: str):
         """Update sensors values in HA (charger + connector child devices)."""

--- a/custom_components/ocpp/const.py
+++ b/custom_components/ocpp/const.py
@@ -73,6 +73,27 @@ DEFAULT_WEBSOCKET_PING_INTERVAL = 20
 DEFAULT_WEBSOCKET_PING_TIMEOUT = 20
 DOMAIN = "ocpp"
 CONFIG = "config"
+
+
+def sensor_unique_id(cpid: str, metric: str, connector_id: int | None = None) -> str:
+    """Return the canonical unique_id of the sensor backing a metric.
+
+    The single source of truth: ChargePointMetric builds its unique_id
+    from this, the stale-entity cleanup in sensor.py matches against it,
+    and chargepoint.py resolves entities through it for targeted refresh
+    dispatches. Hand-mirrored copies of this format drifted apart once
+    already (a copy that forgot the dot replacement never matched any
+    dotted metric), so changes belong here and nowhere else. And think
+    hard before changing it at all: unique_ids are persisted in the
+    entity registry, so a new format orphans every existing sensor.
+    """
+    key = str(metric).strip().lower().replace(".", "_")
+    parts = [DOMAIN, cpid, key, "sensor"]
+    if connector_id is not None:
+        parts.insert(2, f"conn{connector_id}")
+    return ".".join(parts)
+
+
 ICON = "mdi:ev-station"
 SLEEP_TIME = 60
 

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1230,5 +1230,5 @@ class ChargePoint(cp):
         """Handle a Heartbeat."""
         now = datetime.now(tz=UTC)
         self._metrics[0][cstat.heartbeat.value].value = now
-        self.hass.async_create_task(self.update(self.settings.cpid))
+        self._async_refresh_heartbeat_entity()
         return call_result.Heartbeat(current_time=now.strftime("%Y-%m-%dT%H:%M:%SZ"))

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1230,5 +1230,5 @@ class ChargePoint(cp):
         """Handle a Heartbeat."""
         now = datetime.now(tz=UTC)
         self._metrics[0][cstat.heartbeat.value].value = now
-        self._async_refresh_heartbeat_entity()
+        self._async_refresh_metric_entities([cstat.heartbeat.value])
         return call_result.Heartbeat(current_time=now.strftime("%Y-%m-%dT%H:%M:%SZ"))

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -964,7 +964,7 @@ class ChargePoint(cp):
         # heartbeats were answered here but recorded nowhere.
         now = datetime.now(tz=UTC)
         self._metrics[(0, cstat.heartbeat.value)].value = now
-        self.hass.async_create_task(self.update(self.settings.cpid))
+        self._async_refresh_heartbeat_entity()
         # Deliberately not mirrored: 1.6 replies with whole seconds
         # (strftime %H:%M:%SZ); 2.0.1 keeps its pre-existing isoformat
         # reply, microseconds and all - both are valid RFC 3339.

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -964,7 +964,7 @@ class ChargePoint(cp):
         # heartbeats were answered here but recorded nowhere.
         now = datetime.now(tz=UTC)
         self._metrics[(0, cstat.heartbeat.value)].value = now
-        self._async_refresh_heartbeat_entity()
+        self._async_refresh_metric_entities([cstat.heartbeat.value])
         # Deliberately not mirrored: 1.6 replies with whole seconds
         # (strftime %H:%M:%SZ); 2.0.1 keeps its pre-existing isoformat
         # reply, microseconds and all - both are valid RFC 3339.

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
+
 import homeassistant
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -33,6 +35,8 @@ from .const import (
     sensor_unique_id,
 )
 from .enums import HAChargerDetails, HAChargerSession, HAChargerStatuses
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 @dataclass
@@ -128,7 +132,20 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 uid = _uid(cpid, metric, connector_id=None)
                 stale_eid = ent_reg.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, uid)
                 if stale_eid:
-                    # Remove the old entity so it doesn't linger as 'unavailable'
+                    # Remove the old entity so it doesn't linger as
+                    # 'unavailable': with more than one connector these
+                    # metrics exist per-connector only, so the flat variant
+                    # is a genuine orphan. Removal destroys any rename or
+                    # customisation with it, so say what happened - for
+                    # dotted metrics this lookup never matched before the
+                    # unique_id format was single-sourced, meaning upgrades
+                    # can hit this for the first time long after setup.
+                    _LOGGER.info(
+                        "Removing stale charger-level entity %s; "
+                        "%s is per-connector on this charger",
+                        stale_eid,
+                        metric,
+                    )
                     ent_reg.async_remove(stale_eid)
 
         # Root/charger-entities

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     DOMAIN,
     ICON,
     Measurand,
+    sensor_unique_id,
 )
 from .enums import HAChargerDetails, HAChargerSession, HAChargerStatuses
 
@@ -113,12 +114,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
             )
 
         def _uid(cpid: str, key: str, connector_id: int | None) -> str:
-            """Mirror ChargePointMetric unique_id construction."""
-            key = key.lower()
-            parts = [DOMAIN, cpid, key, SENSOR_DOMAIN]
-            if connector_id is not None:
-                parts.insert(2, f"conn{connector_id}")
-            return ".".join(parts)
+            """Mirror ChargePointMetric unique_id construction.
+
+            Delegates to the canonical helper. The previous local copy
+            lowercased without replacing dots, so the stale-entity cleanup
+            below never matched any dotted metric (Status.Connector and
+            friends) - single-sourcing the format is what fixes that.
+            """
+            return sensor_unique_id(cpid, key, connector_id)
 
         if num_connectors > 1:
             for metric in CONNECTOR_ONLY:
@@ -204,10 +207,9 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
         self._hass = hass
         self._extra_attr = {}
         self._last_reset = homeassistant.util.dt.utc_from_timestamp(0)
-        parts = [DOMAIN, self.cpid, self.entity_description.key, SENSOR_DOMAIN]
-        if self.connector_id is not None:
-            parts.insert(2, f"conn{self.connector_id}")
-        self._attr_unique_id = ".".join(parts)
+        self._attr_unique_id = sensor_unique_id(
+            self.cpid, self.entity_description.metric, self.connector_id
+        )
         self._attr_name = self.entity_description.name
         if self.connector_id is not None:
             self._attr_device_info = DeviceInfo(

--- a/tests/test_sensor_stale_cleanup.py
+++ b/tests/test_sensor_stale_cleanup.py
@@ -97,9 +97,20 @@ async def test_single_connector_setup_removes_nothing(hass, bypass_websockets, c
 
     The cleanup must never fire there - removing the flat entity on a
     single-connector charger would delete the entity actually in use.
+    Seeding the flat entity first makes this assert something real: an
+    over-eager cleanup would remove it, where an empty registry would
+    let even a broken guard pass.
     """
     from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_CP_APPEND
     from custom_components.ocpp.const import CONF_CPIDS
+
+    registry = er.async_get(hass)
+    live = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        sensor_unique_id("test_cpid", cstat.status_connector.value),
+        suggested_object_id="test_cpid_status_connector",
+    )
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -117,6 +128,7 @@ async def test_single_connector_setup_removes_nothing(hass, bypass_websockets, c
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    assert registry.async_get(live.entity_id) is not None
     assert not [
         r
         for r in caplog.records

--- a/tests/test_sensor_stale_cleanup.py
+++ b/tests/test_sensor_stale_cleanup.py
@@ -1,0 +1,124 @@
+"""The multi-connector stale-entity cleanup must fire, and say so.
+
+When a charger reports more than one connector, the CONNECTOR_ONLY
+metrics exist per-connector and the charger-level (flat) variant is a
+genuine orphan, lingering as 'unavailable'. sensor.py has removed such
+orphans at setup since the cleanup was introduced - except it never
+actually matched one: its local unique_id mirror lowercased without
+replacing dots, so every dotted metric (Status.Connector, all the
+measurands) missed. Single-sourcing the format in const.sensor_unique_id
+made the cleanup work for the first time, which makes it user-visible on
+upgrade: a removal destroys renames and customisations with it, so it
+must be logged.
+
+Nothing previously drove this path in tests, which let an undefined
+logger reference sit on it - HA swallows platform setup errors, so the
+whole sensor platform would have died silently on exactly the installs
+the cleanup targets.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+import websockets.asyncio.server
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ocpp.const import DOMAIN, sensor_unique_id
+from custom_components.ocpp.enums import HAChargerStatuses as cstat
+
+from .const import MOCK_CONFIG_DATA_1
+
+
+@pytest.fixture(name="bypass_websockets")
+def bypass_websockets_fixture():
+    """Stub only the websocket server; the real state machine stays."""
+    future = asyncio.Future()
+    future.set_result(websockets.asyncio.server.Server)
+    with (
+        patch("websockets.asyncio.server.serve", return_value=future),
+        patch("websockets.asyncio.server.Server.close"),
+        patch("websockets.asyncio.server.Server.wait_closed"),
+    ):
+        yield
+
+
+async def test_setup_removes_the_stale_flat_entity_and_logs_it(
+    hass, bypass_websockets, caplog
+):
+    """A dotted metric's orphan is removed at setup, with a log line.
+
+    MOCK_CONFIG_DATA_1's charger reports two connectors, so
+    Status.Connector exists per-connector and the flat variant seeded
+    here is exactly the orphan the cleanup exists for. The removal
+    assert also guards the code path itself: a broken cleanup dies
+    inside platform setup, which Home Assistant swallows, so without
+    this test the sensor platform could fail silently on precisely the
+    multi-connector installs the cleanup targets.
+    """
+    cpid = "test_cpid_9001"
+    registry = er.async_get(hass)
+    stale = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        sensor_unique_id(cpid, cstat.status_connector.value),
+        suggested_object_id=f"{cpid}_status_connector_renamed",
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA_1,
+        entry_id="test_stale_cleanup",
+        title="test_stale_cleanup",
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The platform came up cleanly - a failure inside the cleanup would
+    # have been swallowed into this log line rather than raising.
+    assert not [r for r in caplog.records if "Error setting up entry" in r.getMessage()]
+    assert registry.async_get(stale.entity_id) is None
+    removal_logs = [
+        r
+        for r in caplog.records
+        if "Removing stale charger-level entity" in r.getMessage()
+    ]
+    assert len(removal_logs) >= 1
+    assert stale.entity_id in removal_logs[0].getMessage()
+
+
+async def test_single_connector_setup_removes_nothing(hass, bypass_websockets, caplog):
+    """Control: with one connector the flat entities are the live ones.
+
+    The cleanup must never fire there - removing the flat entity on a
+    single-connector charger would delete the entity actually in use.
+    """
+    from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_CP_APPEND
+    from custom_components.ocpp.const import CONF_CPIDS
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG_DATA,
+            CONF_CPIDS: [{"CP_single": {**MOCK_CONFIG_CP_APPEND}}],
+        },
+        entry_id="test_no_cleanup",
+        title="test_no_cleanup",
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not [
+        r
+        for r in caplog.records
+        if "Removing stale charger-level entity" in r.getMessage()
+    ]

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -23,6 +23,7 @@ from custom_components.ocpp.const import (
     DOMAIN,
     CentralSystemSettings,
     ChargerSystemSettings,
+    sensor_unique_id,
 )
 from custom_components.ocpp.enums import HAChargerStatuses as cstat
 from custom_components.ocpp.ocppv16 import ChargePoint as ChargePoint16
@@ -137,21 +138,29 @@ async def test_the_reply_and_the_metric_agree(hass):
     assert result.current_time == recorded.isoformat()
 
 
-def _register_heartbeat_sensor(hass, cpid="test_cpid"):
-    """Register the heartbeat sensor as the platform would, renamed even.
+def _register_metric_sensor(hass, metric, cpid="test_cpid", suffix="renamed"):
+    """Register a metric sensor as the platform would, renamed even.
 
-    The renamed entity_id pins that the dispatch resolves through the
-    registry rather than reconstructing sensor.<cpid>_heartbeat by slug -
-    users rename entities, unique_ids are forever.
+    The unique_id comes from the same canonical helper production uses,
+    so this fixture moves with the format instead of hiding drift - a
+    hand-written literal here would keep passing while the resolution
+    silently fell back to the full update. The renamed entity_id pins
+    that the dispatch resolves through the registry rather than
+    reconstructing sensor.<cpid>_<metric> by slug.
     """
     registry = er.async_get(hass)
     entry = registry.async_get_or_create(
         "sensor",
         DOMAIN,
-        f"{DOMAIN}.{cpid}.heartbeat.sensor",
-        suggested_object_id=f"{cpid}_pulse_renamed",
+        sensor_unique_id(cpid, metric),
+        suggested_object_id=f"{cpid}_{metric.lower().replace('.', '_')}_{suffix}",
     )
     return entry.entity_id
+
+
+def _register_heartbeat_sensor(hass, cpid="test_cpid"):
+    """Register the heartbeat sensor under a deliberately renamed id."""
+    return _register_metric_sensor(hass, cstat.heartbeat.value, cpid, "pulse")
 
 
 def _capture_dispatches(hass):
@@ -212,3 +221,104 @@ async def test_the_v16_handler_refreshes_the_same_way(hass):
     update.assert_not_awaited()
     assert seen == [({entity_id},)]
     assert cp16._metrics[0][cstat.heartbeat.value].value is not None
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_is_temporary(hass):
+    """Once the sensor registers, the helper must switch to targeted.
+
+    The fallback exists for the startup window only; a helper that kept
+    falling back would silently reinstate the full-refresh cost forever.
+    """
+    cp = _mk_cp(hass)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+        update.assert_awaited_once_with("test_cpid")
+
+        entity_id = _register_heartbeat_sensor(hass)
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+
+        update.assert_awaited_once_with("test_cpid")
+        assert seen == [({entity_id},)]
+
+
+def _drive_monitor_once(monkeypatch, cp, fail_first_iteration=False):
+    """Prepare monitor_connection to run exactly one measuring iteration."""
+    from custom_components.ocpp import chargepoint as cp_mod
+
+    cp.post_connect_success = True
+    cp._connection.state = State.OPEN
+    cp._connection.ping = lambda: asyncio.sleep(0)
+    cp.cs_settings.websocket_ping_interval = 0.0
+    cp.cs_settings.websocket_ping_timeout = 0.01
+    cp.cs_settings.websocket_ping_tries = 1
+
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(cp_mod.asyncio, "sleep", fast_sleep, raising=True)
+
+    calls = {"n": 0}
+
+    async def fake_wait_for(awaitable, timeout):
+        calls["n"] += 1
+        if asyncio.iscoroutine(awaitable):
+            awaitable.close()
+        if fail_first_iteration:
+            # One TimeoutError, then close the loop out.
+            cp._connection.state = State.CLOSED
+            raise TimeoutError
+        if calls["n"] == 2:
+            # Pong received; end the loop after this iteration.
+            cp._connection.state = State.CLOSED
+        return None
+
+    monkeypatch.setattr(cp_mod.asyncio, "wait_for", fake_wait_for, raising=True)
+
+
+@pytest.mark.asyncio
+async def test_the_ping_loop_publishes_the_latency_sensors(hass, monkeypatch):
+    """The loop is these sensors' only publisher; it must dispatch them.
+
+    The heartbeat handler's full update() used to republish them as a
+    side effect - on an idle charger, removing it silently froze both
+    latency sensors, which feed long-term statistics. The loop now
+    pushes exactly the two entities it wrote.
+    """
+    cp = _mk_cp(hass)
+    eid_ping = _register_metric_sensor(hass, cstat.latency_ping.value)
+    eid_pong = _register_metric_sensor(hass, cstat.latency_pong.value)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        _drive_monitor_once(monkeypatch, cp)
+        await cp.monitor_connection()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == [({eid_ping, eid_pong},)]
+
+
+@pytest.mark.asyncio
+async def test_a_ping_timeout_also_publishes_the_latency_sensors(hass, monkeypatch):
+    """The timeout branch records the timeout value; it must publish too.
+
+    A charger falling off the network is exactly when the user looks at
+    the latency sensors, so the degraded reading matters most.
+    """
+    cp = _mk_cp(hass)
+    eid_ping = _register_metric_sensor(hass, cstat.latency_ping.value)
+    eid_pong = _register_metric_sensor(hass, cstat.latency_pong.value)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        _drive_monitor_once(monkeypatch, cp, fail_first_iteration=True)
+        await cp.monitor_connection()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == [({eid_ping, eid_pong},)]

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -13,15 +13,19 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from websockets.protocol import State
 
 from custom_components.ocpp.const import (
+    DATA_UPDATED,
     DOMAIN,
     CentralSystemSettings,
     ChargerSystemSettings,
 )
 from custom_components.ocpp.enums import HAChargerStatuses as cstat
+from custom_components.ocpp.ocppv16 import ChargePoint as ChargePoint16
 from custom_components.ocpp.ocppv201 import ChargePoint
 
 from .const import CONF_SSL_CERTFILE_PATH, CONF_SSL_KEYFILE_PATH
@@ -64,6 +68,43 @@ def _mk_cp(hass):
     return ChargePoint("CP_A", conn, hass, entry, central, charger)
 
 
+def _mk_cp16(hass):
+    """Build the 1.6 twin of _mk_cp, for the shared-helper parity test."""
+    data = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "csid": "cs",
+        "cpids": [{"CP_A": {"cpid": "test_cpid"}}],
+        "subprotocols": ["ocpp1.6"],
+        "websocket_close_timeout": 5,
+        "ssl": False,
+        "websocket_ping_interval": 0.0,
+        "websocket_ping_timeout": 0.01,
+        "websocket_ping_tries": 0,
+        "ssl_certfile_path": CONF_SSL_CERTFILE_PATH,
+        "ssl_keyfile_path": CONF_SSL_KEYFILE_PATH,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    central = CentralSystemSettings(**data)
+    charger = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(
+        state=State.CLOSED,
+        close=lambda: asyncio.sleep(0),
+        subprotocol="ocpp1.6",
+    )
+    return ChargePoint16("CP_A", conn, hass, entry, central, charger)
+
+
 @pytest.mark.asyncio
 async def test_a_heartbeat_writes_the_metric(hass):
     """The sensor's backing metric must move when the charger beats."""
@@ -96,13 +137,57 @@ async def test_the_reply_and_the_metric_agree(hass):
     assert result.current_time == recorded.isoformat()
 
 
-@pytest.mark.asyncio
-async def test_the_entities_are_pushed(hass):
-    """Writing the metric is not enough; the sensor updates on push.
+def _register_heartbeat_sensor(hass, cpid="test_cpid"):
+    """Register the heartbeat sensor as the platform would, renamed even.
 
-    The 1.6 handler schedules an entity update on every heartbeat so the
-    sensor refreshes without waiting for another state change; parity
-    matters because on an idle charger heartbeats may be the only traffic.
+    The renamed entity_id pins that the dispatch resolves through the
+    registry rather than reconstructing sensor.<cpid>_heartbeat by slug -
+    users rename entities, unique_ids are forever.
+    """
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}.{cpid}.heartbeat.sensor",
+        suggested_object_id=f"{cpid}_pulse_renamed",
+    )
+    return entry.entity_id
+
+
+def _capture_dispatches(hass):
+    """Collect every DATA_UPDATED payload."""
+    seen = []
+    async_dispatcher_connect(hass, DATA_UPDATED, lambda *args: seen.append(args))
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_a_heartbeat_refreshes_only_its_own_sensor(hass):
+    """One metric moved, so one entity refreshes.
+
+    The full update() walks the device registry and force-refreshes every
+    entity of the charger, at a rate the charger controls - a charger
+    beating every 10 s did all that work for one timestamp. The dispatch
+    must carry exactly the heartbeat sensor, resolved via the registry.
+    """
+    cp = _mk_cp(hass)
+    entity_id = _register_heartbeat_sensor(hass)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == [({entity_id},)]
+
+
+@pytest.mark.asyncio
+async def test_an_unregistered_sensor_falls_back_to_the_full_update(hass):
+    """The first heartbeat can arrive before the platforms add entities.
+
+    Dropping the refresh there would leave the sensor stale until the next
+    unrelated update; the pre-optimisation full push is the safe fallback.
     """
     cp = _mk_cp(hass)
 
@@ -111,3 +196,19 @@ async def test_the_entities_are_pushed(hass):
         await hass.async_block_till_done()
 
     update.assert_awaited_once_with("test_cpid")
+
+
+@pytest.mark.asyncio
+async def test_the_v16_handler_refreshes_the_same_way(hass):
+    """Both protocols share the helper; neither walks the registry per beat."""
+    cp16 = _mk_cp16(hass)
+    entity_id = _register_heartbeat_sensor(hass)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint16, "update", AsyncMock()) as update:
+        cp16.on_heartbeat()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == [({entity_id},)]
+    assert cp16._metrics[0][cstat.heartbeat.value].value is not None

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -360,3 +360,28 @@ async def test_a_partially_registered_pair_dispatches_what_resolved(hass, monkey
 
     update.assert_not_awaited()
     assert seen == [({eid_ping},)]
+
+
+@pytest.mark.asyncio
+async def test_a_sensor_deleted_after_startup_does_not_revive_the_full_walk(hass):
+    """The fallback is for the startup window, not for deleted entities.
+
+    Once the sensor has resolved, a later registry miss means the user
+    removed the entity - there is nothing to refresh, and falling back
+    would silently reinstate the full update at heartbeat rate, forever.
+    """
+    cp = _mk_cp(hass)
+    entity_id = _register_heartbeat_sensor(hass)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+        assert seen == [({entity_id},)]
+
+        er.async_get(hass).async_remove(entity_id)
+        cp.on_heartbeat()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == [({entity_id},)]

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -247,37 +247,32 @@ async def test_the_fallback_is_temporary(hass):
 
 
 def _drive_monitor_once(monkeypatch, cp, fail_first_iteration=False):
-    """Prepare monitor_connection to run exactly one measuring iteration."""
+    """Prepare monitor_connection to run exactly one measuring iteration.
+
+    Everything runs on real asyncio - the only monkeypatch is our own
+    module's backstop delay. The scripted ping resolves immediately for
+    the success path, or never for the timeout path so the real
+    wait_for(timeout=0.01) raises a genuine TimeoutError, and it closes
+    the connection so the loop exits after one iteration.
+    """
     from custom_components.ocpp import chargepoint as cp_mod
 
+    monkeypatch.setattr(cp_mod, "MONITOR_BACKSTOP_DELAY", 0, raising=True)
     cp.post_connect_success = True
     cp._connection.state = State.OPEN
-    cp._connection.ping = lambda: asyncio.sleep(0)
     cp.cs_settings.websocket_ping_interval = 0.0
     cp.cs_settings.websocket_ping_timeout = 0.01
     cp.cs_settings.websocket_ping_tries = 1
 
-    async def fast_sleep(_):
-        return None
-
-    monkeypatch.setattr(cp_mod.asyncio, "sleep", fast_sleep, raising=True)
-
-    calls = {"n": 0}
-
-    async def fake_wait_for(awaitable, timeout):
-        calls["n"] += 1
-        if asyncio.iscoroutine(awaitable):
-            awaitable.close()
+    async def scripted_ping():
+        cp._connection.state = State.CLOSED
         if fail_first_iteration:
-            # One TimeoutError, then close the loop out.
-            cp._connection.state = State.CLOSED
-            raise TimeoutError
-        if calls["n"] == 2:
-            # Pong received; end the loop after this iteration.
-            cp._connection.state = State.CLOSED
-        return None
+            await asyncio.get_running_loop().create_future()  # never resolves
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(None)
+        return fut
 
-    monkeypatch.setattr(cp_mod.asyncio, "wait_for", fake_wait_for, raising=True)
+    cp._connection.ping = scripted_ping
 
 
 @pytest.mark.asyncio
@@ -322,3 +317,46 @@ async def test_a_ping_timeout_also_publishes_the_latency_sensors(hass, monkeypat
 
     update.assert_not_awaited()
     assert seen == [({eid_ping, eid_pong},)]
+
+
+@pytest.mark.asyncio
+async def test_unregistered_latency_sensors_skip_rather_than_fall_back(
+    hass, monkeypatch
+):
+    """The periodic caller must not buy the full walk at ping rate.
+
+    During the startup window the heartbeat's fallback runs at most at
+    heartbeat rate; a ping-loop fallback would run the full registry walk
+    every ping interval, more often than the behaviour this optimisation
+    replaced. Skipping is safe - the next tick republishes.
+    """
+    cp = _mk_cp(hass)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        _drive_monitor_once(monkeypatch, cp)
+        await cp.monitor_connection()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_a_partially_registered_pair_dispatches_what_resolved(hass, monkeypatch):
+    """Skipping must not discard the sensor that did resolve.
+
+    One registered sensor and one missing is the transient shape while
+    platforms add entities; the resolved one still deserves its refresh.
+    """
+    cp = _mk_cp(hass)
+    eid_ping = _register_metric_sensor(hass, cstat.latency_ping.value)
+    seen = _capture_dispatches(hass)
+
+    with patch.object(ChargePoint, "update", AsyncMock()) as update:
+        _drive_monitor_once(monkeypatch, cp)
+        await cp.monitor_connection()
+        await hass.async_block_till_done()
+
+    update.assert_not_awaited()
+    assert seen == [({eid_ping},)]


### PR DESCRIPTION
Closes #2058 — the separate PR requested in #2057's merge comment. The issue carries the full mechanics; short version: a heartbeat used to walk the device registry and force-refresh **every** entity of the charger, at whatever rate the charger chooses to beat, and that full refresh turned out to be secretly load-bearing — it was the only periodic publisher the latency sensors had.

## What changes

**Heartbeats refresh one entity.** A shared helper resolves the heartbeat sensor through the entity registry by its canonical unique_id — rename-proof, since the dispatcher filter matches on current entity_id — and dispatches exactly that entity. Both protocol handlers use it, so the 1.6 path sheds a cost it has carried for years. The startup window (first heartbeat before the platforms finish adding entities) falls back to the full update so the write is not lost, and a test pins that the fallback gives way to targeted dispatch once the sensor registers.

**The latency sensors get their own publisher.** `monitor_connection` now dispatches `latency_ping`/`latency_pong` right where it writes them, in both the success and the timeout branch — a charger falling off the network is exactly when those sensors get looked at. Without this, the optimisation would have frozen both sensors on idle chargers (they feed long-term statistics, `state_class = MEASUREMENT`). The periodic call site *skips* rather than falls back when a sensor is unregistered, dispatching whatever did resolve: it re-fires every ping interval anyway, and a ping-rate fallback would run the full registry walk more often than the behaviour this replaces.

**The unique_id format is single-sourced.** `const.sensor_unique_id()` now serves the sensor entities, the stale-entity cleanup, and the refresh helper. It is byte-identical to the persisted format for every metric the platform builds — `OcppSensorDescription` is constructed in exactly one place, so the key normalisation is uniform — and the docstring marks the format as effectively frozen, since changing it would orphan every registered sensor.

## ⚠️ User-visible on upgrade — worth a release note

Single-sourcing the format fixes a latent bug with a visible consequence: the multi-connector stale-entity cleanup in `sensor.py` has **never matched a dotted metric** (its local mirror of the format forgot the dot replacement), so it has been dead code for essentially its whole target set. With the format repaired, the first setup after upgrade on a charger reporting **more than one connector** will actually remove the orphaned charger-level entities (`Status.Connector`, `Stop.Reason`, every measurand…). They are genuine orphans — in the multi-connector branch those metrics only exist per-connector, and the flat variant lingers as `unavailable`, which is precisely what the cleanup was written to remove — but removal destroys user renames, icons and area assignments with it. Each removal is now logged (`Removing stale charger-level entity …`), and a regression test drives the path: it turned out nothing ever had, which had let a broken reference sit on it undetected because Home Assistant swallows platform setup errors.

One more deliberate cadence change: the latency sensors now publish every ping interval (default 20 s) instead of at heartbeat rate as a side effect. More recorder writes for two sensors per charger — a consideration for SQLite installs — but the sensor finally updates at the cadence it claims to measure.

## Testing

12 new/updated tests across `tests/test_v201_heartbeat_metric.py` and `tests/test_sensor_stale_cleanup.py`; 277 pass overall. The monitor-loop tests drive the real `monitor_connection` on real asyncio — the scripted ping resolves instantly or never, so the timeout path exercises a genuine `TimeoutError` from the real `wait_for`; the only monkeypatch is a new module constant for the 10 s backstop delay.

Mutation-verified — each fails the tests aimed at it:

| Mutation | Killed by |
|---|---|
| revert to full update on heartbeat | targeted-dispatch tests (v16 + v201) |
| dispatch a global refresh (no payload) | targeted-dispatch tests |
| build the entity_id by slug instead of the registry | the renamed-entity registration |
| success-branch latency dispatch removed | ping-loop publish test |
| timeout-branch latency dispatch removed | timeout publish test |
| latency site falls back instead of skipping | startup skip test |
| partial resolution discarded | partial-pair dispatch test |
| heartbeat fallback made permanent | transition + targeted tests |
| stale-entity removal dropped | cleanup test |
| removal log line dropped | cleanup log assert |
| undefined logger reintroduced | cleanup test, via the swallowed-setup-error assert |

Review history for transparency: this went through two adversarial review rounds before filing. The first found the latency-publisher coupling (a blocker — the naive optimisation froze two sensors); the second verified the unique_id migration byte-for-byte across all 47 metrics and pushed the upgrade-visibility and test-hygiene work. Both rounds' findings are addressed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heartbeat and connection monitoring so latency and heartbeat sensors update more reliably.
  * Reduced unnecessary full charger refreshes for faster, more efficient updates.
  * Removed stale charger-level sensors while preserving valid sensors for single-connector chargers.
  * Added safe fallback handling when individual sensor entities are unavailable.

* **Reliability**
  * Added clearer logging when outdated sensor entities are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->