### PR TITLE
Scope the update() registry fakes so they cannot leak into entry teardown

### DIFF
--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -244,6 +244,8 @@ async def test_update_returns_early_when_root_device_missing(
                 # No entities to update; the loop is exercised anyway.
                 return []
 
+            dispatched = []
+
             # Patch HA helpers & dispatcher for the update() call only.
             # Still a module-global patch while it lasts: any concurrent HA
             # task that resolves a registry inside this await sees the fakes.
@@ -267,7 +269,10 @@ async def test_update_returns_early_when_root_device_missing(
                     raising=True,
                 )
                 mp.setattr(
-                    mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
+                    mod,
+                    "async_dispatcher_send",
+                    lambda _hass, _sig, payload: dispatched.append(payload),
+                    raising=True,
                 )
 
                 # Should exit early without error (L602).
@@ -282,6 +287,8 @@ async def test_update_returns_early_when_root_device_missing(
                 mod.entity_registry.async_entries_for_device,
                 mod.async_dispatcher_send,
             )
+            # Early return means no dispatch at all - not an empty one.
+            assert dispatched == []
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -344,12 +351,33 @@ async def test_update_traverses_children_and_skips_visited(
             class FakeER:
                 """Fake ER: only ever passed to the patched entries_for_device."""
 
+            def ent(entity_id, disabled_by=None):
+                return SimpleNamespace(
+                    entity_id=entity_id, disabled=False, disabled_by=disabled_by
+                )
+
+            # Each device carries one live entity plus one that a filter must
+            # drop: root's second entity is registry-disabled (but HAS a
+            # state, so only the disabled check can exclude it); child's
+            # second is enabled but never gets a state, so only the
+            # states-lookup check can exclude it.
+            ents_by_dev = {
+                "root": [
+                    ent("sensor.root_live"),
+                    ent("sensor.root_disabled", disabled_by="user"),
+                ],
+                "child": [ent("sensor.child_live"), ent("sensor.child_nostate")],
+            }
+            hass.states.async_set("sensor.root_live", "on")
+            hass.states.async_set("sensor.root_disabled", "on")
+            hass.states.async_set("sensor.child_live", "on")
+
             entity_lookup_device_ids = []
+            dispatched = []
 
             def fake_entries_for_device(_er, _dev_id):
                 entity_lookup_device_ids.append(_dev_id)
-                # No entities to update; the lookup order is the observable.
-                return []
+                return ents_by_dev.get(_dev_id, [])
 
             # Patch HA helpers & dispatcher for the update() call only -
             # the module-level patch must not leak into entry teardown.
@@ -375,14 +403,13 @@ async def test_update_traverses_children_and_skips_visited(
                     raising=True,
                 )
                 mp.setattr(
-                    mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
+                    mod,
+                    "async_dispatcher_send",
+                    lambda _hass, _sig, payload: dispatched.append(payload),
+                    raising=True,
                 )
 
-                # The traversal appends 'child' twice (neither copy is in
-                # 'visited' at append time); the second pop must hit the
-                # 'continue', so 'child' gets exactly one registry lookup.
                 await srv.update(srv.settings.cpid)
-                assert entity_lookup_device_ids == ["root", "child"]
 
             # The leak guard: on the pinned harness the fakes are harmless at
             # teardown, so nothing else fails if this scoping regresses. The
@@ -393,6 +420,19 @@ async def test_update_traverses_children_and_skips_visited(
                 mod.entity_registry.async_entries_for_device,
                 mod.async_dispatcher_send,
             )
+
+            # The traversal appends 'child' twice (neither copy is in
+            # 'visited' at append time); the second pop must hit the
+            # 'continue', so 'child' gets exactly one registry lookup.
+            # This lookup ORDER is a proxy for the visit order - kept
+            # because the dispatched payload is a set of entity_ids and
+            # cannot see a double visit (same ids re-added change nothing).
+            assert entity_lookup_device_ids == ["root", "child"]
+
+            # update()'s actual product: one dispatch carrying exactly the
+            # enabled-with-state entities - the disabled and stateless ones
+            # must have been dropped by their respective filters.
+            assert dispatched == [{"sensor.root_live", "sensor.child_live"}]
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -344,8 +344,11 @@ async def test_update_traverses_children_and_skips_visited(
             class FakeER:
                 """Fake ER: only ever passed to the patched entries_for_device."""
 
+            entity_lookup_device_ids = []
+
             def fake_entries_for_device(_er, _dev_id):
-                # No entities to update; the loop is exercised anyway.
+                entity_lookup_device_ids.append(_dev_id)
+                # No entities to update; the lookup order is the observable.
                 return []
 
             # Patch HA helpers & dispatcher for the update() call only -
@@ -375,9 +378,11 @@ async def test_update_traverses_children_and_skips_visited(
                     mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
                 )
 
-                # No exceptions expected; internal traversal will append 'child' twice,
-                # so on second pop it will be in 'visited' and trigger L612 'continue'.
+                # The traversal appends 'child' twice (neither copy is in
+                # 'visited' at append time); the second pop must hit the
+                # 'continue', so 'child' gets exactly one registry lookup.
                 await srv.update(srv.settings.cpid)
+                assert entity_lookup_device_ids == ["root", "child"]
 
             # The leak guard: on the pinned harness the fakes are harmless at
             # teardown, so nothing else fails if this scoping regresses. The

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -218,16 +218,18 @@ async def test_update_returns_early_when_root_device_missing(
             await wait_ready(cs.charge_points[cp_id])
             srv = cs.charge_points[cp_id]
 
-            # Fake registries: no device returned.
+            # Fake registries: no device returned. The fakes implement only
+            # what update() itself touches - patching the shared helper
+            # modules swaps the registries for ALL of Home Assistant, so the
+            # patches must not outlive this block. Left installed (as they
+            # were until HA 2026.8), core's config-entry teardown hits the
+            # fakes and fails on registry surface they don't implement.
             import custom_components.ocpp.chargepoint as mod
 
             class FakeDR:
-                """Fake DR."""
+                """Fake DR: only what update()'s early-return path touches."""
 
                 def async_get_device(self, identifiers):
-                    return None
-
-                def async_clear_config_entry(self, config_entry_id):
                     return None
 
                 @property
@@ -235,42 +237,51 @@ async def test_update_returns_early_when_root_device_missing(
                     """Fake devices."""
                     return {}
 
-                def async_update_device(self, *args, **kwargs):
-                    return None
-
-                def async_get_or_create(self, *args, **kwargs):
-                    return SimpleNamespace(id="dummy")
-
             class FakeER:
-                """Fake ER."""
-
-                def async_clear_config_entry(self, config_entry_id):
-                    return None
+                """Fake ER: only ever passed to the patched entries_for_device."""
 
             def fake_entries_for_device(_er, _dev_id):
                 # No entities to update; the loop is exercised anyway.
                 return []
 
-            # Patch HA helpers & dispatcher.
-            monkeypatch.setattr(
-                mod.device_registry, "async_get", lambda _: FakeDR(), raising=True
+            # Patch HA helpers & dispatcher for the update() call only.
+            # Still a module-global patch while it lasts: any concurrent HA
+            # task that resolves a registry inside this await sees the fakes.
+            originals = (
+                mod.device_registry.async_get,
+                mod.entity_registry.async_get,
+                mod.entity_registry.async_entries_for_device,
+                mod.async_dispatcher_send,
             )
-            monkeypatch.setattr(
-                mod.entity_registry, "async_get", lambda _: FakeER(), raising=True
-            )
+            with monkeypatch.context() as mp:
+                mp.setattr(
+                    mod.device_registry, "async_get", lambda _: FakeDR(), raising=True
+                )
+                mp.setattr(
+                    mod.entity_registry, "async_get", lambda _: FakeER(), raising=True
+                )
+                mp.setattr(
+                    mod.entity_registry,
+                    "async_entries_for_device",
+                    fake_entries_for_device,
+                    raising=True,
+                )
+                mp.setattr(
+                    mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
+                )
 
-            monkeypatch.setattr(
-                mod.entity_registry,
-                "async_entries_for_device",
-                fake_entries_for_device,
-                raising=True,
-            )
-            monkeypatch.setattr(
-                mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
-            )
+                # Should exit early without error (L602).
+                await srv.update(srv.settings.cpid)
 
-            # Should exit early without error (L602).
-            await srv.update(srv.settings.cpid)
+            # The leak guard: on the pinned harness the fakes are harmless at
+            # teardown, so nothing else fails if this scoping regresses. The
+            # helpers being restored right here is the actual contract.
+            assert originals == (
+                mod.device_registry.async_get,
+                mod.entity_registry.async_get,
+                mod.entity_registry.async_entries_for_device,
+                mod.async_dispatcher_send,
+            )
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -316,16 +327,7 @@ async def test_update_traverses_children_and_skips_visited(
             child = Dev("child", via="root")
 
             class FakeDR:
-                """Fake DR."""
-
-                def async_clear_config_entry(self, config_entry_id):
-                    return None
-
-                def async_update_device(self, *args, **kwargs):
-                    return None
-
-                def async_get_or_create(self, *args, **kwargs):
-                    return SimpleNamespace(id="dummy")
+                """Fake DR: only what update()'s traversal touches (see above)."""
 
                 def async_get_device(self, identifiers):
                     return root
@@ -340,35 +342,52 @@ async def test_update_traverses_children_and_skips_visited(
                     return Container()
 
             class FakeER:
-                """Fake ER."""
-
-                def async_clear_config_entry(self, config_entry_id):
-                    return None
+                """Fake ER: only ever passed to the patched entries_for_device."""
 
             def fake_entries_for_device(_er, _dev_id):
                 # No entities to update; the loop is exercised anyway.
                 return []
 
-            # Patch HA helpers & dispatcher.
-            monkeypatch.setattr(
-                mod.device_registry, "async_get", lambda _: FakeDR(), raising=True
+            # Patch HA helpers & dispatcher for the update() call only -
+            # the module-level patch must not leak into entry teardown.
+            # Still a module-global patch while it lasts: any concurrent HA
+            # task that resolves a registry inside this await sees the fakes.
+            originals = (
+                mod.device_registry.async_get,
+                mod.entity_registry.async_get,
+                mod.entity_registry.async_entries_for_device,
+                mod.async_dispatcher_send,
             )
-            monkeypatch.setattr(
-                mod.entity_registry, "async_get", lambda _: FakeER(), raising=True
-            )
-            monkeypatch.setattr(
-                mod.entity_registry,
-                "async_entries_for_device",
-                fake_entries_for_device,
-                raising=True,
-            )
-            monkeypatch.setattr(
-                mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
-            )
+            with monkeypatch.context() as mp:
+                mp.setattr(
+                    mod.device_registry, "async_get", lambda _: FakeDR(), raising=True
+                )
+                mp.setattr(
+                    mod.entity_registry, "async_get", lambda _: FakeER(), raising=True
+                )
+                mp.setattr(
+                    mod.entity_registry,
+                    "async_entries_for_device",
+                    fake_entries_for_device,
+                    raising=True,
+                )
+                mp.setattr(
+                    mod, "async_dispatcher_send", lambda *args, **kw: None, raising=True
+                )
 
-            # No exceptions expected; internal traversal will append 'child' twice,
-            # so on second pop it will be in 'visited' and trigger L612 'continue'.
-            await srv.update(srv.settings.cpid)
+                # No exceptions expected; internal traversal will append 'child' twice,
+                # so on second pop it will be in 'visited' and trigger L612 'continue'.
+                await srv.update(srv.settings.cpid)
+
+            # The leak guard: on the pinned harness the fakes are harmless at
+            # teardown, so nothing else fails if this scoping regresses. The
+            # helpers being restored right here is the actual contract.
+            assert originals == (
+                mod.device_registry.async_get,
+                mod.entity_registry.async_get,
+                mod.entity_registry.async_entries_for_device,
+                mod.async_dispatcher_send,
+            )
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):


### PR DESCRIPTION
## What this fixes

CI on #2064 (the pytest-homeassistant-custom-component 0.13.348 → 0.13.354 bump, i.e. HA core 2026.7 → 2026.8) fails with two teardown ERRORs in `tests/test_more_coverage_chargepoint.py`:

```
TypeError: FakeDR.async_clear_config_entry() takes 2 positional arguments but 3 were given
AttributeError: 'FakeDR' object has no attribute 'async_get'
```

No production code is involved — the integration itself runs fine on HA 2026.8 (verified on a live install: HA 2026.8.0 + v0.10.18).

## Root cause

`test_update_returns_early_when_root_device_missing` and `test_update_traverses_children_and_skips_visited` drive two branches of `chargepoint.update()` by replacing the **module-level** device/entity registry helpers with minimal fakes. The monkeypatch could outlive the test body, so Home Assistant's own config-entry teardown also ran against the fakes.

The tell that this was always happening: the fakes stub `async_clear_config_entry`, `async_update_device` and `async_get_or_create` — methods `update()` never calls, only core's device/entity lifecycle does. They existed purely to absorb teardown, and they matched the old core's surface exactly.

HA 2026.8 moved that surface: entry removal now calls `dev_reg.async_clear_config_entry(entry_id, entry.domain)` — a second positional argument ([config_entries.py L2282](https://github.com/home-assistant/core/blob/2026.8.0/homeassistant/config_entries.py#L2282)) — and entity removal resolves devices via `DeviceRegistry.async_get`. Both hit fake surface that does not exist.

This is the same hazard class #2055 is tracking: test infrastructure that papers over lifecycle reality instead of respecting it. A leaked registry fake stubbing teardown methods it shouldn't know about is a first cousin of the global `StateMachine.get` patch that hid the migration bug (#2060) — this is that cleanup continuing.

## The fix (one test file, no production changes)

1. **Scope the patches** with `monkeypatch.context()` around the single `update()` call, so core's teardown always runs against the real registries — on every harness version, past and future.
2. **Delete every stub `update()` does not reach** (`async_clear_config_entry`, `async_update_device`, `async_get_or_create`, on both fakes). Verified dead against `update()`'s source and empirically. If the fakes ever leak again, the missing attributes fail loudly instead of silently absorbing core's cleanup.
3. **Assert after the block that all four patched helpers are restored.** On the pinned 0.13.348 the leaked fakes were harmless at teardown, so without this the scoping could regress invisibly until the next harness bump — the fix would be a no-op on the version CI actually runs. Widening any patch back to function scope now fails the test on both versions (mutation-verified: the reverted-scope mutant dies at this assert on 0.13.348, and at the assert plus the teardown errors on 0.13.354).

The patch is still module-global for the duration of the single await (any concurrent HA task resolving a registry in that window would see the fakes); a comment marks that residual rather than hiding it. This file is the only place in the suite using the module-registry-patch technique, so the fix is complete for its class.

## Verification

| Harness | HA core | Result |
|---|---|---|
| 0.13.354 (the #2064 target) | 2026.8.0 | full suite 280/280 |
| 0.13.348 (current pin) | 2026.7.4 | changed file 9/9; scope-regression mutant killed by the new assert |

One caveat for full transparency: a local full-suite run on 0.13.348 surfaced a **pre-existing, environment-sensitive** teardown error in `test_session_energy_meter_start_cast_exception` (tests/test_additional_charge_point_v16.py) — that test poisons `Energy.Meter.Start` with a raw `object()` sentinel, the sentinel outlives the test into the sensor's teardown render, and whether the resulting "task exception was never retrieved" surfaces depends on event-loop/GC timing. It reproduces identically on unmodified `main` on this machine and is green in repo CI (main's latest run, and the #2064 run, both pass it). Unrelated to this change — same leaked-poison family as the fakes fixed here; happy to file it separately.

Sequencing: merge this, then `@dependabot rebase` on #2064 and it goes green. This PR deliberately does not bump the pin — that stays #2064's job.

Closes nothing; unblocks #2064.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for child-device traversal, including duplicate-child skipping, entity filtering, and lookup order.
  * Added verification that updates dispatch the exact set of enabled entities.
  * Confirmed temporary helper overrides are restored after updates.
  * Simplified registry test fakes and removed obsolete registry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->