### PR TITLE
Fix authorization_list iteration crashing every Authorize request

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -736,7 +736,7 @@ class ChargePoint(cp):
         auth_list = config.get(CONF_AUTH_LIST, {})
         # search for the entry, based on the id_tag
         auth_status = None
-        for auth_entry in auth_list:
+        for auth_entry in auth_list.values():
             id_entry = auth_entry.get(CONF_ID_TAG, None)
             if id_tag == id_entry:
                 # get the authorization status, use the default if not configured


### PR DESCRIPTION
## Bug

`get_authorization_status()` in `chargepoint.py` iterates `authorization_list` (a dict, per its schema `vol.Schema({cv.string: AUTH_LIST_SCHEMA})`) with:

```python
for auth_entry in auth_list:
    id_entry = auth_entry.get(CONF_ID_TAG, None)
```

Iterating a dict yields its keys (strings), not the entry dicts, so `auth_entry.get(...)` raises `AttributeError: 'str' object has no attribute 'get'`. This happens on the **first** loop iteration for every `Authorize.req`, as soon as `authorization_list` has any entries at all -- regardless of whether the swiped `id_tag` would have matched one. The whole feature is unusable the moment it's actually configured with data, including for tags that should explicitly match an `Accepted` entry.

## Traceback

```
Traceback (most recent call last):
  File ".../ocpp/charge_point.py", line 322, in _handle_call
    response = handler(**snake_case_payload)
  File ".../ocpp/routing.py", line 48, in inner
    return func(*args, **kwargs)
  File "custom_components/ocpp/ocppv16.py", line 1120, in on_authorize
    auth_status = self.get_authorization_status(id_tag)
  File "custom_components/ocpp/chargepoint.py", line 728, in get_authorization_status
    id_entry = auth_entry.get(CONF_ID_TAG, None)
AttributeError: 'str' object has no attribute 'get'
```

## Fix

Iterate `auth_list.values()` instead of `auth_list`.

## Testing

Confirmed live against a real charger (Schneider Electric EVlink Pro AC, OCPP 1.6J) with:

```yaml
ocpp:
  default_authorization_status: Blocked
  authorization_list:
    fob_test_01:
      id_tag: "044517B2936984"
      authorization_status: Accepted
```

Before the fix: every `Authorize.req` errored (`InternalError`), including the listed tag.

After the fix, across repeated real swipes: the listed tag authorized (`Accepted`) twice, and four different unrecognized tags were each correctly denied (`Blocked`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed authorization-list processing when entries are provided in dictionary format.
  - Authorization checks now correctly evaluate all configured entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->