### PR TITLE
Make lifecycle failures assertable, and fail tests that swallow them

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ addopts = -qq --cov=custom_components.ocpp --allow-unix-socket --allow-hosts=127
 console_output_style = count
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
+markers =
+    allow_lifecycle_errors: this test deliberately provokes swallowed lifecycle errors (see tests/lifecycle_asserts.py)
 
 [coverage:report]
 show_missing = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -qq --cov=custom_components.ocpp --allow-unix-socket --allow-hosts=127.0.0.1
+addopts = -qq --strict-markers --cov=custom_components.ocpp --allow-unix-socket --allow-hosts=127.0.0.1
 console_output_style = count
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from .charge_point_test import (
     remove_configuration,
 )
 
+from .lifecycle_asserts import assert_no_swallowed_lifecycle_errors
+
 pytest_plugins = "pytest_homeassistant_custom_component"
 
 
@@ -23,6 +25,27 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations defined in the test dir."""
     yield
+
+
+@pytest.fixture(autouse=True)
+def fail_on_swallowed_lifecycle_errors(request, caplog):
+    """Fail any test whose log carries a swallowed lifecycle failure.
+
+    Home Assistant turns platform-setup exceptions, forward collisions
+    and bad unloads into log lines while the calls report success, so a
+    regression fails no assertion anywhere - this tripwire makes the
+    nearest test fail instead. Tests that provoke these deliberately
+    opt out with @pytest.mark.allow_lifecycle_errors.
+
+    Only the synchronous signatures are enforced here: "Task exception
+    was never retrieved" surfaces at GC/loop-drain time, so it can miss
+    or cross test boundaries depending on environment - dedicated
+    lifecycle tests assert it inside controlled windows instead.
+    """
+    yield
+    if request.node.get_closest_marker("allow_lifecycle_errors"):
+        return
+    assert_no_swallowed_lifecycle_errors(caplog, include_async=False)
 
 
 # This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent

--- a/tests/lifecycle_asserts.py
+++ b/tests/lifecycle_asserts.py
@@ -21,15 +21,23 @@ PLATFORM_DOMAINS = ("sensor", "switch", "number", "button")
 
 # Logged synchronously, in-band, by the setup/reload/unload call the test
 # itself makes - deterministic, and safe for the autouse tripwire.
+# Note: a mid-test caplog.clear() empties the live phase list, so records
+# logged before the clear are invisible to these checks - clear sparingly.
 SYNC_SWALLOWED_SIGNATURES = (
     # HA wraps a platform's setup exception into this line and the entry
     # still reports loaded (#2053: every platform dead, nothing failed).
     "Error setting up entry",
+    # HA swallows any exception from an integration's unload the same
+    # way (config_entries "Error unloading entry %s for %s") - the
+    # deterministic fingerprint of a broken unload during teardown.
+    "Error unloading entry",
     # A forward colliding with still-registered platforms - the unload
-    # that claimed success but never ran (#2054).
+    # that claimed success but never ran (#2054). This text is raised,
+    # not logged: it reaches a record via the exception attached to
+    # "Error setting up entry" (scanned below) or a task-death repr.
     "has already been setup",
     # The mirror image: unloading platforms that were never forwarded
-    # (#2054's first-discovery edge).
+    # (#2054's first-discovery edge). Raised, not logged, like the above.
     "Config entry was never loaded",
 )
 
@@ -44,8 +52,24 @@ SYNC_SWALLOWED_SIGNATURES = (
 ASYNC_SWALLOWED_SIGNATURES = ("Task exception was never retrieved",)
 
 
-def swallowed_lifecycle_errors(caplog, include_async=True):
-    """Return the swallowed-failure records captured by caplog.
+def _searchable_text(record):
+    """Message plus any attached exception text.
+
+    The collision/never-loaded signatures are RAISE sites: their text
+    never appears in a log message, only in the exception Home Assistant
+    attaches to its own "Error setting up entry" line - so the traceback
+    must be scanned for them to match on the deterministic path.
+    """
+    parts = [record.getMessage()]
+    if record.exc_text:
+        parts.append(record.exc_text)
+    elif record.exc_info and record.exc_info[1] is not None:
+        parts.append(str(record.exc_info[1]))
+    return "\n".join(parts)
+
+
+def _offending(caplog, include_async):
+    """Yield (phase, record) pairs matching the swallowed signatures.
 
     Reads all three capture phases explicitly: caplog.records is scoped
     to the CURRENT phase, so a fixture-teardown check reading it would
@@ -55,21 +79,25 @@ def swallowed_lifecycle_errors(caplog, include_async=True):
     signatures = SYNC_SWALLOWED_SIGNATURES
     if include_async:
         signatures = signatures + ASYNC_SWALLOWED_SIGNATURES
-    records = []
-    for phase in ("setup", "call", "teardown"):
-        records.extend(caplog.get_records(phase))
     return [
-        record
-        for record in records
-        if any(sig in record.getMessage() for sig in signatures)
+        (phase, record)
+        for phase in ("setup", "call", "teardown")
+        for record in caplog.get_records(phase)
+        if any(sig in _searchable_text(record) for sig in signatures)
     ]
+
+
+def swallowed_lifecycle_errors(caplog, include_async=True):
+    """Return the swallowed-failure records captured by caplog."""
+    return [record for _, record in _offending(caplog, include_async)]
 
 
 def assert_no_swallowed_lifecycle_errors(caplog, include_async=True):
     """Fail if the log carries any swallowed lifecycle-failure signature."""
-    offenders = swallowed_lifecycle_errors(caplog, include_async)
+    offenders = _offending(caplog, include_async)
     assert not offenders, "Swallowed lifecycle errors in log:\n" + "\n".join(
-        f"  {record.levelname}: {record.getMessage()}" for record in offenders
+        f"  [{phase}] {record.levelname}: {record.getMessage()}"
+        for phase, record in offenders
     )
 
 

--- a/tests/lifecycle_asserts.py
+++ b/tests/lifecycle_asserts.py
@@ -45,13 +45,22 @@ ASYNC_SWALLOWED_SIGNATURES = ("Task exception was never retrieved",)
 
 
 def swallowed_lifecycle_errors(caplog, include_async=True):
-    """Return the swallowed-failure records captured by caplog."""
+    """Return the swallowed-failure records captured by caplog.
+
+    Reads all three capture phases explicitly: caplog.records is scoped
+    to the CURRENT phase, so a fixture-teardown check reading it would
+    see only teardown records and miss everything the test body logged -
+    a tripwire that can never fire (caught by its synthetic mutant).
+    """
     signatures = SYNC_SWALLOWED_SIGNATURES
     if include_async:
         signatures = signatures + ASYNC_SWALLOWED_SIGNATURES
+    records = []
+    for phase in ("setup", "call", "teardown"):
+        records.extend(caplog.get_records(phase))
     return [
         record
-        for record in caplog.records
+        for record in records
         if any(sig in record.getMessage() for sig in signatures)
     ]
 

--- a/tests/lifecycle_asserts.py
+++ b/tests/lifecycle_asserts.py
@@ -1,0 +1,114 @@
+"""Shared assertions for config-entry lifecycle correctness.
+
+Home Assistant swallows most lifecycle failures: a platform that raises
+during setup becomes an "Error setting up entry" log line while setup
+still returns True, an unload that never happened still reports success,
+and a task that dies in teardown surfaces (sometimes) as an unretrieved
+exception long after the code that caused it. Tests that assert only on
+hass.data shape pass through all of it - which is how the #2054 platform
+collision, the #2064 registry-fake leak and the Energy.Meter.Start poison
+each stayed green for months.
+
+These helpers make those failures assertable. The log-signature checks
+are the secondary net; the structural asserts (platform bookkeeping,
+entity identity across a reload) are the load-bearing ones, because they
+hold even if Home Assistant rewords its log lines.
+"""
+
+from homeassistant.setup import async_setup_component
+
+PLATFORM_DOMAINS = ("sensor", "switch", "number", "button")
+
+# Logged synchronously, in-band, by the setup/reload/unload call the test
+# itself makes - deterministic, and safe for the autouse tripwire.
+SYNC_SWALLOWED_SIGNATURES = (
+    # HA wraps a platform's setup exception into this line and the entry
+    # still reports loaded (#2053: every platform dead, nothing failed).
+    "Error setting up entry",
+    # A forward colliding with still-registered platforms - the unload
+    # that claimed success but never ran (#2054).
+    "has already been setup",
+    # The mirror image: unloading platforms that were never forwarded
+    # (#2054's first-discovery edge).
+    "Config entry was never loaded",
+)
+
+# Emitted when a fire-and-forget task dies unobserved. This surfaces at
+# GC/event-loop-drain time, NOT in-band: the same test can be red on one
+# machine and green on CI, and a surviving task can in principle land its
+# message in a neighbouring test's window. The autouse tripwire therefore
+# deliberately does NOT enforce this class; dedicated lifecycle tests,
+# whose windows are controlled, do. Motivating incidents: the registry
+# fakes leaking into teardown (#2064/#2065) and the Energy.Meter.Start
+# object() poison - both invisible to every assertion then in the suite.
+ASYNC_SWALLOWED_SIGNATURES = ("Task exception was never retrieved",)
+
+
+def swallowed_lifecycle_errors(caplog, include_async=True):
+    """Return the swallowed-failure records captured by caplog."""
+    signatures = SYNC_SWALLOWED_SIGNATURES
+    if include_async:
+        signatures = signatures + ASYNC_SWALLOWED_SIGNATURES
+    return [
+        record
+        for record in caplog.records
+        if any(sig in record.getMessage() for sig in signatures)
+    ]
+
+
+def assert_no_swallowed_lifecycle_errors(caplog, include_async=True):
+    """Fail if the log carries any swallowed lifecycle-failure signature."""
+    offenders = swallowed_lifecycle_errors(caplog, include_async)
+    assert not offenders, "Swallowed lifecycle errors in log:\n" + "\n".join(
+        f"  {record.levelname}: {record.getMessage()}" for record in offenders
+    )
+
+
+def assert_platforms_hold(hass, entry_id, platforms=PLATFORM_DOMAINS):
+    """Assert exactly these entity platforms currently hold this entry.
+
+    Reads EntityComponent._platforms, which is core-private: a rename
+    breaks this loudly (KeyError), not silently. Accepted because the
+    public surface has no way to ask "who holds this entry", and the
+    entity-identity asserts below do not depend on it.
+    """
+    components = hass.data.get("entity_components", {})
+    holding = {
+        domain
+        for domain in PLATFORM_DOMAINS
+        if domain in components and entry_id in components[domain]._platforms
+    }
+    assert holding == set(platforms), (
+        f"Entity platforms holding {entry_id}: {sorted(holding)}, "
+        f"expected {sorted(platforms)}"
+    )
+
+
+def live_entity(hass, entity_id, domain):
+    """Return the entity object the given platform currently owns."""
+    return hass.data["entity_components"][domain].get_entity(entity_id)
+
+
+def assert_rebuilt(before, after):
+    """Assert an entity was rebuilt - the load-bearing reload check.
+
+    A clean reload tears platforms down and builds new ones, so the
+    entity must be a fresh object. The broken path leaves the pre-reload
+    platforms - and this exact instance - in place, whatever the logs
+    say.
+    """
+    assert before is not None, "entity did not exist before the reload"
+    assert after is not None, "entity missing after the reload"
+    assert after is not before, "entity survived the reload - stale platforms"
+
+
+async def load_platform_components(hass):
+    """Load the platform integrations globally, as any real install has.
+
+    Without this the harness lets an over-eager unload off the hook: core
+    short-circuits unloading a platform whose component is not loaded at
+    all, a state that does not exist on a live system.
+    """
+    for domain in PLATFORM_DOMAINS:
+        assert await async_setup_component(hass, domain, {})
+    await hass.async_block_till_done()

--- a/tests/test_additional_charge_point_v16.py
+++ b/tests/test_additional_charge_point_v16.py
@@ -876,72 +876,24 @@ async def test_mirror_single_connector_handles_int_exception(
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "setup_config_entry",
-    [{"port": 9328, "cp_id": "CP_cov_sess_energy_cast_exc", "cms": "cms_services"}],
+    [{"port": 9328, "cp_id": "CP_val_coerce", "cms": "cms_services"}],
     indirect=True,
 )
-@pytest.mark.parametrize("cp_id", ["CP_cov_sess_energy_cast_exc"])
+@pytest.mark.parametrize("cp_id", ["CP_val_coerce"])
 @pytest.mark.parametrize("port", [9328])
-async def test_session_energy_get_energy_kwh_exception_ignored(
-    hass, socket_enabled, cp_id, port, setup_config_entry, monkeypatch
-):
-    """Test session energy calculation ignores EAIR entries raising conversion errors."""
-    cs = setup_config_entry
-    async with websockets.connect(
-        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
-    ) as ws:
-        cp = ChargePoint(f"{cp_id}_client", ws)
-        task = asyncio.create_task(cp.start())
-        try:
-            await cp.send_boot_notification()
-            await wait_ready(cs.charge_points[cp_id])
-
-            from custom_components.ocpp.ocppv16 import cp as cp_mod
-
-            monkeypatch.setattr(
-                cp_mod,
-                "get_energy_kwh",
-                lambda item: (_ for _ in ()).throw(RuntimeError("bad")),
-            )
-
-            mv = call.MeterValues(
-                connector_id=1,
-                meter_value=[
-                    {
-                        "timestamp": datetime.now(tz=UTC).isoformat(),
-                        "sampledValue": [
-                            {
-                                "value": "1000",
-                                "measurand": "Energy.Active.Import.Register",
-                                "unit": "Wh",
-                                "context": "Sample.Clock",
-                            }
-                        ],
-                    }
-                ],
-                transaction_id=3,
-            )
-            _ = await cp.call(mv)
-            # No crash == lines 1005-1006 exercised
-            assert True
-        finally:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-            await ws.close()
-
-
-@pytest.mark.timeout(10)
-@pytest.mark.parametrize(
-    "setup_config_entry",
-    [{"port": 9329, "cp_id": "CP_cov_sess_ms_cast_exc", "cms": "cms_services"}],
-    indirect=True,
-)
-@pytest.mark.parametrize("cp_id", ["CP_cov_sess_ms_cast_exc"])
-@pytest.mark.parametrize("port", [9329])
-async def test_session_energy_meter_start_cast_exception(
+async def test_non_numeric_sampled_value_coerces_to_zero(
     hass, socket_enabled, cp_id, port, setup_config_entry
 ):
-    """Test session energy path when meter_start cannot be cast to float."""
+    """A sampled value that cannot parse must coerce to 0.0, not kill the call.
+
+    Drives the guard at ocppv16 on_meter_values (value = float(value)
+    except -> 0.0) with the input it exists for. The previous version of
+    this test monkeypatched get_energy_kwh on what it believed was a
+    module (actually the ChargePoint class), drove an unguarded raise the
+    library swallowed into a CALLError the suppressing client never saw,
+    and asserted True - it could not fail. suppress=False makes any
+    unhandled server-side exception fail this test loudly.
+    """
     cs = setup_config_entry
     async with websockets.connect(
         f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
@@ -952,8 +904,78 @@ async def test_session_energy_meter_start_cast_exception(
             await cp.send_boot_notification()
             await wait_ready(cs.charge_points[cp_id])
             srv = cs.charge_points[cp_id]
-            # Poison meter_start with a non-float so that float() raises
-            srv._metrics[(1, "Energy.Meter.Start")].value = object()
+
+            mv = call.MeterValues(
+                connector_id=1,
+                meter_value=[
+                    {
+                        "timestamp": datetime.now(tz=UTC).isoformat(),
+                        "sampledValue": [
+                            {
+                                "value": "garbage",
+                                "measurand": "Energy.Active.Import.Register",
+                                "unit": "Wh",
+                                "context": "Sample.Clock",
+                            }
+                        ],
+                    }
+                ],
+                transaction_id=3,
+            )
+            resp = await cp.call(mv, suppress=False)
+            assert resp is not None
+
+            # The guard coerced the unparseable reading to 0.0 and the
+            # session machinery seeded its baseline from it. A numeric
+            # input here ("1000") lands 1.0 instead - the assert is
+            # input-sensitive, so the coercion is what it verifies.
+            assert srv._metrics[(1, "Energy.Active.Import.Register")].value == 0.0
+            assert srv._metrics[(1, "Energy.Meter.Start")].value == 0.0
+            assert srv._metrics[(1, "Energy.Session")].value == 0.0
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await ws.close()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize(
+    "setup_config_entry",
+    [{"port": 9329, "cp_id": "CP_ms_restore", "cms": "cms_services"}],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_ms_restore"])
+@pytest.mark.parametrize("port", [9329])
+async def test_meter_start_restores_from_ha_state(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """A numeric restored state becomes the session baseline after restart.
+
+    Seeds the meter-start sensor's HA state the way a real restart leaves
+    it and asserts the restore path consumed it: session energy is the
+    reading minus the RESTORED baseline. Removing the seeded state flips
+    the outcome (baseline re-seeds from the reading, session becomes 0.0),
+    so the assertion is input-sensitive - this test is the discriminating
+    twin of the non-numeric case below, which converges with the no-state
+    path by design.
+    """
+    cs = setup_config_entry
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
+    ) as ws:
+        cp = ChargePoint(f"{cp_id}_client", ws)
+        task = asyncio.create_task(cp.start())
+        try:
+            await cp.send_boot_notification()
+            await wait_ready(cs.charge_points[cp_id])
+            srv = cs.charge_points[cp_id]
+            assert srv._metrics[(1, "Energy.Meter.Start")].value is None
+            # The entity id get_ha_metric builds for connector 1 of cpid
+            # "test_cpid"; the value is what RestoreSensor would republish.
+            hass.states.async_set(
+                "sensor.test_cpid_connector_1_energy_meter_start", "0.5"
+            )
 
             mv = call.MeterValues(
                 connector_id=1,
@@ -972,9 +994,85 @@ async def test_session_energy_meter_start_cast_exception(
                 ],
                 transaction_id=4,
             )
-            _ = await cp.call(mv)
-            # No crash is sufficient to cover lines 1023-1024
-            assert True
+            resp = await cp.call(mv, suppress=False)
+            assert resp is not None
+
+            assert srv._metrics[(1, "Energy.Meter.Start")].value == 0.5
+            # 1000 Wh reading (1.0 kWh) minus the restored 0.5 baseline -
+            # the healthy subtraction branch, driven with real inputs.
+            assert srv._metrics[(1, "Energy.Session")].value == 0.5
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await ws.close()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize(
+    "setup_config_entry",
+    [{"port": 9417, "cp_id": "CP_ms_restore_bad", "cms": "cms_services"}],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_ms_restore_bad"])
+@pytest.mark.parametrize("port", [9417])
+async def test_meter_start_restore_rejects_non_numeric_state(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """A garbage restored state is rejected by the cast guard, not stored.
+
+    Drives the float() guard in on_meter_values' restore block with the
+    input it exists for. The guard swallows the ValueError, the metric
+    stays None, and the session machinery re-seeds its baseline from the
+    reading. Removing the guard makes float() raise unhandled, the server
+    answers a CALLError, and suppress=False fails this test loudly.
+
+    This replaces a test that wrote a raw object() sentinel into the
+    metric: the sentinel crashed an UNGUARDED line the test never claimed
+    to cover, the suppressing client discarded the resulting CALLError so
+    assert True passed anyway, and the poison outlived the test into the
+    sensor's teardown render, detonating environment-dependently as
+    "Task exception was never retrieved".
+    """
+    cs = setup_config_entry
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
+    ) as ws:
+        cp = ChargePoint(f"{cp_id}_client", ws)
+        task = asyncio.create_task(cp.start())
+        try:
+            await cp.send_boot_notification()
+            await wait_ready(cs.charge_points[cp_id])
+            srv = cs.charge_points[cp_id]
+            assert srv._metrics[(1, "Energy.Meter.Start")].value is None
+            hass.states.async_set(
+                "sensor.test_cpid_connector_1_energy_meter_start", "not-a-number"
+            )
+
+            mv = call.MeterValues(
+                connector_id=1,
+                meter_value=[
+                    {
+                        "timestamp": datetime.now(tz=UTC).isoformat(),
+                        "sampledValue": [
+                            {
+                                "value": "1000",
+                                "measurand": "Energy.Active.Import.Register",
+                                "unit": "Wh",
+                                "context": "Sample.Clock",
+                            }
+                        ],
+                    }
+                ],
+                transaction_id=4,
+            )
+            resp = await cp.call(mv, suppress=False)
+            assert resp is not None
+
+            # Guard rejected the garbage: baseline re-seeded from the
+            # reading, session starts at zero.
+            assert srv._metrics[(1, "Energy.Meter.Start")].value == 1.0
+            assert srv._metrics[(1, "Energy.Session")].value == 0.0
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_additional_charge_point_v16.py
+++ b/tests/test_additional_charge_point_v16.py
@@ -970,6 +970,9 @@ async def test_meter_start_restores_from_ha_state(
             await cp.send_boot_notification()
             await wait_ready(cs.charge_points[cp_id])
             srv = cs.charge_points[cp_id]
+            # Drain boot-era update tasks before seeding: a straggler
+            # dispatch would republish the sensor as unknown over the seed.
+            await hass.async_block_till_done()
             assert srv._metrics[(1, "Energy.Meter.Start")].value is None
             # The entity id get_ha_metric builds for connector 1 of cpid
             # "test_cpid"; the value is what RestoreSensor would republish.
@@ -1044,6 +1047,8 @@ async def test_meter_start_restore_rejects_non_numeric_state(
             await cp.send_boot_notification()
             await wait_ready(cs.charge_points[cp_id])
             srv = cs.charge_points[cp_id]
+            # Drain boot-era update tasks before seeding (see twin above).
+            await hass.async_block_till_done()
             assert srv._metrics[(1, "Energy.Meter.Start")].value is None
             hass.states.async_set(
                 "sensor.test_cpid_connector_1_energy_meter_start", "not-a-number"

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -2071,28 +2071,23 @@ async def test_on_diagnostics_status_notification(
             captured = {"called": 0, "msg": None}
 
             async def fake_notify(msg: str, title: str = "Ocpp integration"):
-                # record the message; return True like the real notifier
+                # Count the actual notification. The previous version
+                # counted hass.async_create_task calls as a proxy, which
+                # broke on HA 2026.8: entity updates now route through
+                # the same method, so unrelated tasks landed in the count.
+                captured["called"] += 1
                 captured["msg"] = msg
                 return True
 
-            def fake_async_create_task(coro):
-                # actually schedule the coroutine so fake_notify runs
-                captured["called"] += 1
-                return asyncio.create_task(coro)
-
             monkeypatch.setattr(srv_cp, "notify_ha", fake_notify, raising=True)
-            monkeypatch.setattr(
-                srv_cp.hass, "async_create_task", fake_async_create_task, raising=True
-            )
 
             # trigger server handler
             req = call.DiagnosticsStatusNotification(status="Uploaded")
             resp = await cp.call(req)
             assert resp is not None  # server replied
 
-            # ensure notify_ha ran and message content is correct
-            # give the task a tick to run
-            await asyncio.sleep(0)
+            # let the scheduled notify task actually run
+            await hass.async_block_till_done()
             assert captured["called"] == 1
             assert captured["msg"] == "Diagnostics upload status: Uploaded"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,17 @@ from .const import (
     MOCK_CONFIG_MIGRATION_FLOW,
     MOCK_CONFIG_DATA_1_MC,
 )
+from .lifecycle_asserts import (
+    assert_no_swallowed_lifecycle_errors,
+    assert_platforms_hold,
+    assert_rebuilt,
+    live_entity,
+)
+
+# Both single- and multi-connector mocks configure cpid "test_cpid_9001"
+# with at least one connector, so this entity exists in each lifecycle
+# test and its identity across a reload is the load-bearing assertion.
+MAX_CURRENT_EID = "number.test_cpid_9001_connector_1_maximum_current"
 
 
 # We can pass fixtures as defined in conftest.py to tell pytest to use the fixture
@@ -24,7 +35,7 @@ from .const import (
 # Assertions allow you to verify that the return value of whatever is on the left
 # side of the assertion matches with the right side.
 async def test_setup_unload_and_reload_entry(
-    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None, caplog
 ):
     """Test entry setup and unload."""
     # Create a mock entry so we don't have to go through config flow
@@ -47,20 +58,28 @@ async def test_setup_unload_and_reload_entry(
     assert DOMAIN in hass.data
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+    # Structural: the forward actually registered every entity platform.
+    assert_platforms_hold(hass, config_entry.entry_id)
+    entity_before = live_entity(hass, MAX_CURRENT_EID, "number")
 
     # Reload the entry and assert that the data from above is still there
     assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+    # Structural: fresh platforms, fresh entity - not the old ones surviving.
+    assert_platforms_hold(hass, config_entry.entry_id)
+    assert_rebuilt(entity_before, live_entity(hass, MAX_CURRENT_EID, "number"))
 
     # Unload the entry and verify that the data has been removed
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.entry_id not in hass.data[DOMAIN]
+    assert_no_swallowed_lifecycle_errors(caplog)
 
 
 async def test_setup_unload_and_reload_entry_multiple_connectors(
-    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None, caplog
 ):
     """Test entry setup and unload."""
     # Create a mock entry so we don't have to go through config flow
@@ -83,20 +102,26 @@ async def test_setup_unload_and_reload_entry_multiple_connectors(
     assert DOMAIN in hass.data
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+    assert_platforms_hold(hass, config_entry.entry_id)
+    entity_before = live_entity(hass, MAX_CURRENT_EID, "number")
 
     # Reload the entry and assert that the data from above is still there
     assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+    assert_platforms_hold(hass, config_entry.entry_id)
+    assert_rebuilt(entity_before, live_entity(hass, MAX_CURRENT_EID, "number"))
 
     # Unload the entry and verify that the data has been removed
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.entry_id not in hass.data[DOMAIN]
+    assert_no_swallowed_lifecycle_errors(caplog)
 
 
 async def test_migration_entry(
-    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None, caplog
 ):
     """Test entry migration."""
     # Create a mock entry so we don't have to go through config flow
@@ -130,6 +155,8 @@ async def test_migration_entry(
     assert DOMAIN in hass.data
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert type(hass.data[DOMAIN][config_entry.entry_id]) is CentralSystem
+    # The migrated entry's setup must have forwarded the platforms too.
+    assert_platforms_hold(hass, config_entry.entry_id)
     # check migration has created new entry with correct keys
     assert config_entry.data.keys() == MOCK_CONFIG_DATA.keys()
     # The charge point key must be the seeded sensor's VALUE, as a plain
@@ -149,6 +176,7 @@ async def test_migration_entry(
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.entry_id not in hass.data[DOMAIN]
+    assert_no_swallowed_lifecycle_errors(caplog)
 
 
 # async def test_setup_entry_exception(hass, error_on_get_data):
@@ -166,7 +194,7 @@ async def test_migration_entry(
 
 
 async def test_migration_refuses_a_sentinel_charger_id(
-    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None, caplog
 ):
     """An 'unavailable' id sensor must fail migration, not become the key.
 
@@ -193,10 +221,13 @@ async def test_migration_refuses_a_sentinel_charger_id(
 
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
     assert config_entry.version == 1
+    # The refusal is a clean, deliberate failure ("Error migrating entry"
+    # from core) - none of the swallowed-failure signatures may appear.
+    assert_no_swallowed_lifecycle_errors(caplog)
 
 
 async def test_migration_finds_a_non_slug_cpid(
-    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None
+    hass: AsyncGenerator[HomeAssistant, None], bypass_get_data: None, caplog
 ):
     """A cpid like 'Garage Charger' must still resolve its id sensor.
 
@@ -221,7 +252,10 @@ async def test_migration_finds_a_non_slug_cpid(
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    assert_platforms_hold(hass, config_entry.entry_id)
     migrated_key = next(iter(config_entry.data[CONF_CPIDS][0]))
     assert migrated_key == "CP_migration_2"
 
     assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert_no_swallowed_lifecycle_errors(caplog)

--- a/tests/test_reload_offline_charger.py
+++ b/tests/test_reload_offline_charger.py
@@ -22,7 +22,7 @@ on every run. The load-bearing assertion here is therefore structural -
 the entity object must be a fresh instance created by the post-reload
 platforms, because the bug's signature is the OLD platforms surviving
 with their old entities. The log check is a secondary signal only, and
-tracks Home Assistant core wording.
+tracks Home Assistant core wording via lifecycle_asserts.
 """
 
 import asyncio
@@ -30,14 +30,18 @@ from unittest.mock import patch
 
 import pytest
 import websockets.asyncio.server
-from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ocpp.const import CONF_CPIDS, DOMAIN
 
 from .const import MOCK_CONFIG_DATA, MOCK_CONFIG_DATA_1, MOCK_CONFIG_CP_APPEND
-
-PLATFORM_DOMAINS = ("sensor", "switch", "number", "button")
+from .lifecycle_asserts import (
+    assert_no_swallowed_lifecycle_errors,
+    assert_platforms_hold,
+    assert_rebuilt,
+    live_entity,
+    load_platform_components,
+)
 
 
 @pytest.fixture(name="bypass_websockets")
@@ -60,49 +64,6 @@ def bypass_websockets_fixture():
         yield
 
 
-async def _load_platform_components(hass):
-    """Load the platform integrations globally, as any real install has.
-
-    Without this the harness lets an over-eager unload off the hook: core
-    short-circuits unloading a platform whose component is not loaded at
-    all, a state that does not exist on a live system.
-    """
-    for domain in PLATFORM_DOMAINS:
-        assert await async_setup_component(hass, domain, {})
-    await hass.async_block_till_done()
-
-
-def _setup_errors(caplog):
-    """Return the swallowed platform-collision log records."""
-    return [
-        record
-        for record in caplog.records
-        if "Error setting up entry" in record.getMessage()
-        or "has already been setup" in record.getMessage()
-    ]
-
-
-def _platforms_holding(hass, entry_id):
-    """Return which entity platforms currently hold this entry.
-
-    Reads EntityComponent._platforms, which is core-private: a rename
-    breaks this helper loudly (KeyError), not silently. Accepted because
-    the public surface has no way to ask "who holds this entry", and the
-    freshness assertions below do not depend on it.
-    """
-    components = hass.data.get("entity_components", {})
-    return {
-        domain
-        for domain in PLATFORM_DOMAINS
-        if domain in components and entry_id in components[domain]._platforms
-    }
-
-
-def _live_entity(hass, entity_id):
-    """Return the entity object the number platform currently owns."""
-    return hass.data["entity_components"]["number"].get_entity(entity_id)
-
-
 async def test_reload_with_charger_offline_keeps_every_platform(
     hass, bypass_websockets, caplog
 ):
@@ -119,23 +80,20 @@ async def test_reload_with_charger_offline_keeps_every_platform(
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+    assert_platforms_hold(hass, entry.entry_id)
     eid = "number.test_cpid_9001_connector_1_maximum_current"
-    entity_before = _live_entity(hass, eid)
+    entity_before = live_entity(hass, eid, "number")
     assert entity_before is not None
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
 
     # The structural check: a clean reload tears the platforms down and
-    # builds new ones, so the entity must be a fresh object. The broken
-    # path leaves the pre-reload platforms - and this exact entity
-    # instance - in place, whatever the logs say.
-    entity_after = _live_entity(hass, eid)
-    assert entity_after is not None
-    assert entity_after is not entity_before
-    assert _setup_errors(caplog) == []
-    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+    # builds new ones, so the entity must be a fresh object.
+    entity_after = live_entity(hass, eid, "number")
+    assert_rebuilt(entity_before, entity_after)
+    assert_no_swallowed_lifecycle_errors(caplog)
+    assert_platforms_hold(hass, entry.entry_id)
 
 
 async def test_a_second_offline_reload_is_also_clean(hass, bypass_websockets, caplog):
@@ -158,19 +116,19 @@ async def test_a_second_offline_reload_is_also_clean(hass, bypass_websockets, ca
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     eid = "number.test_cpid_9001_connector_1_maximum_current"
-    entity_start = _live_entity(hass, eid)
+    entity_start = live_entity(hass, eid, "number")
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
-    entity_mid = _live_entity(hass, eid)
+    entity_mid = live_entity(hass, eid, "number")
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
-    entity_end = _live_entity(hass, eid)
+    entity_end = live_entity(hass, eid, "number")
 
-    assert entity_start is not entity_mid
-    assert entity_mid is not entity_end
-    assert _setup_errors(caplog) == []
-    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+    assert_rebuilt(entity_start, entity_mid)
+    assert_rebuilt(entity_mid, entity_end)
+    assert_no_swallowed_lifecycle_errors(caplog)
+    assert_platforms_hold(hass, entry.entry_id)
 
 
 async def test_reload_of_a_chargerless_entry_stays_clean(
@@ -183,7 +141,7 @@ async def test_reload_of_a_chargerless_entry_stays_clean(
     skip them here - the flag has to track what setup did, in both
     directions.
     """
-    await _load_platform_components(hass)
+    await load_platform_components(hass)
     entry = MockConfigEntry(
         domain=DOMAIN,
         # MOCK_CONFIG_DATA used directly, deliberately: these chargerless
@@ -200,15 +158,12 @@ async def test_reload_of_a_chargerless_entry_stays_clean(
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert _platforms_holding(hass, entry.entry_id) == set()
+    assert_platforms_hold(hass, entry.entry_id, platforms=())
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert _setup_errors(caplog) == []
-    assert not [
-        r for r in caplog.records if "Config entry was never loaded" in r.getMessage()
-    ]
+    assert_no_swallowed_lifecycle_errors(caplog)
 
 
 async def test_first_charger_discovery_reload_transitions_cleanly(
@@ -222,7 +177,7 @@ async def test_first_charger_discovery_reload_transitions_cleanly(
     reading the entry data would try to unload platforms that do not
     exist. The flag records what this setup actually did instead.
     """
-    await _load_platform_components(hass)
+    await load_platform_components(hass)
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG_DATA,
@@ -242,9 +197,6 @@ async def test_first_charger_discovery_reload_transitions_cleanly(
     )
     await hass.async_block_till_done()
 
-    assert _setup_errors(caplog) == []
-    assert not [
-        r for r in caplog.records if "Config entry was never loaded" in r.getMessage()
-    ]
+    assert_no_swallowed_lifecycle_errors(caplog)
     # The reload's fresh setup saw the charger and forwarded the platforms.
-    assert _platforms_holding(hass, entry.entry_id) == set(PLATFORM_DOMAINS)
+    assert_platforms_hold(hass, entry.entry_id)

--- a/tests/test_sensor_stale_cleanup.py
+++ b/tests/test_sensor_stale_cleanup.py
@@ -29,6 +29,7 @@ from custom_components.ocpp.const import DOMAIN, sensor_unique_id
 from custom_components.ocpp.enums import HAChargerStatuses as cstat
 
 from .const import MOCK_CONFIG_DATA_1
+from .lifecycle_asserts import assert_no_swallowed_lifecycle_errors
 
 
 @pytest.fixture(name="bypass_websockets")
@@ -80,8 +81,8 @@ async def test_setup_removes_the_stale_flat_entity_and_logs_it(
     await hass.async_block_till_done()
 
     # The platform came up cleanly - a failure inside the cleanup would
-    # have been swallowed into this log line rather than raising.
-    assert not [r for r in caplog.records if "Error setting up entry" in r.getMessage()]
+    # have been swallowed into a lifecycle log line rather than raising.
+    assert_no_swallowed_lifecycle_errors(caplog)
     assert registry.async_get(stale.entity_id) is None
     removal_logs = [
         r
@@ -134,3 +135,4 @@ async def test_single_connector_setup_removes_nothing(hass, bypass_websockets, c
         for r in caplog.records
         if "Removing stale charger-level entity" in r.getMessage()
     ]
+    assert_no_swallowed_lifecycle_errors(caplog)


### PR DESCRIPTION
## What this is

Item 3 of #2055, per your Go on the consolidated proposal — plus the two baseline fixes the work surfaced. Five commits, **test-only**: `custom_components/` is untouched; the only non-test change is the marker registration and `--strict-markers` in setup.cfg.

Closes #2055 (items 1 and 2 landed in #2060; this completes item 3 and folds in the `Energy.Meter.Start` poison as proposed).

## The pieces, mapped to the proposal

**1. `tests/lifecycle_asserts.py`** — single-sources what three files half-carried:
- The swallowed-failure log signatures, each annotated with its motivating incident: `Error setting up entry` (#2053), `Error unloading entry` (HA swallows unload exceptions the same way), `has already been setup` / `Config entry was never loaded` (#2054's two edges — these are raise sites, so records are scanned with their attached exception text to catch them deterministically).
- `assert_platforms_hold` (structural platform bookkeeping), `live_entity` / `assert_rebuilt` (entity identity across a reload — the load-bearing reload check), `load_platform_components`.

**2. Retrofit of the dedicated lifecycle tests** — `test_init.py` previously asserted only hass.data shape (no caplog anywhere, no structural checks — the reason the #2054 collision passed there for years); every test now gets the swallowed-error assert and the reload tests get platform-bookkeeping plus entity-identity asserts. `test_reload_offline_charger.py` sheds its inline helpers for the shared module; `test_sensor_stale_cleanup.py` gets the check its control test was missing. Non-lifecycle tests deliberately untouched.

**3. The opt-out tripwire** — an autouse fixture fails any test whose captured log carries a synchronous signature; `@pytest.mark.allow_lifecycle_errors` opts out. **Survey result: zero tests in the suite trip it** (including the live charge-point reload sequences), so no test carries the marker today — the escape hatch exists for future deliberate-failure tests.

**One deliberate deviation from the consolidated proposal, explained:** the proposal said the signature list gains the "Task exception was never retrieved" class. It does — in `lifecycle_asserts` for the dedicated lifecycle tests — but the autouse tripwire enforces only the synchronous signatures. That class surfaces at GC/event-loop-drain time: the meter_start sentinel was red on macOS, green in CI, and flipped between harness versions, so enforcing it suite-wide would import that nondeterminism into every test and can even attribute a straggler task's death to an innocent neighbouring test. Dedicated lifecycle tests assert it inside controlled windows instead. Happy to harden to suite-wide later if you prefer — the plumbing supports it with a one-argument change.

**The folded-in poison fix** — `test_session_energy_meter_start_cast_exception` was vacuous, not just leaky: the ocpp client's `call()` suppresses CALLError replies by default, so the `object()` sentinel crashed an unguarded line, the resulting InternalError was discarded, `assert True` passed, and the sentinel outlived the test into the sensor's teardown render (the environment-sensitive detonations catalogued on #2055). Its sibling `test_session_energy_get_energy_kwh_exception_ignored` was vacuous the same way. Both are replaced by three input-sensitive tests that drive the actual guards (`float()` restore cast, sampled-value coercion) with production-shaped inputs and `suppress=False`, so an unhandled server exception fails loudly. Nothing outlives any test.

**Two baseline fixes found on the way** (both broke locally on HA 2026.8.x while CI stayed green):
- `test_on_diagnostics_status_notification` counted `hass.async_create_task` calls as a proxy for notifications; HA 2026.8 routes entity updates through the same method, so an unrelated task landed in the count. It now counts actual `notify_ha` invocations.
- The tripwire's own first version could never fire: pytest's `caplog.records` is phase-scoped, so a teardown-time check saw only teardown records. Its synthetic mutant caught it (a test logging `Error setting up entry` passed); the helper now reads all three capture phases explicitly. That mutant is the reason to trust the net.

## Verification

- Full suite green after every commit, serial and under xdist (4 workers, CI parity), on the current pins (0.13.355 / HA 2026.8.1 / websockets 17.0.1).
- **Eight mutants, each killed by exactly the assertion built for it:** setup-never-forwards → `assert_platforms_hold`; unload-never-tears-down → `assert_rebuilt`; `async_unload_entry` raises → tripwire at teardown (`[teardown] ERROR: Error unloading entry …`); restore-cast guard removed → restore test fails via CALLError; coercion guard removed → coercion test fails; seeded-state removed → restore-success test fails (input-sensitivity); synthetic tripwire probe fails unmarked / passes marked.
- Coverage 96% overall, per-file identical to the pre-change baseline.

## Flagged, not fixed here

- A full `-n auto` run on a many-core machine can overload unrelated tests' own 10s timeout markers (teardown contention) — a local-parallelism artifact, not a tripwire effect; CI's worker count is unaffected.
- The unguarded session-energy subtraction (`chargepoint.py` `value - ms_metric.value`) is unreachable with a non-float via the restore path, but v2.0.1 with `skip_schema_validation` and a charger sending string sampled values could reach it in production. Deliberately out of a test-only PR; can guard it separately if you want.
- Root-level `test_csms.py` (the manual CSMS simulator) is collected by a bare `pytest` from the repo root since setup.cfg has no `testpaths`; CI dodges it by passing `tests` explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened lifecycle testing to detect swallowed setup, reload, unload, and asynchronous task errors.
  - Added coverage for platform registration, entity rebuilding, offline reloads, and stale-entity cleanup.
  - Improved meter-value handling tests, including numeric restoration, invalid state recovery, and non-numeric readings.
  - Updated diagnostics and migration tests for more reliable task completion and edge-case validation.
- **Chores**
  - Enabled strict test-marker validation and registered the lifecycle-error marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->