### PR TITLE
Fix chargers that cannot be stopped from Home Assistant

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -290,7 +290,12 @@ class ChargePoint(cp):
 
         self._attr_supported_features = prof.NONE
         alphabet = string.ascii_uppercase + string.digits
-        self._remote_id_tag = "".join(secrets.choice(alphabet) for i in range(20))
+        # Stay short of the 20 character IdToken limit, for non-compliant
+        # chargers that read past their own tag buffer when it is filled
+        # exactly: they echo a longer tag back in StopTransaction than the spec
+        # allows, which the payload validator rejects, so the stop never
+        # completes and charging continues.
+        self._remote_id_tag = "".join(secrets.choice(alphabet) for i in range(16))
         self.num_connectors: int = DEFAULT_NUM_CONNECTORS
 
     def _init_connector_slots(self, conn_id: int) -> None:

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -339,6 +339,7 @@ class ChargePoint(cp):
     async def post_connect(self):
         """Logic to be executed right after a charger connects."""
         try:
+            _LOGGER.debug("'%s' starting post connection setup", self.id)
             self.status = STATE_OK
             await self.fetch_supported_features()
             self.num_connectors = await self.get_number_of_connectors()
@@ -393,6 +394,12 @@ class ChargePoint(cp):
             # Ensure HA states are correct immediately after connection
             self.hass.async_create_task(self.update(self.settings.cpid))
 
+        except asyncio.CancelledError:
+            # The connection dropped mid-setup, so the task was cancelled rather
+            # than failed. CancelledError is not an Exception, so it passes the
+            # handler below and setup ends without a word about why.
+            _LOGGER.debug("'%s' post connection setup cancelled part way", self.id)
+            raise
         except Exception as e:
             _LOGGER.debug("post_connect aborted non-fatally: %s", e)
 

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1041,6 +1041,12 @@ class ChargePoint(cp):
 
         self.process_measurands(meter_values, transaction_matches, connector_id)
 
+        # The closing values are the last thing a charger sends for a session and
+        # they still carry the final current and power, so they would otherwise
+        # leave those sensors reading as though charging never stopped.
+        if tx_ended:
+            self._zero_flow_measurands(connector_id)
+
         if tx_has_id and transaction_matches:
             try:
                 tx_start_epoch = float(self._metrics[tx_key].value)
@@ -1091,16 +1097,7 @@ class ChargePoint(cp):
                 ChargePointStatus.suspended_ev.value,
                 ChargePointStatus.suspended_evse.value,
             ):
-                for meas in [
-                    Measurand.current_import.value,
-                    Measurand.power_active_import.value,
-                    Measurand.power_reactive_import.value,
-                    Measurand.current_export.value,
-                    Measurand.power_active_export.value,
-                    Measurand.power_reactive_export.value,
-                ]:
-                    if meas in self._metrics[connector_id]:
-                        self._metrics[(connector_id, meas)].value = 0
+                self._zero_flow_measurands(connector_id)
 
         self.hass.async_create_task(self.update(self.settings.cpid))
         return call_result.StatusNotification()
@@ -1225,17 +1222,7 @@ class ChargePoint(cp):
                 session_kwh = 0.0
             self._metrics[(conn, csess.session_energy.value)].value = session_kwh
 
-        for meas in [
-            Measurand.current_import.value,
-            Measurand.power_active_import.value,
-            Measurand.power_reactive_import.value,
-            Measurand.current_export.value,
-            Measurand.power_active_export.value,
-            Measurand.power_reactive_export.value,
-        ]:
-            key = (conn, meas)
-            if key in self._metrics:
-                self._metrics[key].value = 0
+        self._zero_flow_measurands(conn)
 
         self.hass.async_create_task(self.update(self.settings.cpid))
         return call_result.StopTransaction(
@@ -1257,3 +1244,17 @@ class ChargePoint(cp):
         self._metrics[0][cstat.heartbeat.value].value = now
         self._async_refresh_metric_entities([cstat.heartbeat.value])
         return call_result.Heartbeat(current_time=now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    def _zero_flow_measurands(self, connector_id: int) -> None:
+        """Clear the readings that only have meaning while current is flowing."""
+        for meas in [
+            Measurand.current_import.value,
+            Measurand.power_active_import.value,
+            Measurand.power_reactive_import.value,
+            Measurand.current_export.value,
+            Measurand.power_active_export.value,
+            Measurand.power_reactive_export.value,
+        ]:
+            key = (connector_id, meas)
+            if key in self._metrics:
+                self._metrics[key].value = 0

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -28,6 +28,7 @@ from ocpp.v16.enums import (
     DataTransferStatus,
     Measurand,
     MessageTrigger,
+    ReadingContext,
     RegistrationStatus,
     RemoteStartStopStatus,
     ResetStatus,
@@ -102,6 +103,7 @@ class ChargePoint(cp):
             charger,
         )
         self._active_tx: dict[int, int] = {}  # connector_id -> transaction_id
+        self._ended_tx: dict[int, int] = {}  # connector_id -> last stopped tx
 
     async def get_number_of_connectors(self) -> int:
         """Return number of connectors on this charger."""
@@ -958,8 +960,23 @@ class ChargePoint(cp):
         recorded_tx = int(self._metrics[tx_key].value or 0)
         active_tx = int(self._active_tx.get(connector_id, 0) or 0)
 
+        # A transaction's closing values arrive after its StopTransaction, so
+        # adopting their id below would revive the session that just ended. A
+        # charger says so with a Transaction.End context, but OCPP leaves that
+        # field optional, so fall back to the id of the transaction we last saw
+        # stop on this connector.
+        tx_ended: bool = bool(transaction_id) and (
+            transaction_id == int(self._ended_tx.get(connector_id, 0) or 0)
+            or any(
+                sampled_value.get(om.context.value)
+                == ReadingContext.transaction_end.value
+                for bucket in meter_value
+                for sampled_value in bucket.get(om.sampled_value.name, [])
+            )
+        )
+
         # Self-heal after restart: adopt incoming txId if we have none recorded yet
-        if transaction_id and (recorded_tx == 0 and active_tx == 0):
+        if transaction_id and not tx_ended and (recorded_tx == 0 and active_tx == 0):
             self._metrics[tx_key].value = transaction_id
             self._active_tx[connector_id] = transaction_id
             active_tx = transaction_id
@@ -987,6 +1004,12 @@ class ChargePoint(cp):
         transaction_matches: bool = False
         # Match is also false if no transaction is in progress, i.e. active_tx==transaction_id==0
         if transaction_id == active_tx and transaction_id != 0:
+            transaction_matches = True
+        elif transaction_id != 0 and tx_ended:
+            # The closing values arrive once the transaction has been cleared, but
+            # they belong to it and carry its final energy figures. Treating them
+            # as outside a transaction would file session energy as lifetime
+            # energy on chargers that report the two in the same measurand.
             transaction_matches = True
         elif transaction_id != 0 and active_tx != 0 and transaction_id != active_tx:
             _LOGGER.warning(
@@ -1127,6 +1150,7 @@ class ChargePoint(cp):
         auth_status = self.get_authorization_status(id_tag)
         if auth_status == AuthorizationStatus.accepted.value:
             tx_id = int(time.time())
+            self._ended_tx.pop(connector_id, None)
             self._active_tx[connector_id] = tx_id
             self.active_transaction_id = tx_id
             self._metrics[(connector_id, cstat.id_tag.value)].value = id_tag
@@ -1179,6 +1203,7 @@ class ChargePoint(cp):
             conn = 1  # conservative fallback
 
         # Reset active transaction (global + per-connector)
+        self._ended_tx[conn] = int(transaction_id or 0)
         self._active_tx[conn] = 0
         self.active_transaction_id = 0
         self._metrics[(conn, cstat.id_tag.value)].value = ""

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -383,6 +383,7 @@ class ChargePoint(cp):
 
         req = call.TriggerMessage(requested_message=trig)
         resp = await self.call(req)
+        _LOGGER.debug("TriggerMessage %s to %s answered: %s", trig, self.id, resp)
         if resp.status != TriggerMessageStatus.accepted:
             _LOGGER.warning("Failed with response: %s", resp.status)
             return False
@@ -657,6 +658,12 @@ class ChargePoint(cp):
             connector_id=connector_id, id_tag=self._remote_id_tag
         )
         resp = await self.call(req)
+        _LOGGER.debug(
+            "RemoteStartTransaction to %s connector=%s answered: %s",
+            self.id,
+            connector_id,
+            resp,
+        )
         if resp.status == RemoteStartStopStatus.accepted:
             return True
         else:
@@ -1083,6 +1090,14 @@ class ChargePoint(cp):
     @on(Action.status_notification)
     def on_status_notification(self, connector_id, error_code, status, **kwargs):
         """Handle a status notification."""
+        _LOGGER.debug(
+            "Status notification from %s: connector=%s status=%s error_code=%s %s",
+            self.id,
+            connector_id,
+            status,
+            error_code,
+            kwargs,
+        )
 
         if connector_id == 0 or connector_id is None:
             self._metrics[(0, cstat.status.value)].value = status

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -151,6 +151,14 @@ Successful connection requires firmware version **A0-MEV-V2.0.9** or newer.
 
 The "Charger idle sampling interval" is not supported. Set this to **0** to avoid a "ClockAlignedDataInterval is read-only" warning.
 
+## [Ocular LTE Plus v3](https://evse.com.au/) (tested: reports as BS-EV22, firmware 448.3251.0Q03197)
+Works, with some firmware quirks worth knowing about. The same behaviour has been seen on the BS-EV07, so it likely applies to other chargers reporting the vendor `BS AC EV Charger`.
+
+- In the charger's app, set MODE to ONLINE and enter the address without a scheme, for example `192.168.1.10:9000/central`. The examples shown in the app do not work.
+- The charger sends its closing meter reading after StopTransaction rather than before. This is handled.
+- After a remote stop the connector stays in `Finishing` until the cable is unplugged, and it rejects a remote start while it is in that state. To pause and resume a charge without unplugging, leave the session running and set the maximum current to 0 instead of stopping it.
+- Firmware 448.3251.0Q03197 returns a corrupted ID tag, truncates configuration values, and occasionally sends a malformed connection request. These have been reported to the vendor.
+
 ## [Rolec EVO](https://www.rolecserv.com/ev-products/evo)
 Tested single phase 7kW model (ROLEC5011) with firmware 1.2.7, appears to be working fine.
 

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -2663,6 +2663,96 @@ async def test_on_meter_values_tx_updates_connector_and_session_energy(
             await ws.close()
 
 
+@pytest.mark.timeout(20)
+@pytest.mark.parametrize(
+    "setup_config_entry",
+    [{"port": 9106, "cp_id": "CP_tx_end", "cms": "cms_tx_end"}],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_tx_end"])
+@pytest.mark.parametrize("port", [9106])
+async def test_on_meter_values_closing_values_after_stop(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """Closing values must end the session without reviving it or moving its energy.
+
+    A charger sends the Transaction.End values after StopTransaction. They still
+    belong to the transaction, so on a charger that reports session energy in the
+    energy register they must land in Energy.Session and leave the lifetime
+    register alone, and they must not restore the transaction that just ended.
+    """
+
+    cs: CentralSystem = setup_config_entry
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
+    ) as ws:
+        cp = ChargePoint(f"{cp_id}_client", ws)
+        task = asyncio.create_task(cp.start())
+        try:
+            await cp.send_boot_notification()
+            await wait_ready(cs.charge_points[cp_id])
+
+            # meter_start of 0 marks a charger that reports session energy in the
+            # energy register rather than a lifetime total.
+            await cp.send_start_transaction(meter_start=0)
+
+            async def send_eair(context: str | None, kwh: str):
+                sampled = {
+                    "measurand": "Energy.Active.Import.Register",
+                    "unit": "kWh",
+                    "value": kwh,
+                }
+                if context is not None:
+                    sampled["context"] = context
+                await cp.call(
+                    call.MeterValues(
+                        connector_id=1,
+                        transaction_id=cp.active_transactionId,
+                        meter_value=[
+                            {
+                                "timestamp": datetime.now(tz=UTC).isoformat(),
+                                "sampledValue": [sampled],
+                            }
+                        ],
+                    )
+                )
+
+            await send_eair("Sample.Periodic", "2.0")
+            assert cs.get_metric(
+                cp_id, "Energy.Session", connector_id=1
+            ) == pytest.approx(2.0, rel=1e-6)
+            lifetime_before = cs.get_metric(
+                cp_id, "Energy.Active.Import.Register", connector_id=1
+            )
+
+            await cp.send_stop_transaction()
+            await send_eair("Transaction.End", "2.5")
+
+            assert cs.get_metric(cp_id, "Transaction.Id", connector_id=1) == 0
+            assert cs.get_metric(
+                cp_id, "Energy.Session", connector_id=1
+            ) == pytest.approx(2.5, rel=1e-6)
+            assert (
+                cs.get_metric(cp_id, "Energy.Active.Import.Register", connector_id=1)
+                == lifetime_before
+            )
+
+            # The context field is optional in OCPP 1.6, so a trailing reading
+            # that omits it must be recognised by its transaction id alone.
+            await send_eair(None, "2.6")
+            assert cs.get_metric(cp_id, "Transaction.Id", connector_id=1) == 0
+            assert (
+                cs.get_metric(cp_id, "Energy.Active.Import.Register", connector_id=1)
+                == lifetime_before
+            )
+
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await ws.close()
+
+
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "setup_config_entry",


### PR DESCRIPTION
Some chargers cannot be stopped from Home Assistant. You press stop, the charger says yes, and the car keeps charging. After a session has run, the current and power sensors also stay stuck at whatever the car was drawing when it finished.

I have an Ocular LTE Plus v3 that showed both, and I captured full protocol logs to find out why. Three problems are fixable here. The rest are faults in that charger's firmware, which I am raising separately with the manufacturer.

**What was going wrong**

The integration gives each charger a random ID tag that is 20 characters long, which is the longest the OCPP rules allow. Some chargers cannot handle a tag that exactly fills the space and hand it back two characters longer than they received it. That reply is then rejected as invalid, the charger never gets a proper confirmation, and it keeps the session open and carries on charging. Using a slightly shorter tag avoids the problem entirely. This also affects the person in #2030, whose charger sends back exactly the same corruption.

A charger sends its final meter reading just after a session ends. Two things went wrong with that last reading. It was being used to bring the finished session back to life, and it was writing the last current and power values back over the zeros that had just been set, which is why those sensors froze after every charge.

**Changes**

- Use a 16 character remote ID tag instead of 20, so chargers that mishandle a full length tag can complete a stop
- Recognise a session's closing meter reading and stop it restarting the session that just ended
- Clear the current and power readings after that closing reading, so they do not stay stuck
- Add debug logging for status notifications, remote starts and trigger messages, and explain in the log when post connect setup stops because the connection dropped part way through
- Add a supported devices entry for the Ocular LTE Plus v3

Each change is a separate commit, and there is a new regression test for the closing meter reading.

**Two notes for reviewers**

The closing reading still counts as part of its transaction for energy purposes. That matters on chargers that report a meterStart of zero, where the energy register carries session energy rather than a lifetime total. Treating the closing reading as though no session were running would lose the final session energy and stamp a session figure into the lifetime register, which Home Assistant reads as a meter reset. The regression test covers this.

The closing reading is identified by the id of the transaction that last stopped on that connector, not only by its Transaction.End label, because OCPP makes that label optional and some chargers leave it out.

Tested against an Ocular LTE Plus v3 (reports as BS-EV22, firmware 448.3251.0Q03197) on OCPP 1.6. Before the change a remote stop never completed. After it, stops complete first time and the sensors return to zero when charging finishes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of transaction-end meter readings, including readings received after a transaction stops.
  * Flow-related measurements are cleared when appropriate.
  * Added support documentation for the Ocular LTE Plus v3 charger.

* **Bug Fixes**
  * Prevented completed transactions from being restored by later meter updates.
  * Improved cancellation handling during charge point setup.

* **Logging**
  * Added clearer diagnostic logging for setup, triggered messages, remote starts, and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->