### PR TITLE
Fix amp limits for power-only OCPP 1.6 chargers

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -424,8 +424,8 @@ class ChargePoint(cp):
 
     async def set_charge_rate(
         self,
-        limit_amps: int = 32,
-        limit_watts: int = 22000,
+        limit_amps: int | float | None = None,
+        limit_watts: int | float | None = None,
         conn_id: int = 0,
         profile: dict | None = None,
     ):

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -28,6 +28,7 @@ from ocpp.v16.enums import (
     DataTransferStatus,
     Measurand,
     MessageTrigger,
+    Phase,
     ReadingContext,
     RegistrationStatus,
     RemoteStartStopStatus,
@@ -57,6 +58,7 @@ from .const import (
     CentralSystemSettings,
     ChargerSystemSettings,
     DEFAULT_MEASURAND,
+    DEFAULT_MAX_CURRENT,
     HA_ENERGY_UNIT,
     MEASURANDS,
 )
@@ -77,6 +79,37 @@ def _to_message_trigger(name: str) -> MessageTrigger | None:
         "firmwarestatusnotification": MessageTrigger.firmware_status_notification,
     }
     return mapping.get(key)
+
+
+# Charge-rate defaults plus conservative electrical conversion fallbacks.
+_DEFAULT_LIMIT_AMPS = DEFAULT_MAX_CURRENT
+_DEFAULT_LIMIT_WATTS = 22000
+_DEFAULT_LINE_VOLTAGE = 230.0
+_DEFAULT_PHASES = 1
+
+_AMPS_UNIT_TOKENS = frozenset({"current", "a", "amp", "amps", "ampere", "amperes"})
+_WATTS_UNIT_TOKENS = frozenset({"power", "w", "watt", "watts"})
+_PHASE_KEY_GROUPS = (
+    frozenset({Phase.l1.value, Phase.l2.value, Phase.l3.value}),
+    frozenset({Phase.l1_n.value, Phase.l2_n.value, Phase.l3_n.value}),
+    frozenset({Phase.l1_l2.value, Phase.l2_l3.value, Phase.l3_l1.value}),
+)
+
+
+def _allowed_charging_rate_units(units_resp: str | None) -> tuple[bool, bool]:
+    """Parse ChargingScheduleAllowedChargingRateUnit into (amps, watts) support."""
+    if not units_resp:
+        return True, False
+    tokens = {
+        tok.strip().lower()
+        for tok in str(units_resp).replace(";", ",").split(",")
+        if tok.strip()
+    }
+    supports_amps = bool(tokens & _AMPS_UNIT_TOKENS)
+    supports_watts = bool(tokens & _WATTS_UNIT_TOKENS)
+    if not supports_amps and not supports_watts:
+        return True, False
+    return supports_amps, supports_watts
 
 
 class ChargePoint(cp):
@@ -409,10 +442,75 @@ class ChargePoint(cp):
             _LOGGER.debug("ClearChargingProfile raised %s (ignored)", ex)
             return False
 
+    def _lookup_metric(self, measurand: str, conn_id: int):
+        """Return a connector metric if it has a value, else None."""
+        metrics = getattr(self, "_metrics", None)
+        if metrics is None:
+            return None
+        try:
+            target = int(conn_id) if conn_id and int(conn_id) > 0 else 1
+        except (TypeError, ValueError):
+            target = 1
+        # Connector 0 contains legacy/global telemetry. Never fall back to
+        # connector 1 for another connector, as that can mix unrelated ports.
+        connector_ids = (target, 0) if target != 0 else (0,)
+        for cid in connector_ids:
+            key = (cid, measurand)
+            if key not in metrics:
+                continue
+            metric = metrics[key]
+            if metric is not None and getattr(metric, "value", None) is not None:
+                return metric
+        return None
+
+    def _line_voltage(self, conn_id: int) -> float:
+        """Return a plausible line-to-neutral voltage, or the 230 V default."""
+        metric = self._lookup_metric(Measurand.voltage.value, conn_id)
+        if metric is not None:
+            try:
+                voltage = float(metric.value)
+            except (TypeError, ValueError):
+                voltage = 0.0
+            if 50.0 <= voltage <= 500.0:
+                return voltage
+        return _DEFAULT_LINE_VOLTAGE
+
+    def _phase_count(self, conn_id: int) -> int:
+        """Count explicitly reported phases; conservatively default to one."""
+        measurands = (
+            Measurand.voltage.value,
+            Measurand.current_import.value,
+            Measurand.current_offered.value,
+        )
+        best = 0
+        for measurand in measurands:
+            metric = self._lookup_metric(measurand, conn_id)
+            if metric is None:
+                continue
+            keys = {str(k) for k in (metric.extra_attr or {})}
+            for group in _PHASE_KEY_GROUPS:
+                n = len(keys & group)
+                if n > best:
+                    best = n
+        return best if best > 0 else _DEFAULT_PHASES
+
+    def _amps_to_watts(self, amps: float, conn_id: int) -> float:
+        """Convert a current limit to watts for Power-only chargers."""
+        return float(
+            round(amps * self._line_voltage(conn_id) * self._phase_count(conn_id))
+        )
+
+    def _watts_to_amps(self, watts: float, conn_id: int) -> float:
+        """Convert a power limit to amps for Current-only chargers."""
+        denom = self._line_voltage(conn_id) * self._phase_count(conn_id)
+        if denom <= 0:
+            return float(_DEFAULT_LIMIT_AMPS)
+        return round(watts / denom, 1)
+
     async def set_charge_rate(
         self,
-        limit_amps: int = 32,
-        limit_watts: int = 22000,
+        limit_amps: int | float | None = None,
+        limit_watts: int | float | None = None,
         conn_id: int = 0,
         profile: dict | None = None,
     ) -> bool:
@@ -443,10 +541,37 @@ class ChargePoint(cp):
         )
         if not units_resp:
             _LOGGER.debug("Charging rate unit not reported; assuming Amps")
-            units_resp = om.current.value
 
-        use_amps = om.current.value in units_resp
-        limit_value = float(limit_amps if use_amps else limit_watts)
+        supports_amps, supports_watts = _allowed_charging_rate_units(units_resp)
+        # Watt-only chargers (Huawei FusionCharge reports "Power") must not
+        # fall back to the old limit_watts=22000 default when the HA number
+        # entity passes only limit_amps.
+        if supports_amps and not supports_watts:
+            use_amps = True
+        elif supports_watts and not supports_amps:
+            use_amps = False
+        else:
+            use_amps = limit_amps is not None or limit_watts is None
+
+        if use_amps:
+            if limit_amps is not None:
+                limit_value = float(limit_amps)
+            elif limit_watts is not None:
+                limit_value = self._watts_to_amps(float(limit_watts), conn_id)
+            else:
+                limit_value = float(_DEFAULT_LIMIT_AMPS)
+        elif limit_watts is not None:
+            limit_value = float(limit_watts)
+        elif limit_amps is not None:
+            limit_value = self._amps_to_watts(float(limit_amps), conn_id)
+            _LOGGER.debug(
+                "Converted %.1f A to %.0f W for Power-only charger",
+                float(limit_amps),
+                limit_value,
+            )
+        else:
+            limit_value = float(_DEFAULT_LIMIT_WATTS)
+
         units_value = (
             ChargingRateUnitType.amps.value
             if use_amps

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -453,7 +453,7 @@ class ChargePoint(cp):
             target = 1
         # Connector 0 contains legacy/global telemetry. Never fall back to
         # connector 1 for another connector, as that can mix unrelated ports.
-        connector_ids = (target, 0) if target != 0 else (0,)
+        connector_ids = (target, 0)
         for cid in connector_ids:
             key = (cid, measurand)
             if key not in metrics:

--- a/tests/test_set_charge_rate_v16.py
+++ b/tests/test_set_charge_rate_v16.py
@@ -12,17 +12,26 @@ They avoid any parallel/dummy implementation of ChargePoint.
 from types import SimpleNamespace
 
 import pytest
-
-from custom_components.ocpp.ocppv16 import ChargePoint as ChargePointv16
-from custom_components.ocpp.enums import (
-    Profiles as prof,
-    ConfigurationKey as ckey,
-)
 from ocpp.v16.enums import (
-    ChargingProfileStatus,
-    ChargingProfilePurposeType,
     ChargingProfileKindType,
+    ChargingProfilePurposeType,
+    ChargingProfileStatus,
     ChargingRateUnitType,
+    Measurand,
+)
+
+from custom_components.ocpp.chargepoint import (
+    Metric,
+    _ConnectorAwareMetrics,
+)
+from custom_components.ocpp.enums import (
+    ConfigurationKey as ckey,
+    OcppMisc as om,
+    Profiles as prof,
+)
+from custom_components.ocpp.ocppv16 import (
+    ChargePoint as ChargePointv16,
+    _allowed_charging_rate_units,
 )
 
 
@@ -38,6 +47,7 @@ def cp_v16():
     cp._ocpp_version = "1.6"
     cp.active_transaction_id = 0
     cp._active_tx = {}
+    cp._metrics = _ConnectorAwareMetrics()
     # set_charge_rate calls these (we’ll monkeypatch per-test):
     # - cp.get_configuration(key)
     # - cp.call(req)
@@ -185,3 +195,176 @@ async def test_cpmax_rejected_txdefault_accepted_returns_true(cp_v16, monkeypatc
     ok = await cp_v16.set_charge_rate(limit_amps=10, conn_id=2)
     assert ok is True
     assert notices == []
+
+
+def test_allowed_charging_rate_units_tokens():
+    """Chargers report Current/Power, A/W, or mixed, with inconsistent case."""
+    assert _allowed_charging_rate_units(None) == (True, False)
+    assert _allowed_charging_rate_units("") == (True, False)
+    assert _allowed_charging_rate_units("Unknown") == (True, False)
+    assert _allowed_charging_rate_units("Current") == (True, False)
+    assert _allowed_charging_rate_units("power") == (False, True)
+    assert _allowed_charging_rate_units("Power") == (False, True)
+    assert _allowed_charging_rate_units("A") == (True, False)
+    assert _allowed_charging_rate_units("W") == (False, True)
+    assert _allowed_charging_rate_units("Current,Power") == (True, True)
+    assert _allowed_charging_rate_units("Current, Power") == (True, True)
+
+
+def _schedule_limit(req):
+    profile = req.cs_charging_profiles
+    schedule = profile[om.charging_schedule.value]
+    period = schedule[om.charging_schedule_period.value][0]
+    return schedule[om.charging_rate_unit.value], period[om.limit.value]
+
+
+async def _accept_first_profile(cp, monkeypatch, units: str):
+    captured = []
+
+    async def fake_get_conf(key: str):
+        if key == ckey.charging_schedule_allowed_charging_rate_unit.value:
+            return units
+        if key == ckey.charge_profile_max_stack_level.value:
+            return "1"
+        pytest.fail(f"Unexpected get_configuration key: {key}")
+
+    async def fake_call(req):
+        captured.append(req)
+        return SimpleNamespace(status=ChargingProfileStatus.accepted)
+
+    monkeypatch.setattr(cp, "get_configuration", fake_get_conf)
+    monkeypatch.setattr(cp, "call", fake_call)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_power_only_charger_converts_slider_amps_to_watts(cp_v16, monkeypatch):
+    """number.*_maximum_current sends amps; watt-only chargers must get watts.
+
+    Regression for Huawei FusionCharge (ChargingScheduleAllowedChargingRateUnit=power):
+    the slider used to send the default 22000 W, so the car never slowed down.
+    """
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "power")
+    voltage = Metric(230.0, "V")
+    voltage.extra_attr = {"L1-N": 230.0, "L2-N": 230.0, "L3-N": 230.0}
+    cp_v16._metrics[(1, Measurand.voltage.value)] = voltage
+
+    ok = await cp_v16.set_charge_rate(limit_amps=16, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 11040.0  # 16 A * 230 V * 3 phases
+
+
+@pytest.mark.asyncio
+async def test_power_only_charger_does_not_send_default_22000_w(cp_v16, monkeypatch):
+    """Without conversion the charger accepted 22000 W and kept offering 32 A."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Power")
+
+    ok = await cp_v16.set_charge_rate(limit_amps=10, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 2300.0  # 10 A * 230 V * 1 conservative default phase
+    assert limit != 22000
+
+
+@pytest.mark.asyncio
+async def test_power_only_single_phase_uses_one_phase(cp_v16, monkeypatch):
+    """A single L1-N voltage sample must convert as 1-phase, not 3-phase."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "power")
+    voltage = Metric(230.0, "V")
+    voltage.extra_attr = {"L1-N": 230.0}
+    cp_v16._metrics[(1, Measurand.voltage.value)] = voltage
+
+    ok = await cp_v16.set_charge_rate(limit_amps=16, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 3680.0  # 16 A * 230 V * 1 phase
+
+
+@pytest.mark.asyncio
+async def test_power_only_ignores_uncorrelated_cached_power_and_current(
+    cp_v16, monkeypatch
+):
+    """Do not infer W/A from leftover Power.Offered and Current.Offered."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "power")
+    cp_v16._metrics[(1, Measurand.power_offered.value)] = Metric(22.0, "kW")
+    cp_v16._metrics[(1, Measurand.current_offered.value)] = Metric(16.0, "A")
+
+    ok = await cp_v16.set_charge_rate(limit_amps=10, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 2300.0
+
+
+@pytest.mark.asyncio
+async def test_power_only_does_not_use_another_connectors_metrics(cp_v16, monkeypatch):
+    """Connector 2 must not inherit connector 1 voltage or phase count."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "power")
+    connector_1_voltage = Metric(400.0, "V")
+    connector_1_voltage.extra_attr = {
+        "L1-N": 230.0,
+        "L2-N": 230.0,
+        "L3-N": 230.0,
+    }
+    cp_v16._metrics[(1, Measurand.voltage.value)] = connector_1_voltage
+
+    ok = await cp_v16.set_charge_rate(limit_amps=10, conn_id=2)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 2300.0
+
+
+@pytest.mark.asyncio
+async def test_power_only_limit_watts_passthrough(cp_v16, monkeypatch):
+    """An explicit watt limit is sent unchanged to a Power-only charger."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "power")
+
+    ok = await cp_v16.set_charge_rate(limit_watts=5000, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 5000.0
+
+
+@pytest.mark.asyncio
+async def test_current_only_still_sends_amps(cp_v16, monkeypatch):
+    """Amp-capable chargers keep receiving the slider value in amps."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Current")
+
+    ok = await cp_v16.set_charge_rate(limit_amps=16, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.amps.value
+    assert limit == 16.0
+
+
+@pytest.mark.asyncio
+async def test_current_only_converts_watts_to_amps(cp_v16, monkeypatch):
+    """A watt service call is converted when the charger only accepts amps."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Current")
+    voltage = Metric(230.0, "V")
+    voltage.extra_attr = {"L1-N": 230.0}
+    cp_v16._metrics[(1, Measurand.voltage.value)] = voltage
+
+    ok = await cp_v16.set_charge_rate(limit_watts=4600, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.amps.value
+    assert limit == 20.0  # 4600 W / (230 V * 1 phase)
+
+
+@pytest.mark.asyncio
+async def test_unknown_rate_unit_defaults_to_current(cp_v16, monkeypatch):
+    """Unrecognized ChargingScheduleAllowedChargingRateUnit falls back to amps."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Unknown")
+
+    ok = await cp_v16.set_charge_rate(limit_watts=2300, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.amps.value
+    assert limit == 10.0

--- a/tests/test_set_charge_rate_v16.py
+++ b/tests/test_set_charge_rate_v16.py
@@ -24,6 +24,7 @@ from custom_components.ocpp.chargepoint import (
     Metric,
     _ConnectorAwareMetrics,
 )
+from custom_components.ocpp.const import DEFAULT_MAX_CURRENT
 from custom_components.ocpp.enums import (
     ConfigurationKey as ckey,
     OcppMisc as om,
@@ -368,3 +369,70 @@ async def test_unknown_rate_unit_defaults_to_current(cp_v16, monkeypatch):
     unit, limit = _schedule_limit(captured[0])
     assert unit == ChargingRateUnitType.amps.value
     assert limit == 10.0
+
+
+def test_lookup_metric_without_metrics_returns_none(cp_v16):
+    """A ChargePoint with no metric store must not raise."""
+    cp_v16._metrics = None
+    assert cp_v16._lookup_metric(Measurand.voltage.value, 1) is None
+
+
+def test_lookup_metric_invalid_connector_falls_back_to_one(cp_v16):
+    """A non-integer connector id is treated as connector 1."""
+    voltage = Metric(240.0, "V")
+    cp_v16._metrics[(1, Measurand.voltage.value)] = voltage
+    assert cp_v16._lookup_metric(Measurand.voltage.value, "bad") is voltage
+
+
+def test_lookup_metric_skips_empty_values(cp_v16):
+    """A present metric with no value is ignored."""
+    cp_v16._metrics[(1, Measurand.voltage.value)] = Metric(None, "V")
+    assert cp_v16._lookup_metric(Measurand.voltage.value, 1) is None
+
+
+def test_line_voltage_rejects_non_numeric_and_out_of_range(cp_v16):
+    """Implausible voltages fall back to 230 V."""
+    cp_v16._metrics[(1, Measurand.voltage.value)] = Metric("n/a", "V")
+    assert cp_v16._line_voltage(1) == 230.0
+    cp_v16._metrics[(1, Measurand.voltage.value)] = Metric(12.0, "V")
+    assert cp_v16._line_voltage(1) == 230.0
+
+
+def test_watts_to_amps_zero_denominator_uses_default(cp_v16, monkeypatch):
+    """A zero volt-amp product must not divide by zero."""
+    monkeypatch.setattr(cp_v16, "_line_voltage", lambda _conn: 0.0)
+    monkeypatch.setattr(cp_v16, "_phase_count", lambda _conn: 0)
+    assert cp_v16._watts_to_amps(5000, 1) == float(DEFAULT_MAX_CURRENT)
+
+
+@pytest.mark.asyncio
+async def test_amp_charger_default_limit_when_no_value_given(cp_v16, monkeypatch):
+    """Calling set_charge_rate() with no limit uses the default amp cap."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Current")
+
+    assert await cp_v16.set_charge_rate() is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.amps.value
+    assert limit == float(DEFAULT_MAX_CURRENT)
+
+
+@pytest.mark.asyncio
+async def test_power_charger_default_limit_when_no_value_given(cp_v16, monkeypatch):
+    """Calling set_charge_rate() with no limit uses the default watt cap."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Power")
+
+    assert await cp_v16.set_charge_rate() is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 22000.0
+
+
+@pytest.mark.asyncio
+async def test_dual_unit_charger_sends_explicit_watts(cp_v16, monkeypatch):
+    """When both units are allowed, an explicit watt limit stays in watts."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "Current,Power")
+
+    assert await cp_v16.set_charge_rate(limit_watts=7000, conn_id=1) is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 7000.0


### PR DESCRIPTION
## Summary
- Convert amp limits to watts for OCPP 1.6 chargers that only support power-based schedules.
- Preserve explicitly supplied watt limits.
- Prevent the maximum-current slider from always sending 22 kW.

Fixes the issue reported in [discussion #1823](https://github.com/lbbrhzn/ocpp/discussions/1823#discussioncomment-17906139).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Charging limits can be provided in amps or watts, including decimal values.
  - Limits are automatically converted to match the charger’s supported measurement unit.
  - Conversion uses available charging metrics and electrical configuration, including phase settings.
  - Chargers use configured maximum capacity when no limit is specified.

- **Bug Fixes**
  - Improved handling of missing or invalid charging-limit values.

- **Tests**
  - Added coverage for watt-based chargers, amp-to-watt conversion, phase configurations, and current-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->