### PR TITLE
Scope the test-fixture hazards out, and fix the migration bug they hid

### DIFF
--- a/custom_components/ocpp/__init__.py
+++ b/custom_components/ocpp/__init__.py
@@ -4,6 +4,8 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.util import slugify
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers import device_registry
 import homeassistant.helpers.config_validation as cv
@@ -185,8 +187,17 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             csid_data.update({key: old_data.get(key, value)})
 
         new_data = csid_data
-        cp_id_state = hass.states.get(f"sensor.{cpid_data[CONF_CPID].lower()}_id")
-        if cp_id_state is None:
+        # slugify, not lower(): the sensor platform slugifies its object
+        # ids, so any cpid that is not already a slug ("Garage Charger",
+        # "charger-1") would never resolve here.
+        cp_id_state = hass.states.get(f"sensor.{slugify(cpid_data[CONF_CPID])}_id")
+        if cp_id_state is None or cp_id_state.state in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
+            # A sentinel state is a plain string, so without this guard it
+            # would be stored as the charge point key - serialisable, but
+            # matching no charger, the same broken entry by another route.
             _LOGGER.warning(
                 "Could not find charger id during migration, try a clean install"
             )

--- a/custom_components/ocpp/__init__.py
+++ b/custom_components/ocpp/__init__.py
@@ -185,13 +185,19 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             csid_data.update({key: old_data.get(key, value)})
 
         new_data = csid_data
-        cp_id = hass.states.get(f"sensor.{cpid_data[CONF_CPID].lower()}_id")
-        if cp_id is None:
+        cp_id_state = hass.states.get(f"sensor.{cpid_data[CONF_CPID].lower()}_id")
+        if cp_id_state is None:
             _LOGGER.warning(
                 "Could not find charger id during migration, try a clean install"
             )
             return False
-        new_data.update({CONF_CPIDS: [{cp_id: cpid_data}]})
+        # The charge point id is the sensor's VALUE. Storing the State
+        # object itself - as this did until now - produces entry data that
+        # cannot be JSON-serialised and a key no connecting charger can
+        # ever match, so every v1 migration was broken. The test suite
+        # could not see it: a global StateMachine.get patch fed it a
+        # synthetic State, and the assertion checked top-level keys only.
+        new_data.update({CONF_CPIDS: [{cp_id_state.state: cpid_data}]})
 
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, minor_version=0, version=2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Global fixtures for ocpp integration."""
 
 import asyncio
+import copy
 from collections.abc import AsyncGenerator
 from unittest.mock import patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -14,7 +15,6 @@ from .charge_point_test import (
     create_configuration,
     remove_configuration,
 )
-from homeassistant.core import State
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -47,16 +47,15 @@ def bypass_get_data_fixture():
     """Skip calls to get data from API."""
     future = asyncio.Future()
     future.set_result(websockets.asyncio.server.Server)
-    # Return a HomeAssistant State object instead of a plain string. Some HA
-    # helpers expect a State instance (with attributes) during restore/cleanup.
+    # No StateMachine.get patch here: it used to return a synthetic State
+    # for EVERY hass.states.get in the process, which poisoned core's
+    # duplicate-entity checks on reload and shadowed the real state the
+    # migration test seeds - hiding a genuine migration bug behind it.
+    # The migration test provides its own state; nothing else needs one.
     with (
         patch("websockets.asyncio.server.serve", return_value=future),
         patch("websockets.asyncio.server.Server.close"),
         patch("websockets.asyncio.server.Server.wait_closed"),
-        patch(
-            "homeassistant.core.StateMachine.get",
-            return_value=State("sensor.test_cp_id", "test_cp_id"),
-        ),
     ):
         yield
 
@@ -78,9 +77,14 @@ async def setup_config_entry(hass, request) -> AsyncGenerator[CentralSystem, Non
     """Setup/teardown mock config entry and central system."""
     # Create a mock entry so we don't have to go through config flow
     # Both version and minor need to match config flow so as not to trigger migration flow
-    config_data = MOCK_CONFIG_DATA.copy()
+    # deepcopy, not copy: a shallow copy shares the CONF_CPIDS list with
+    # the module-level constant, so the append below permanently mutated
+    # MOCK_CONFIG_DATA for the rest of the pytest session - every later
+    # test asking for "the chargerless config" silently got a charger
+    # (order-dependent failures that never reproduce in isolation).
+    config_data = copy.deepcopy(MOCK_CONFIG_DATA)
     config_data[CONF_CPIDS].append(
-        {request.param["cp_id"]: MOCK_CONFIG_CP_APPEND.copy()}
+        {request.param["cp_id"]: copy.deepcopy(MOCK_CONFIG_CP_APPEND)}
     )
     config_data[CONF_PORT] = request.param["port"]
     config_entry = MockConfigEntry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def skip_notifications_fixture():
 
 # This fixture, when used, will result in calls to websockets to be bypassed. To have the call
 # return a value, we would add the `return_value=<VALUE_TO_RETURN>` parameter to the patch call.
-# include patch for hass.states.get for use with migration to return cp_id
 @pytest.fixture(name="bypass_get_data")
 def bypass_get_data_fixture():
     """Skip calls to get data from API."""

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -1,6 +1,7 @@
 """Implement a test by a simulating an OCPP 2.0.1 chargepoint."""
 
 import asyncio
+import copy
 from datetime import datetime, timedelta, UTC
 
 from homeassistant.const import UnitOfTime
@@ -1468,8 +1469,8 @@ async def test_cms_responses_v201(hass, socket_enabled):
     # test cannot
     # config_data[CONF_MONITORED_VARIABLES] = ",".join(supported_measurands)
     cp_id = "CP_2"
-    config_data = MOCK_CONFIG_DATA.copy()
-    config_data[CONF_CPIDS].append({cp_id: MOCK_CONFIG_CP_APPEND.copy()})
+    config_data = copy.deepcopy(MOCK_CONFIG_DATA)
+    config_data[CONF_CPIDS].append({cp_id: copy.deepcopy(MOCK_CONFIG_CP_APPEND)})
     config_data[CONF_CPIDS][-1][cp_id][CONF_CPID] = "test_v201_cpid"
 
     config_data[CONF_PORT] = 9080
@@ -1513,8 +1514,8 @@ async def test_cms_responses_v201(hass, socket_enabled):
     await remove_configuration(hass, config_entry)
 
     cp_id = "CP_2_noreport"
-    config_data = MOCK_CONFIG_DATA_3.copy()
-    config_data[CONF_CPIDS].append({cp_id: MOCK_CONFIG_CP_APPEND.copy()})
+    config_data = copy.deepcopy(MOCK_CONFIG_DATA_3)
+    config_data[CONF_CPIDS].append({cp_id: copy.deepcopy(MOCK_CONFIG_CP_APPEND)})
     config_data[CONF_CPIDS][-1][cp_id][CONF_CPID] = "test_v201_cpid"
 
     config_data[CONF_PORT] = 9011

--- a/tests/test_charge_point_v201_multi.py
+++ b/tests/test_charge_point_v201_multi.py
@@ -1,6 +1,7 @@
 """Implement a test by a simulating an OCPP 2.0.1 chargepoint."""
 
 import asyncio
+import copy
 from datetime import datetime, UTC
 
 import pytest
@@ -287,8 +288,8 @@ async def test_v201_multi_connectors_per_evse(hass, socket_enabled):
     """Test multi connector per EVSE functionality."""
     cp_id = "CP_v201_multi"
 
-    config_data = MOCK_CONFIG_DATA.copy()
-    config_data[CONF_CPIDS].append({cp_id: MOCK_CONFIG_CP_APPEND.copy()})
+    config_data = copy.deepcopy(MOCK_CONFIG_DATA)
+    config_data[CONF_CPIDS].append({cp_id: copy.deepcopy(MOCK_CONFIG_CP_APPEND)})
     config_data[CONF_CPIDS][-1][cp_id][CONF_CPID] = "test_v201_cpid"
 
     config_entry = MockConfigEntry(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -111,10 +111,15 @@ async def test_migration_entry(
     config_entry.add_to_hass(hass)
     await hass.async_block_till_done()
 
-    # Ensure cp id is present in state machine to trigger migration flow. This simulates the condition where a user has a sensor entity in HA with the cp_id as the state value, which is used to identify the entry to migrate. If this value is not present, the migration flow will not be triggered and the test will fail.
+    # Ensure cp id is present in state machine to trigger migration flow.
+    # This simulates a user with the id sensor still in HA, holding the
+    # charger's OCPP cp_id as its VALUE. The value is deliberately
+    # different from the cpid: they are different things in production
+    # (OCPP identity vs friendly name), and seeding them equal would let
+    # a migration that stored the cpid pass the key assertion below.
     hass.states.async_set(
         f"sensor.{MOCK_CONFIG_MIGRATION_FLOW[CONF_CPID].lower()}_id",
-        MOCK_CONFIG_MIGRATION_FLOW[CONF_CPID],
+        "CP_migration_1",
     )
 
     # Set up the entry and assert that the values set during setup are where we expect
@@ -135,7 +140,7 @@ async def test_migration_entry(
     # synthetic one and only the top-level keys were checked.
     migrated_key = next(iter(config_entry.data[CONF_CPIDS][0]))
     assert isinstance(migrated_key, str)
-    assert migrated_key == MOCK_CONFIG_MIGRATION_FLOW[CONF_CPID]
+    assert migrated_key == "CP_migration_1"
     # check versions match
     assert config_entry.version == 2
     assert config_entry.minor_version == 1
@@ -158,3 +163,65 @@ async def test_migration_entry(
 #     # an error.
 #     with pytest.raises(ConfigEntryNotReady):
 #         assert await async_setup_entry(hass, config_entry)
+
+
+async def test_migration_refuses_a_sentinel_charger_id(
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+):
+    """An 'unavailable' id sensor must fail migration, not become the key.
+
+    Sentinel states are plain strings, so without the guard they pass an
+    isinstance check and get stored as the charge point key - JSON-clean,
+    but matching no charger ever: the same broken entry the State-object
+    bug produced, by a quieter route.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_MIGRATION_FLOW,
+        entry_id="test_migration_sentinel",
+        title="test_migration_sentinel",
+        version=1,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        f"sensor.{MOCK_CONFIG_MIGRATION_FLOW[CONF_CPID].lower()}_id",
+        "unavailable",
+    )
+
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.version == 1
+
+
+async def test_migration_finds_a_non_slug_cpid(
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+):
+    """A cpid like 'Garage Charger' must still resolve its id sensor.
+
+    The sensor platform slugifies object ids, so the entity really lives
+    at sensor.garage_charger_id - a migration lookup built with .lower()
+    would ask for 'sensor.garage charger_id' and always miss, sending the
+    user to a clean install for no reason.
+    """
+    data = {**MOCK_CONFIG_MIGRATION_FLOW, CONF_CPID: "Garage Charger"}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=data,
+        entry_id="test_migration_slug",
+        title="test_migration_slug",
+        version=1,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.garage_charger_id", "CP_migration_2")
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    migrated_key = next(iter(config_entry.data[CONF_CPIDS][0]))
+    assert migrated_key == "CP_migration_2"
+
+    assert await hass.config_entries.async_remove(config_entry.entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ocpp import CentralSystem
-from custom_components.ocpp.const import DOMAIN, CONF_CPID
+from custom_components.ocpp.const import DOMAIN, CONF_CPID, CONF_CPIDS
 
 from .const import (
     MOCK_CONFIG_DATA,
@@ -127,6 +127,15 @@ async def test_migration_entry(
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
     # check migration has created new entry with correct keys
     assert config_entry.data.keys() == MOCK_CONFIG_DATA.keys()
+    # The charge point key must be the seeded sensor's VALUE, as a plain
+    # string. The migration stored the whole State object until 2026-08 -
+    # unserialisable entry data and a key no connecting charger could
+    # match - and this test could not see it, because a global
+    # StateMachine.get patch replaced the state seeded above with a
+    # synthetic one and only the top-level keys were checked.
+    migrated_key = next(iter(config_entry.data[CONF_CPIDS][0]))
+    assert isinstance(migrated_key, str)
+    assert migrated_key == MOCK_CONFIG_MIGRATION_FLOW[CONF_CPID]
     # check versions match
     assert config_entry.version == 2
     assert config_entry.minor_version == 1

--- a/tests/test_reload_offline_charger.py
+++ b/tests/test_reload_offline_charger.py
@@ -186,11 +186,11 @@ async def test_reload_of_a_chargerless_entry_stays_clean(
     await _load_platform_components(hass)
     entry = MockConfigEntry(
         domain=DOMAIN,
-        # CONF_CPIDS pinned to empty explicitly: conftest's
-        # setup_config_entry fixture shallow-copies MOCK_CONFIG_DATA and
-        # appends to the shared CONF_CPIDS list, so by this point in a full
-        # run the module-level constant is no longer chargerless.
-        data={**MOCK_CONFIG_DATA, CONF_CPIDS: []},
+        # MOCK_CONFIG_DATA used directly, deliberately: these chargerless
+        # tests are the natural regression tests for conftest's deepcopy -
+        # if setup_config_entry ever goes back to mutating the shared
+        # constant, this stops being chargerless mid-suite and fails here.
+        data=MOCK_CONFIG_DATA,
         entry_id="test_fresh_reload",
         title="test_fresh_reload",
         version=2,
@@ -225,7 +225,7 @@ async def test_first_charger_discovery_reload_transitions_cleanly(
     await _load_platform_components(hass)
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA, CONF_CPIDS: []},
+        data=MOCK_CONFIG_DATA,
         entry_id="test_growth_reload",
         title="test_growth_reload",
         version=2,

--- a/tests/test_reload_offline_charger.py
+++ b/tests/test_reload_offline_charger.py
@@ -42,13 +42,13 @@ PLATFORM_DOMAINS = ("sensor", "switch", "number", "button")
 
 @pytest.fixture(name="bypass_websockets")
 def bypass_websockets_fixture():
-    """Stub only the websocket server, unlike conftest's bypass_get_data.
+    """Stub only the websocket server.
 
-    That fixture also patches StateMachine.get to always return a State,
-    which poisons core's duplicate-entity check on reload: every re-added
-    entity looks like a live duplicate and is silently discarded, so a
-    genuinely clean reload appears broken. These tests are about reload
-    correctness, so they must run against the real state machine.
+    conftest's bypass_get_data historically also patched StateMachine.get
+    to return a synthetic State for every lookup, which poisoned core's
+    duplicate-entity check on reload; that patch is gone, but these tests
+    keep their own minimal stub so reload correctness never depends on
+    what the shared fixture carries.
     """
     future = asyncio.Future()
     future.set_result(websockets.asyncio.server.Server)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,7 @@
 """Test sensor for ocpp integration."""
 
 import asyncio
+import copy
 import websockets
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -28,7 +29,7 @@ async def test_sensor(hass, socket_enabled):
 
     cp_id = "CP_1_sens"
     cpid = "test_cpid_sens"
-    data = MOCK_CONFIG_DATA.copy()
+    data = copy.deepcopy(MOCK_CONFIG_DATA)
     cp_data = MOCK_CONFIG_CP_APPEND.copy()
     cp_data[CONF_CPID] = cpid
     data[CONF_CPIDS].append({cp_id: cp_data})
@@ -74,7 +75,7 @@ async def test_sensor_entities_per_connector_created(hass, socket_enabled):
     cp_id = "CP_1_sens_mc"
     cpid = "test_cpid_sens_mc"
 
-    data = MOCK_CONFIG_DATA.copy()
+    data = copy.deepcopy(MOCK_CONFIG_DATA)
     cp_data = MOCK_CONFIG_CP_APPEND.copy()
     cp_data[CONF_CPID] = cpid
     cp_data[CONF_NUM_CONNECTORS] = 2  # ensure two connectors up front


### PR DESCRIPTION
Addresses items 1 and 2 of #2055, per your direction there ("For item 1 scope it to its own migration test, for 2 use deepcopy") — and carries one production fix that fell out of doing it, which deserves top billing:

## 🐛 The removed fixture patch was hiding a real migration bug

The v1→v2 migration stores `hass.states.get(...)` — the **State object**, not its `.state` value — as the charge point key in the entry data. A State is hashable, so nothing crashed at assignment; but config-entry data is persisted as JSON, and `json.dumps` rejects a State key, and no connecting charger can ever match one. Every v1 migration that reached this line produced a broken entry.

The migration test could not see it: it seeds a real id-sensor state to drive the flow, but `bypass_get_data`'s global `StateMachine.get` patch **replaced the state the test itself seeded** with a synthetic one, and the assertion checked top-level keys only. The migration now stores the state's value, and the test asserts the migrated key equals a seeded value that is deliberately **different from the cpid** — so it discriminates all three behaviours (State object fails `isinstance`, cpid fails equality, state value passes).

Two adjacent holes in the same block, closed while it was open:

* **Sentinel states**: `unknown`/`unavailable` are plain strings that would have become unmatchable keys without even a warning; the guard now rejects them alongside `None`.
* **`.lower()` vs `slugify`**: the sensor platform slugifies object ids, so a cpid like `Garage Charger` could never resolve through the old lookup — the user got "try a clean install" for no reason. The lookup now slugifies. Both paths have tests that fail against the previous code.

**An honest open question rather than a claim:** it is unclear this migration path was ever reachable on a real restart — `async_migrate_entry` runs before this integration creates any entity, and the state machine starts empty, so the lookup may always have returned `None` in production (matching the "try a clean install" reports). The fixes are correct regardless — they repair the code for whenever the state *is* present — but if the path is inert, the durable fix is to stop depending on the live state machine (e.g. the restored-state store). Flagging for your judgement rather than folding a redesign into a test-hygiene PR.

## Item 1 — the `StateMachine.get` patch is gone entirely

Scoping it "to its own migration test" turned out to mean *deleting it*: the migration test provides its own real state (its comment says exactly that intent), and nothing else needed the patch — the full suite passes unchanged without it. Its other effect was poisoning core's duplicate-entity check for every test using `bypass_get_data`, which is what had hidden the bug above.

## Item 2 — deepcopy, everywhere the pattern exists

`setup_config_entry` now deep-copies, and a census found the identical shallow-copy-append in three more test files, mutating `MOCK_CONFIG_DATA` and `MOCK_CONFIG_DATA_3` (whose siblings share the parent's `CONF_CPIDS` list through dict spread). Every site that mutates the shared list now deep-copies; shallow copies that only set scalar keys are untouched. The chargerless reload tests had been pinning `CONF_CPIDS: []` as a workaround — those sandbags are removed, so they are now the natural regression tests: reverting the deepcopy fails them in suite order, verified by mutation.

## Testing

270 pass, pre-commit clean. Mutations, each killed by the right test:

| Mutation | Killed by |
|---|---|
| deepcopy reverted to shallow copy | chargerless reload test, in suite order |
| State object stored as the key again | migration test (`isinstance`) |
| migration stores the cpid instead of the state value | migration test (equality, distinct seed) |
| sentinel guard removed | `test_migration_refuses_a_sentinel_charger_id` |
| `slugify` reverted to `.lower()` | `test_migration_finds_a_non_slug_cpid` |

Item 3 remains open pending your view on the proposal posted on #2055.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration of charger configurations by correctly resolving charge-point identifiers, including names with spaces or special formatting.
  * Prevented migrations when the charger sensor reports unavailable or unknown states.
  * Stored the charger’s actual string identifier, improving configuration reliability.

* **Tests**
  * Added coverage for unavailable sensor states and non-standard charge-point names.
  * Improved test isolation to prevent shared configuration data from being modified across tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->