### PR TITLE
Migrate (str, Enum) classes to StrEnum

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -37,10 +37,6 @@ lint.ignore = [
     "D411",  # Missing blank line before section
     "E501",  # line too long
     "E731",  # do not assign a lambda expression, use a def
-    "UP042", # Class inherits from both str and enum.Enum. Migrating the
-             # existing (str, Enum) classes to StrEnum changes __str__ and
-             # __format__ behaviour for members that are compared and
-             # serialised as strings throughout, so it needs its own change.
 ]
 
 [lint.flake8-pytest-style]

--- a/custom_components/ocpp/__init__.py
+++ b/custom_components/ocpp/__init__.py
@@ -227,63 +227,63 @@ def _register_domain_services(hass: HomeAssistant) -> list[str]:
         await _route("handle_get_diagnostics", call)
 
     services = [
-        csvcs.service_configure.value,
-        csvcs.service_get_configuration.value,
-        csvcs.service_data_transfer.value,
-        csvcs.service_trigger_custom_message.value,
-        csvcs.service_clear_profile.value,
-        csvcs.service_set_charge_rate.value,
-        csvcs.service_update_firmware.value,
-        csvcs.service_get_diagnostics.value,
+        csvcs.service_configure,
+        csvcs.service_get_configuration,
+        csvcs.service_data_transfer,
+        csvcs.service_trigger_custom_message,
+        csvcs.service_clear_profile,
+        csvcs.service_set_charge_rate,
+        csvcs.service_update_firmware,
+        csvcs.service_get_diagnostics,
     ]
 
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_configure.value,
+        csvcs.service_configure,
         _route_configure,
         CONF_SERVICE_DATA_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_get_configuration.value,
+        csvcs.service_get_configuration,
         _route_get_configuration,
         GCONF_SERVICE_DATA_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_data_transfer.value,
+        csvcs.service_data_transfer,
         _route_data_transfer,
         TRANS_SERVICE_DATA_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_trigger_custom_message.value,
+        csvcs.service_trigger_custom_message,
         _route_trigger_custom_message,
         CUSTMSG_SERVICE_DATA_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_clear_profile.value,
+        csvcs.service_clear_profile,
         _route_clear_profile,
         CLEAR_PROFILE_SERVICE_DATA_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_set_charge_rate.value,
+        csvcs.service_set_charge_rate,
         _route_set_charge_rate,
         CHRGR_SERVICE_DATA_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_update_firmware.value,
+        csvcs.service_update_firmware,
         _route_update_firmware,
         UFW_SERVICE_DATA_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
-        csvcs.service_get_diagnostics.value,
+        csvcs.service_get_diagnostics,
         _route_get_diagnostics,
         GDIAG_SERVICE_DATA_SCHEMA,
     )

--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -564,12 +564,12 @@ class CentralSystem:
         status_val = None
         with contextlib.suppress(Exception):
             status_val = m[
-                (self._norm_conn(connector_id), cstat.status_connector.value)
+                (self._norm_conn(connector_id), cstat.status_connector)
             ].value
 
         if not status_val:
             try:
-                flat = m[cstat.status_connector.value]
+                flat = m[cstat.status_connector]
                 if hasattr(flat, "extra_attr"):
                     status_val = flat.extra_attr.get(
                         self._norm_conn(connector_id)

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import defaultdict
 from collections.abc import MutableMapping
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 import logging
 from math import sqrt
 import secrets
@@ -201,7 +201,7 @@ class _ConnectorAwareMetrics(MutableMapping):
         return key in self._by_conn[0]
 
 
-class OcppVersion(str, Enum):
+class OcppVersion(StrEnum):
     """OCPP version choice."""
 
     V16 = "1.6"

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -285,8 +285,8 @@ class ChargePoint(cp):
         self._metrics: _ConnectorAwareMetrics = _ConnectorAwareMetrics()
 
         # Init standard metrics for connector 0
-        self._metrics[(0, cdet.identifier.value)].value = id
-        self._metrics[(0, cstat.reconnects.value)].value = 0
+        self._metrics[(0, cdet.identifier)].value = id
+        self._metrics[(0, cstat.reconnects)].value = 0
 
         self._attr_supported_features = prof.NONE
         alphabet = string.ascii_uppercase + string.digits
@@ -300,13 +300,13 @@ class ChargePoint(cp):
 
     def _init_connector_slots(self, conn_id: int) -> None:
         """Ensure connector-scoped metrics exist and carry the right units."""
-        _ = self._metrics[(conn_id, cstat.status_connector.value)]
-        _ = self._metrics[(conn_id, cstat.error_code_connector.value)]
-        _ = self._metrics[(conn_id, csess.transaction_id.value)]
+        _ = self._metrics[(conn_id, cstat.status_connector)]
+        _ = self._metrics[(conn_id, cstat.error_code_connector)]
+        _ = self._metrics[(conn_id, csess.transaction_id)]
 
-        self._metrics[(conn_id, csess.session_time.value)].unit = TIME_MINUTES
-        self._metrics[(conn_id, csess.session_energy.value)].unit = HA_ENERGY_UNIT
-        self._metrics[(conn_id, csess.meter_start.value)].unit = HA_ENERGY_UNIT
+        self._metrics[(conn_id, csess.session_time)].unit = TIME_MINUTES
+        self._metrics[(conn_id, csess.session_energy)].unit = HA_ENERGY_UNIT
+        self._metrics[(conn_id, csess.meter_start)].unit = HA_ENERGY_UNIT
 
     async def get_number_of_connectors(self) -> int:
         """Return number of connectors on this charger."""
@@ -331,7 +331,7 @@ class ChargePoint(cp):
     async def fetch_supported_features(self):
         """Get supported features."""
         self._attr_supported_features = await self.get_supported_features()
-        self._metrics[(0, cdet.features.value)].value = self._attr_supported_features
+        self._metrics[(0, cdet.features)].value = self._attr_supported_features
         _LOGGER.debug(
             "Feature profiles returned: %s", self._attr_supported_features.labels()
         )
@@ -345,7 +345,7 @@ class ChargePoint(cp):
             self.num_connectors = await self.get_number_of_connectors()
             for conn in range(1, self.num_connectors + 1):
                 self._init_connector_slots(conn)
-            self._metrics[(0, cdet.connectors.value)].value = self.num_connectors
+            self._metrics[(0, cdet.connectors)].value = self.num_connectors
             await self.get_heartbeat_interval()
 
             accepted_measurands: str = await self.get_supported_measurands()
@@ -494,8 +494,8 @@ class ChargePoint(cp):
 
     async def monitor_connection(self):
         """Monitor the connection, by measuring the connection latency."""
-        self._metrics[(0, cstat.latency_ping.value)].unit = "ms"
-        self._metrics[(0, cstat.latency_pong.value)].unit = "ms"
+        self._metrics[(0, cstat.latency_ping)].unit = "ms"
+        self._metrics[(0, cstat.latency_pong)].unit = "ms"
         connection = self._connection
         timeout_counter = 0
 
@@ -528,12 +528,12 @@ class ChargePoint(cp):
                     f"Connection latency from '{self.cs_settings.csid}' to '{self.id}': "
                     f"ping={latency_ping} ms, pong={latency_pong} ms",
                 )
-                self._metrics[(0, cstat.latency_ping.value)].value = latency_ping
-                self._metrics[(0, cstat.latency_pong.value)].value = latency_pong
+                self._metrics[(0, cstat.latency_ping)].value = latency_ping
+                self._metrics[(0, cstat.latency_pong)].value = latency_pong
                 # This loop is these sensors' only publisher: nothing
                 # message-driven republishes them on an idle charger.
                 self._async_refresh_metric_entities(
-                    [cstat.latency_ping.value, cstat.latency_pong.value],
+                    [cstat.latency_ping, cstat.latency_pong],
                     fallback_to_full_update=False,
                 )
 
@@ -543,10 +543,10 @@ class ChargePoint(cp):
                     f"Connection latency from '{self.cs_settings.csid}' to '{self.id}': "
                     f"ping={latency_ping} ms, pong={latency_pong} ms",
                 )
-                self._metrics[(0, cstat.latency_ping.value)].value = latency_ping
-                self._metrics[(0, cstat.latency_pong.value)].value = latency_pong
+                self._metrics[(0, cstat.latency_ping)].value = latency_ping
+                self._metrics[(0, cstat.latency_pong)].value = latency_pong
                 self._async_refresh_metric_entities(
-                    [cstat.latency_ping.value, cstat.latency_pong.value],
+                    [cstat.latency_ping, cstat.latency_pong],
                     fallback_to_full_update=False,
                 )
 
@@ -610,7 +610,7 @@ class ChargePoint(cp):
         await self.stop()
         self.status = STATE_OK
         self._connection = connection
-        self._metrics[(0, cstat.reconnects.value)].value += 1
+        self._metrics[(0, cstat.reconnects)].value += 1
         # post connect now handled on receiving boot notification or with backstop in monitor connection
         await self.run([super().start(), self.monitor_connection()])
 
@@ -619,10 +619,10 @@ class ChargePoint(cp):
     ):
         """Update device info asynchronously."""
 
-        self._metrics[(0, cdet.model.value)].value = model
-        self._metrics[(0, cdet.vendor.value)].value = vendor
-        self._metrics[(0, cdet.firmware_version.value)].value = firmware_version
-        self._metrics[(0, cdet.serial.value)].value = serial
+        self._metrics[(0, cdet.model)].value = model
+        self._metrics[(0, cdet.vendor)].value = vendor
+        self._metrics[(0, cdet.firmware_version)].value = firmware_version
+        self._metrics[(0, cdet.serial)].value = serial
 
         identifiers = {(DOMAIN, self.id), (DOMAIN, self.settings.cpid)}
 
@@ -794,16 +794,14 @@ class ChargePoint(cp):
                 measurand_data[measurand] = {}
 
             if unit is not None:
-                measurand_data[measurand][om.unit.value] = unit
+                measurand_data[measurand][om.unit] = unit
                 self._metrics[(target_cid, measurand)].unit = unit
-                self._metrics[(target_cid, measurand)].extra_attr[om.unit.value] = unit
+                self._metrics[(target_cid, measurand)].extra_attr[om.unit] = unit
 
             measurand_data[measurand][phase] = value
             self._metrics[(target_cid, measurand)].extra_attr[phase] = value
             if context is not None:
-                self._metrics[(target_cid, measurand)].extra_attr[om.context.value] = (
-                    context
-                )
+                self._metrics[(target_cid, measurand)].extra_attr[om.context] = context
 
         line_phases_all = [
             Phase.l1.value,
@@ -876,7 +874,7 @@ class ChargePoint(cp):
                     # If only a single phase value exists, just pass it through
                     else:
                         metric_value = next(
-                            (v for k, v in phase_info.items() if k != om.unit.value),
+                            (v for k, v in phase_info.items() if k != om.unit),
                             None,
                         )
 
@@ -891,7 +889,7 @@ class ChargePoint(cp):
                         )
 
             if metric_value is not None:
-                metric_unit = phase_info.get(om.unit.value)
+                metric_unit = phase_info.get(om.unit)
 
                 if metric_unit == DEFAULT_POWER_UNIT:
                     self._metrics[(target_cid, metric)].value = metric_value / 1000
@@ -1008,7 +1006,7 @@ class ChargePoint(cp):
                     value = value / 1000
                     unit = HA_POWER_UNIT
 
-                if self._metrics[(connector_id, csess.meter_start.value)].value == 0:
+                if self._metrics[(connector_id, csess.meter_start)].value == 0:
                     # Charger reports Energy.Active.Import.Register directly as Session energy for transactions.
                     self._charger_reports_session_energy = True
 
@@ -1059,10 +1057,10 @@ class ChargePoint(cp):
                         self._metrics[(target_cid, measurand)].unit = unit
                         if location is not None:
                             self._metrics[(target_cid, measurand)].extra_attr[
-                                om.location.value
+                                om.location
                             ] = location
                         self._metrics[(target_cid, measurand)].extra_attr[
-                            om.context.value
+                            om.context
                         ] = context
 
                     # Session handling, only for EAIR during a transaction (per-connector)
@@ -1071,15 +1069,15 @@ class ChargePoint(cp):
                             # Charger reports session energy directly; ignore Transaction.Begin.
                             if context != ReadingContext.transaction_begin.value:
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].value = value
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].unit = unit
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].extra_attr[cstat.id_tag.name] = self._metrics[
-                                    (target_cid, cstat.id_tag.value)
+                                    (target_cid, cstat.id_tag)
                                 ].value
                         else:
                             # Initialize baseline on first tx-bound EAIR; then derive Session = EAIR - meter_start.
@@ -1088,17 +1086,17 @@ class ChargePoint(cp):
                                 ms_metric.value = value
                                 ms_metric.unit = unit
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].value = 0.0
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].unit = unit
                             elif ms_metric.unit == unit:
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].value = round(1000 * (value - ms_metric.value)) / 1000
                                 self._metrics[
-                                    (target_cid, csess.session_energy.value)
+                                    (target_cid, csess.session_energy)
                                 ].unit = unit
                 else:
                     unprocessed.append(sampled_value)

--- a/custom_components/ocpp/enums.py
+++ b/custom_components/ocpp/enums.py
@@ -1,9 +1,9 @@
 """Additional enumerated values to use in home assistant."""
 
-from enum import Enum, IntFlag, auto
+from enum import IntFlag, StrEnum, auto
 
 
-class HAChargerServices(str, Enum):
+class HAChargerServices(StrEnum):
     """Charger status conditions to report in home assistant."""
 
     # For HA service reference and for function to call use .value
@@ -22,7 +22,7 @@ class HAChargerServices(str, Enum):
     service_data_transfer = "data_transfer"
 
 
-class HAChargerStatuses(str, Enum):
+class HAChargerStatuses(StrEnum):
     """Charger status conditions to report in home assistant."""
 
     status = "Status"
@@ -38,7 +38,7 @@ class HAChargerStatuses(str, Enum):
     id_tag = "Id.Tag"
 
 
-class HAChargerDetails(str, Enum):
+class HAChargerDetails(StrEnum):
     """Charger nameplate information to report in home assistant."""
 
     identifier = "ID"
@@ -53,7 +53,7 @@ class HAChargerDetails(str, Enum):
     config_response = "Timestamp.Config.Response"
 
 
-class HAChargerSession(str, Enum):
+class HAChargerSession(StrEnum):
     """Charger session information to report in home assistant."""
 
     transaction_id = "Transaction.Id"
@@ -80,7 +80,7 @@ class Profiles(IntFlag):
         return "|".join([p.name for p in Profiles if p & self])
 
 
-class OcppMisc(str, Enum):
+class OcppMisc(StrEnum):
     """Miscellaneous strings used in ocpp v1.6 responses."""
 
     # For pythonic version use .name (eg with kwargs) for ocpp json use .value
@@ -122,7 +122,7 @@ class OcppMisc(str, Enum):
     power = "Power"
 
 
-class ConfigurationKey(str, Enum):
+class ConfigurationKey(StrEnum):
     """Configuration Key Names."""
 
     # 9.1 Core Profile

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -181,7 +181,7 @@ class ChargePoint(cp):
 
     async def get_heartbeat_interval(self):
         """Retrieve heartbeat interval from the charger and store it."""
-        await self.get_configuration(ckey.heartbeat_interval.value)
+        await self.get_configuration(ckey.heartbeat_interval)
 
     async def get_supported_measurands(self) -> str:
         """Get comma-separated list of measurands supported by the charger."""
@@ -217,7 +217,7 @@ class ChargePoint(cp):
 
         all_measurands = self.settings.monitored_variables or ""
         autodetect_measurands = bool(self.settings.monitored_variables_autoconfig)
-        key = ckey.meter_values_sampled_data.value
+        key = ckey.meter_values_sampled_data
 
         desired_csv = all_measurands.strip().strip(",")
         cfg_ok = {ConfigurationStatus.accepted, ConfigurationStatus.reboot_required}
@@ -312,27 +312,27 @@ class ChargePoint(cp):
     async def set_standard_configuration(self):
         """Send configuration values to the charger."""
         await self.configure(
-            ckey.meter_value_sample_interval.value,
+            ckey.meter_value_sample_interval,
             str(self.settings.meter_interval),
         )
         await self.configure(
-            ckey.clock_aligned_data_interval.value,
+            ckey.clock_aligned_data_interval,
             str(self.settings.idle_interval),
         )
 
     async def get_supported_features(self) -> prof:
         """Get features supported by the charger."""
         features = prof.NONE
-        req = call.GetConfiguration(key=[ckey.supported_feature_profiles.value])
+        req = call.GetConfiguration(key=[ckey.supported_feature_profiles])
         resp = await self.call(req)
         try:
-            feature_list = (resp.configuration_key[0][om.value.value]).split(",")
+            feature_list = (resp.configuration_key[0][om.value]).split(",")
         except (IndexError, KeyError, TypeError):
             feature_list = [""]
         if feature_list[0] == "":
             _LOGGER.warning("No feature profiles detected, defaulting to Core")
             await self.notify_ha("No feature profiles detected, defaulting to Core")
-            feature_list = [om.feature_profile_core.value]
+            feature_list = [om.feature_profile_core]
 
         if self.settings.force_smart_charging:
             _LOGGER.warning("Force Smart Charging feature profile")
@@ -340,17 +340,17 @@ class ChargePoint(cp):
 
         for item in feature_list:
             item = item.strip().replace(" ", "")
-            if item == om.feature_profile_core.value:
+            if item == om.feature_profile_core:
                 features |= prof.CORE
-            elif item == om.feature_profile_firmware.value:
+            elif item == om.feature_profile_firmware:
                 features |= prof.FW
-            elif item == om.feature_profile_smart.value:
+            elif item == om.feature_profile_smart:
                 features |= prof.SMART
-            elif item == om.feature_profile_reservation.value:
+            elif item == om.feature_profile_reservation:
                 features |= prof.RES
-            elif item == om.feature_profile_remote.value:
+            elif item == om.feature_profile_remote:
                 features |= prof.REM
-            elif item == om.feature_profile_auth.value:
+            elif item == om.feature_profile_auth:
                 features |= prof.AUTH
             else:
                 _LOGGER.warning("Unknown feature profile detected ignoring: %s", item)
@@ -374,7 +374,7 @@ class ChargePoint(cp):
     async def trigger_status_notification(self):
         """Trigger status notifications for all connectors."""
         try:
-            n = int(self._metrics[0][cdet.connectors.value].value or 1)
+            n = int(self._metrics[0][cdet.connectors].value or 1)
         except Exception:
             n = 1
 
@@ -398,7 +398,7 @@ class ChargePoint(cp):
                 if cid > 0:
                     _LOGGER.warning("Failed with response: %s", status)
                     # Reduce to the last known-good connector index.
-                    self._metrics[0][cdet.connectors.value].value = max(1, cid - 1)
+                    self._metrics[0][cdet.connectors].value = max(1, cid - 1)
                     return False
                 # If connector 0 is rejected, continue probing numbered connectors.
 
@@ -537,7 +537,7 @@ class ChargePoint(cp):
 
         # Determine allowed unit (default to Amps if not reported)
         units_resp = await self.get_configuration(
-            ckey.charging_schedule_allowed_charging_rate_unit.value
+            ckey.charging_schedule_allowed_charging_rate_unit
         )
         if not units_resp:
             _LOGGER.debug("Charging rate unit not reported; assuming Amps")
@@ -580,7 +580,7 @@ class ChargePoint(cp):
 
         try:
             stack_level_resp = await self.get_configuration(
-                ckey.charge_profile_max_stack_level.value
+                ckey.charge_profile_max_stack_level
             )
             stack_level = int(stack_level_resp)
         except Exception:
@@ -589,10 +589,8 @@ class ChargePoint(cp):
         # Helper to build a simple relative schedule with one period
         def _mk_schedule(_units: str, _limit: float) -> dict:
             return {
-                om.charging_rate_unit.value: _units,
-                om.charging_schedule_period.value: [
-                    {om.start_period.value: 0, om.limit.value: _limit}
-                ],
+                om.charging_rate_unit: _units,
+                om.charging_schedule_period: [{om.start_period: 0, om.limit: _limit}],
             }
 
         # Helper to generate a unique, stable chargingProfileId per purpose+connector
@@ -613,13 +611,13 @@ class ChargePoint(cp):
             req = call.SetChargingProfile(
                 connector_id=0,
                 cs_charging_profiles={
-                    om.charging_profile_id.value: _profile_id(
+                    om.charging_profile_id: _profile_id(
                         ChargingProfilePurposeType.charge_point_max_profile.value, 0
                     ),
-                    om.stack_level.value: stack_level,
-                    om.charging_profile_kind.value: ChargingProfileKindType.relative.value,
-                    om.charging_profile_purpose.value: ChargingProfilePurposeType.charge_point_max_profile.value,
-                    om.charging_schedule.value: _mk_schedule(units_value, limit_value),
+                    om.stack_level: stack_level,
+                    om.charging_profile_kind: ChargingProfileKindType.relative.value,
+                    om.charging_profile_purpose: ChargingProfilePurposeType.charge_point_max_profile.value,
+                    om.charging_schedule: _mk_schedule(units_value, limit_value),
                 },
             )
             resp = await self.call(req)
@@ -651,17 +649,15 @@ class ChargePoint(cp):
                 req = call.SetChargingProfile(
                     connector_id=target_cid,
                     cs_charging_profiles={
-                        om.charging_profile_id.value: _profile_id(
+                        om.charging_profile_id: _profile_id(
                             ChargingProfilePurposeType.tx_profile.value, target_cid
                         ),
-                        om.stack_level.value: txp_stack,
-                        om.charging_profile_kind.value: ChargingProfileKindType.relative.value,
-                        om.charging_profile_purpose.value: ChargingProfilePurposeType.tx_profile.value,
-                        om.charging_schedule.value: _mk_schedule(
-                            units_value, limit_value
-                        ),
+                        om.stack_level: txp_stack,
+                        om.charging_profile_kind: ChargingProfileKindType.relative.value,
+                        om.charging_profile_purpose: ChargingProfilePurposeType.tx_profile.value,
+                        om.charging_schedule: _mk_schedule(units_value, limit_value),
                         # Bind to the ongoing transaction
-                        om.transaction_id.value: active_tx_id,
+                        om.transaction_id: active_tx_id,
                     },
                 )
                 resp = await self.call(req)
@@ -680,13 +676,13 @@ class ChargePoint(cp):
             req = call.SetChargingProfile(
                 connector_id=target_cid,
                 cs_charging_profiles={
-                    om.charging_profile_id.value: _profile_id(
+                    om.charging_profile_id: _profile_id(
                         ChargingProfilePurposeType.tx_default_profile.value, target_cid
                     ),
-                    om.stack_level.value: tx_stack,
-                    om.charging_profile_kind.value: ChargingProfileKindType.relative.value,
-                    om.charging_profile_purpose.value: ChargingProfilePurposeType.tx_default_profile.value,
-                    om.charging_schedule.value: _mk_schedule(units_value, limit_value),
+                    om.stack_level: tx_stack,
+                    om.charging_profile_kind: ChargingProfileKindType.relative.value,
+                    om.charging_profile_purpose: ChargingProfilePurposeType.tx_default_profile.value,
+                    om.charging_schedule: _mk_schedule(units_value, limit_value),
                 },
             )
             resp = await self.call(req)
@@ -745,7 +741,7 @@ class ChargePoint(cp):
             target_str = "Operative" if state else "Inoperative"
             scope_str = "station" if conn == 0 else "connector"
 
-            metric_key = (conn, cstat.status_connector.value)
+            metric_key = (conn, cstat.status_connector)
             metric = self._metrics.get(metric_key)
 
             if status == AvailabilityStatus.scheduled:
@@ -843,7 +839,7 @@ class ChargePoint(cp):
 
     async def reset(self, typ: str = ResetType.hard):
         """Hard reset charger unless soft reset requested."""
-        self._metrics[0][cstat.reconnects.value].value = 0
+        self._metrics[0][cstat.reconnects].value = 0
         req = call.Reset(typ)
         resp = await self.call(req)
         if resp.status == ResetStatus.accepted:
@@ -931,10 +927,8 @@ class ChargePoint(cp):
                 data,
                 resp.data,
             )
-            self._metrics[0][cdet.data_response.value].value = datetime.now(tz=UTC)
-            self._metrics[0][cdet.data_response.value].extra_attr = {
-                message_id: resp.data
-            }
+            self._metrics[0][cdet.data_response].value = datetime.now(tz=UTC)
+            self._metrics[0][cdet.data_response].extra_attr = {message_id: resp.data}
             return True
         else:
             _LOGGER.warning("Failed with response: %s", resp.status)
@@ -959,14 +953,14 @@ class ChargePoint(cp):
                 result = {}
                 for entry in resp.configuration_key:
                     entry_key = entry.get("key", "")
-                    entry_value = entry.get(om.value.value, "")
+                    entry_value = entry.get(om.value, "")
                     result[entry_key] = entry_value
                 _LOGGER.debug("Get Configuration returned %d keys", len(result))
                 return result
-            value = resp.configuration_key[0][om.value.value]
+            value = resp.configuration_key[0][om.value]
             _LOGGER.debug("Get Configuration for %s: %s", key, value)
-            self._metrics[0][cdet.config_response.value].value = datetime.now(tz=UTC)
-            self._metrics[0][cdet.config_response.value].extra_attr = {key: value}
+            self._metrics[0][cdet.config_response].value = datetime.now(tz=UTC)
+            self._metrics[0][cdet.config_response].extra_attr = {key: value}
             return value
         if resp.unknown_key:
             _LOGGER.warning("Get Configuration returned unknown key for: %s", key)
@@ -995,7 +989,7 @@ class ChargePoint(cp):
         for key_value in resp.configuration_key:
             # If the key already has the targeted value we don't need to set
             # it.
-            if key_value[om.key.value] == key and key_value[om.value.value] == value:
+            if key_value[om.key] == key and key_value[om.value] == value:
                 return
 
             if key_value.get(om.readonly.name, False):
@@ -1042,12 +1036,12 @@ class ChargePoint(cp):
         tx_has_id: bool = transaction_id not in (None, 0)
 
         # Restore missing per-connector meter_start / active_transaction_id from HA if possible.
-        ms_key = (connector_id, csess.meter_start.value)
-        tx_key = (connector_id, csess.transaction_id.value)
-        session_key = (connector_id, csess.session_time.value)
+        ms_key = (connector_id, csess.meter_start)
+        tx_key = (connector_id, csess.transaction_id)
+        session_key = (connector_id, csess.session_time)
 
         if self._metrics[ms_key].value is None:
-            value = self.get_ha_metric(csess.meter_start.value, connector_id)
+            value = self.get_ha_metric(csess.meter_start, connector_id)
             if value is None:
                 m = self._metrics.get((connector_id, DEFAULT_MEASURAND))
                 value = m.value if m is not None else None
@@ -1056,7 +1050,7 @@ class ChargePoint(cp):
                     value = float(value)
                     _LOGGER.debug(
                         "%s[%s] was None, restored value=%s from HA.",
-                        csess.meter_start.value,
+                        csess.meter_start,
                         connector_id,
                         value,
                     )
@@ -1065,7 +1059,7 @@ class ChargePoint(cp):
             self._metrics[ms_key].value = value
 
         if self._metrics[tx_key].value is None:
-            value = self.get_ha_metric(csess.transaction_id.value, connector_id)
+            value = self.get_ha_metric(csess.transaction_id, connector_id)
             if value is None:
                 value = transaction_id if transaction_id else None
             else:
@@ -1073,7 +1067,7 @@ class ChargePoint(cp):
                     value = int(value)
                     _LOGGER.debug(
                         "%s[%s] was None, restored value=%s from HA.",
-                        csess.transaction_id.value,
+                        csess.transaction_id,
                         connector_id,
                         value,
                     )
@@ -1100,8 +1094,7 @@ class ChargePoint(cp):
         tx_ended: bool = bool(transaction_id) and (
             transaction_id == int(self._ended_tx.get(connector_id, 0) or 0)
             or any(
-                sampled_value.get(om.context.value)
-                == ReadingContext.transaction_end.value
+                sampled_value.get(om.context) == ReadingContext.transaction_end.value
                 for bucket in meter_value
                 for sampled_value in bucket.get(om.sampled_value.name, [])
             )
@@ -1155,17 +1148,17 @@ class ChargePoint(cp):
         for bucket in meter_value:
             measurands: list[MeasurandValue] = []
             for sampled_value in bucket.get(om.sampled_value.name, []):
-                measurand = sampled_value.get(om.measurand.value, None)
-                value = sampled_value.get(om.value.value, None)
+                measurand = sampled_value.get(om.measurand, None)
+                value = sampled_value.get(om.value, None)
                 # Where an empty string is supplied convert to 0
                 try:
                     value = float(value)
                 except (ValueError, TypeError):
                     value = 0.0
-                unit = sampled_value.get(om.unit.value, None)
-                phase = sampled_value.get(om.phase.value, None)
-                location = sampled_value.get(om.location.value, None)
-                context = sampled_value.get(om.context.value, None)
+                unit = sampled_value.get(om.unit, None)
+                phase = sampled_value.get(om.phase, None)
+                location = sampled_value.get(om.location, None)
+                context = sampled_value.get(om.context, None)
                 measurands.append(
                     MeasurandValue(measurand, value, phase, unit, context, location)
                 )
@@ -1225,13 +1218,11 @@ class ChargePoint(cp):
         )
 
         if connector_id == 0 or connector_id is None:
-            self._metrics[(0, cstat.status.value)].value = status
-            self._metrics[(0, cstat.error_code.value)].value = error_code
+            self._metrics[(0, cstat.status)].value = status
+            self._metrics[(0, cstat.error_code)].value = error_code
         else:
-            self._metrics[(connector_id, cstat.status_connector.value)].value = status
-            self._metrics[
-                (connector_id, cstat.error_code_connector.value)
-            ].value = error_code
+            self._metrics[(connector_id, cstat.status_connector)].value = status
+            self._metrics[(connector_id, cstat.error_code_connector)].value = error_code
 
             if status in (
                 ChargePointStatus.suspended_ev.value,
@@ -1245,7 +1236,7 @@ class ChargePoint(cp):
     @on(Action.firmware_status_notification)
     def on_firmware_status(self, status, **kwargs):
         """Handle firmware status notification."""
-        self._metrics[0][cstat.firmware_status.value].value = status
+        self._metrics[0][cstat.firmware_status].value = status
         self.hass.async_create_task(self.update(self.settings.cpid))
         self.hass.async_create_task(self.notify_ha(f"Firmware upload status: {status}"))
         return call_result.FirmwareStatusNotification()
@@ -1276,9 +1267,9 @@ class ChargePoint(cp):
     @on(Action.authorize)
     def on_authorize(self, id_tag, **kwargs):
         """Handle an Authorization request."""
-        self._metrics[0][cstat.id_tag.value].value = id_tag
+        self._metrics[0][cstat.id_tag].value = id_tag
         auth_status = self.get_authorization_status(id_tag)
-        return call_result.Authorize(id_tag_info={om.status.value: auth_status})
+        return call_result.Authorize(id_tag_info={om.status: auth_status})
 
     @on(Action.start_transaction)
     def on_start_transaction(self, connector_id, id_tag, meter_start, **kwargs):
@@ -1290,34 +1281,28 @@ class ChargePoint(cp):
             self._ended_tx.pop(connector_id, None)
             self._active_tx[connector_id] = tx_id
             self.active_transaction_id = tx_id
-            self._metrics[(connector_id, cstat.id_tag.value)].value = id_tag
-            self._metrics[(connector_id, cstat.stop_reason.value)].value = ""
-            self._metrics[(connector_id, csess.transaction_id.value)].value = tx_id
+            self._metrics[(connector_id, cstat.id_tag)].value = id_tag
+            self._metrics[(connector_id, cstat.stop_reason)].value = ""
+            self._metrics[(connector_id, csess.transaction_id)].value = tx_id
             try:
                 meter_start_kwh = float(meter_start) / 1000.0
             except Exception:
                 meter_start_kwh = 0.0
-            self._metrics[
-                (connector_id, csess.meter_start.value)
-            ].value = meter_start_kwh
-            self._metrics[(connector_id, csess.meter_start.value)].unit = HA_ENERGY_UNIT
+            self._metrics[(connector_id, csess.meter_start)].value = meter_start_kwh
+            self._metrics[(connector_id, csess.meter_start)].unit = HA_ENERGY_UNIT
 
-            self._metrics[(connector_id, csess.session_time.value)].value = 0
-            self._metrics[
-                (connector_id, csess.session_time.value)
-            ].unit = UnitOfTime.MINUTES
-            self._metrics[(connector_id, csess.session_energy.value)].value = 0.0
-            self._metrics[
-                (connector_id, csess.session_energy.value)
-            ].unit = HA_ENERGY_UNIT
+            self._metrics[(connector_id, csess.session_time)].value = 0
+            self._metrics[(connector_id, csess.session_time)].unit = UnitOfTime.MINUTES
+            self._metrics[(connector_id, csess.session_energy)].value = 0.0
+            self._metrics[(connector_id, csess.session_energy)].unit = HA_ENERGY_UNIT
 
             result = call_result.StartTransaction(
-                id_tag_info={om.status.value: AuthorizationStatus.accepted.value},
+                id_tag_info={om.status: AuthorizationStatus.accepted.value},
                 transaction_id=tx_id,
             )
         else:
             result = call_result.StartTransaction(
-                id_tag_info={om.status.value: auth_status},
+                id_tag_info={om.status: auth_status},
                 transaction_id=0,
             )
 
@@ -1343,13 +1328,13 @@ class ChargePoint(cp):
         self._ended_tx[conn] = int(transaction_id or 0)
         self._active_tx[conn] = 0
         self.active_transaction_id = 0
-        self._metrics[(conn, cstat.id_tag.value)].value = ""
-        self._metrics[(conn, csess.transaction_id.value)].value = 0
-        self._metrics[(conn, cstat.stop_reason.value)].value = kwargs.get(
+        self._metrics[(conn, cstat.id_tag)].value = ""
+        self._metrics[(conn, csess.transaction_id)].value = 0
+        self._metrics[(conn, cstat.stop_reason)].value = kwargs.get(
             om.reason.name, None
         )
 
-        ms_key = (conn, csess.meter_start.value)
+        ms_key = (conn, csess.meter_start)
         if (
             self._metrics[ms_key].value is not None
             and not self._charger_reports_session_energy
@@ -1360,29 +1345,29 @@ class ChargePoint(cp):
                 )
             except Exception:
                 session_kwh = 0.0
-            self._metrics[(conn, csess.session_energy.value)].value = session_kwh
+            self._metrics[(conn, csess.session_energy)].value = session_kwh
 
         self._zero_flow_measurands(conn)
 
         self.hass.async_create_task(self.update(self.settings.cpid))
         return call_result.StopTransaction(
-            id_tag_info={om.status.value: AuthorizationStatus.accepted.value}
+            id_tag_info={om.status: AuthorizationStatus.accepted.value}
         )
 
     @on(Action.data_transfer)
     def on_data_transfer(self, vendor_id, **kwargs):
         """Handle a Data transfer request."""
         _LOGGER.debug("Data transfer received from %s: %s", self.id, kwargs)
-        self._metrics[0][cdet.data_transfer.value].value = datetime.now(tz=UTC)
-        self._metrics[0][cdet.data_transfer.value].extra_attr = {vendor_id: kwargs}
+        self._metrics[0][cdet.data_transfer].value = datetime.now(tz=UTC)
+        self._metrics[0][cdet.data_transfer].extra_attr = {vendor_id: kwargs}
         return call_result.DataTransfer(status=DataTransferStatus.accepted.value)
 
     @on(Action.heartbeat)
     def on_heartbeat(self, **kwargs):
         """Handle a Heartbeat."""
         now = datetime.now(tz=UTC)
-        self._metrics[0][cstat.heartbeat.value].value = now
-        self._async_refresh_metric_entities([cstat.heartbeat.value])
+        self._metrics[0][cstat.heartbeat].value = now
+        self._async_refresh_metric_entities([cstat.heartbeat])
         return call_result.Heartbeat(current_time=now.strftime("%Y-%m-%dT%H:%M:%SZ"))
 
     def _zero_flow_measurands(self, connector_id: int) -> None:

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -310,7 +310,7 @@ class ChargePoint(cp):
         # would mask a faulted connector via the flattened sensor's fallback
         # chain.
         if evse_id == 0 and connector_id == 0:
-            self._metrics[(0, cstat.status.value)].value = ConnectorStatusEnumType(
+            self._metrics[(0, cstat.status)].value = ConnectorStatusEnumType(
                 connector_status
             ).value
             return
@@ -351,16 +351,14 @@ class ChargePoint(cp):
         # follow only carry chargingState when it changes - so letting it
         # overwrite Charging would turn charge_control off for the rest of the
         # session. Every other status is real news and still applies.
-        current = self._metrics[(global_idx, cstat.status_connector.value)].value
+        current = self._metrics[(global_idx, cstat.status_connector)].value
         downgrades_live_charge = (
             translated == ChargePointStatusv16.preparing
             and current in self._CHARGING_STATES
             and self._has_live_transaction(evse_id, connector_id)
         )
         if not downgrades_live_charge:
-            self._metrics[
-                (global_idx, cstat.status_connector.value)
-            ].value = translated.value
+            self._metrics[(global_idx, cstat.status_connector)].value = translated.value
 
         evse_status = self._aggregate_evse_status(evse_id)
         if evse_status is not None:
@@ -837,12 +835,12 @@ class ChargePoint(cp):
             if evse < 1 or evse > total:
                 _LOGGER.info("Requested EVSE %s is out of range (1..%s)", evse, total)
                 return False
-            val = self._metrics[(evse, csess.transaction_id.value)].value
+            val = self._metrics[(evse, csess.transaction_id)].value
             tx_id = str(val) if val else None
         else:
             # Global stop: find the first active transaction across EVSEs
             for evse in range(1, total + 1):
-                val = self._metrics[(evse, csess.transaction_id.value)].value
+                val = self._metrics[(evse, csess.transaction_id)].value
                 if val:
                     tx_id = str(val)
                     break
@@ -963,8 +961,8 @@ class ChargePoint(cp):
         # the write the sensor keeps whatever an earlier session left -
         # heartbeats were answered here but recorded nowhere.
         now = datetime.now(tz=UTC)
-        self._metrics[(0, cstat.heartbeat.value)].value = now
-        self._async_refresh_metric_entities([cstat.heartbeat.value])
+        self._metrics[(0, cstat.heartbeat)].value = now
+        self._async_refresh_metric_entities([cstat.heartbeat])
         # Deliberately not mirrored: 1.6 replies with whole seconds
         # (strftime %H:%M:%SZ); 2.0.1 keeps its pre-existing isoformat
         # reply, microseconds and all - both are valid RFC 3339.
@@ -988,7 +986,7 @@ class ChargePoint(cp):
         if evse_id >= 1:
             self._evse_status_v16[evse_id] = evse_status_v16
         derived = self._derive_station_status()
-        self._metrics[(0, cstat.status_connector.value)].value = (
+        self._metrics[(0, cstat.status_connector)].value = (
             derived if derived is not None else evse_status_v16.value
         )
         if connector_id is not None and evse_id >= 1 and connector_id >= 1:
@@ -997,7 +995,7 @@ class ChargePoint(cp):
             # real one, so it must not reach the metric from here either.
             global_idx = self._pair_to_global(evse_id, connector_id)
             self._metrics[
-                (global_idx, cstat.status_connector.value)
+                (global_idx, cstat.status_connector)
             ].value = evse_status_v16.value
         self.hass.async_create_task(self.update(self.settings.cpid))
 
@@ -1248,7 +1246,7 @@ class ChargePoint(cp):
 
         if (tx_event_type == TransactionEventEnumType.started.value) or (
             (tx_event_type == TransactionEventEnumType.updated.value)
-            and (self._metrics[(global_idx, csess.meter_start.value)].value is None)
+            and (self._metrics[(global_idx, csess.meter_start)].value is None)
         ):
             energy_measurand = MeasurandEnumType.energy_active_import_register.value
             for meter_value in converted_values:
@@ -1257,10 +1255,10 @@ class ChargePoint(cp):
                         energy_value = cp.get_energy_kwh(measurand_item)
                         energy_unit = HA_ENERGY_UNIT if measurand_item.unit else None
                         self._metrics[
-                            (global_idx, csess.meter_start.value)
+                            (global_idx, csess.meter_start)
                         ].value = energy_value
                         self._metrics[
-                            (global_idx, csess.meter_start.value)
+                            (global_idx, csess.meter_start)
                         ].unit = energy_unit
 
         self.process_measurands(converted_values, True, global_idx)
@@ -1340,7 +1338,7 @@ class ChargePoint(cp):
                     known = self._known_occupancy(evse_id, evse_conn_id)
                     if known is not None:
                         self._metrics[
-                            (global_idx, cstat.status_connector.value)
+                            (global_idx, cstat.status_connector)
                         ].value = self._connector_status_v16(known).value
                 else:
                     self._report_evse_status(
@@ -1352,29 +1350,25 @@ class ChargePoint(cp):
         if id_token:
             response.id_token_info = {"status": AuthorizationStatusEnumType.accepted}
             id_tag_string: str = id_token["type"] + ":" + id_token["id_token"]
-            self._metrics[(global_idx, cstat.id_tag.value)].value = id_tag_string
+            self._metrics[(global_idx, cstat.id_tag)].value = id_tag_string
 
         if event_type == TransactionEventEnumType.started.value:
             self._tx_start_time[global_idx] = t
             tx_id: str = transaction_info["transaction_id"]
-            self._metrics[(global_idx, csess.transaction_id.value)].value = tx_id
-            self._metrics[(global_idx, csess.session_time.value)].value = 0
-            self._metrics[
-                (global_idx, csess.session_time.value)
-            ].unit = UnitOfTime.MINUTES
+            self._metrics[(global_idx, csess.transaction_id)].value = tx_id
+            self._metrics[(global_idx, csess.session_time)].value = 0
+            self._metrics[(global_idx, csess.session_time)].unit = UnitOfTime.MINUTES
         else:
             if self._tx_start_time.get(global_idx):
                 elapsed = (t - self._tx_start_time[global_idx]).total_seconds()
                 duration_minutes: int = int((elapsed + 59) // 60)
+                self._metrics[(global_idx, csess.session_time)].value = duration_minutes
                 self._metrics[
-                    (global_idx, csess.session_time.value)
-                ].value = duration_minutes
-                self._metrics[
-                    (global_idx, csess.session_time.value)
+                    (global_idx, csess.session_time)
                 ].unit = UnitOfTime.MINUTES
             if event_type == TransactionEventEnumType.ended.value:
-                self._metrics[(global_idx, csess.transaction_id.value)].value = ""
-                self._metrics[(global_idx, cstat.id_tag.value)].value = ""
+                self._metrics[(global_idx, csess.transaction_id)].value = ""
+                self._metrics[(global_idx, cstat.id_tag)].value = ""
                 self._tx_start_time.pop(global_idx, None)
 
         if not offline:

--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -78,34 +78,34 @@ async def async_setup_entry(hass, entry, async_add_devices):
         measurands = sorted(configured or default_measurands)
 
         CHARGER_ONLY = [
-            HAChargerStatuses.status.value,
-            HAChargerStatuses.error_code.value,
-            HAChargerStatuses.firmware_status.value,
-            HAChargerStatuses.heartbeat.value,
-            HAChargerStatuses.id_tag.value,
-            HAChargerStatuses.latency_ping.value,
-            HAChargerStatuses.latency_pong.value,
-            HAChargerStatuses.reconnects.value,
-            HAChargerDetails.identifier.value,
-            HAChargerDetails.vendor.value,
-            HAChargerDetails.model.value,
-            HAChargerDetails.serial.value,
-            HAChargerDetails.firmware_version.value,
-            HAChargerDetails.features.value,
-            HAChargerDetails.connectors.value,
-            HAChargerDetails.config_response.value,
-            HAChargerDetails.data_response.value,
-            HAChargerDetails.data_transfer.value,
+            HAChargerStatuses.status,
+            HAChargerStatuses.error_code,
+            HAChargerStatuses.firmware_status,
+            HAChargerStatuses.heartbeat,
+            HAChargerStatuses.id_tag,
+            HAChargerStatuses.latency_ping,
+            HAChargerStatuses.latency_pong,
+            HAChargerStatuses.reconnects,
+            HAChargerDetails.identifier,
+            HAChargerDetails.vendor,
+            HAChargerDetails.model,
+            HAChargerDetails.serial,
+            HAChargerDetails.firmware_version,
+            HAChargerDetails.features,
+            HAChargerDetails.connectors,
+            HAChargerDetails.config_response,
+            HAChargerDetails.data_response,
+            HAChargerDetails.data_transfer,
         ]
 
         CONNECTOR_ONLY = measurands + [
-            HAChargerStatuses.status_connector.value,
-            HAChargerStatuses.error_code_connector.value,
-            HAChargerStatuses.stop_reason.value,
-            HAChargerSession.transaction_id.value,
-            HAChargerSession.session_time.value,
-            HAChargerSession.session_energy.value,
-            HAChargerSession.meter_start.value,
+            HAChargerStatuses.status_connector,
+            HAChargerStatuses.error_code_connector,
+            HAChargerStatuses.stop_reason,
+            HAChargerSession.transaction_id,
+            HAChargerSession.session_time,
+            HAChargerSession.session_energy,
+            HAChargerSession.meter_start,
         ]
 
         def _mk_desc(metric: str, *, cat_diag: bool = False) -> OcppSensorDescription:
@@ -172,8 +172,8 @@ async def async_setup_entry(hass, entry, async_add_devices):
                                 metric,
                                 cat_diag=metric
                                 in [
-                                    HAChargerStatuses.status_connector.value,
-                                    HAChargerStatuses.error_code_connector.value,
+                                    HAChargerStatuses.status_connector,
+                                    HAChargerStatuses.error_code_connector,
                                 ],
                             ),
                             connector_id=conn_id,
@@ -190,8 +190,8 @@ async def async_setup_entry(hass, entry, async_add_devices):
                             metric,
                             cat_diag=metric
                             in [
-                                HAChargerStatuses.status_connector.value,
-                                HAChargerStatuses.error_code_connector.value,
+                                HAChargerStatuses.status_connector,
+                                HAChargerStatuses.error_code_connector,
                             ],
                         ),
                         connector_id=None,
@@ -283,9 +283,9 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
             SensorDeviceClass.BATTERY,
             SensorDeviceClass.FREQUENCY,
         ] or self.metric in [
-            HAChargerStatuses.latency_ping.value,
-            HAChargerStatuses.latency_pong.value,
-            HAChargerSession.session_time.value,
+            HAChargerStatuses.latency_ping,
+            HAChargerStatuses.latency_pong,
+            HAChargerSession.session_time,
         ]:
             state_class = SensorStateClass.MEASUREMENT
 
@@ -315,9 +315,9 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
         elif self.metric.lower().startswith("temperature"):
             device_class = SensorDeviceClass.TEMPERATURE
         elif self.metric.lower().startswith("timestamp") or self.metric in [
-            HAChargerDetails.config_response.value,
-            HAChargerDetails.data_response.value,
-            HAChargerStatuses.heartbeat.value,
+            HAChargerDetails.config_response,
+            HAChargerDetails.data_response,
+            HAChargerStatuses.heartbeat,
         ]:
             device_class = SensorDeviceClass.TIMESTAMP
         elif self.metric.lower().startswith("soc"):
@@ -332,7 +332,7 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
         )
 
         # Special case for features - show profiles as labels from IntFlag
-        if self.metric == HAChargerDetails.features.value and value is not None:
+        if self.metric == HAChargerDetails.features and value is not None:
             if hasattr(value, "labels"):
                 self._attr_native_value = value.labels()
             else:

--- a/custom_components/ocpp/switch.py
+++ b/custom_components/ocpp/switch.py
@@ -52,7 +52,7 @@ SWITCHES: Final[list[OcppSwitchDescription]] = [
         icon=ICON,
         on_action=HAChargerServices.service_charge_start.name,
         off_action=HAChargerServices.service_charge_stop.name,
-        metric_state=HAChargerStatuses.status_connector.value,
+        metric_state=HAChargerStatuses.status_connector,
         metric_condition=[
             ChargePointStatus.charging.value,
             ChargePointStatus.suspended_evse.value,
@@ -66,7 +66,7 @@ SWITCHES: Final[list[OcppSwitchDescription]] = [
         icon=ICON,
         on_action=HAChargerServices.service_availability.name,
         off_action=HAChargerServices.service_availability.name,
-        metric_state=HAChargerStatuses.status.value,  # charger-level status
+        metric_state=HAChargerStatuses.status,  # charger-level status
         metric_condition=[ChargePointStatus.available.value],
         default_state=True,
         per_connector=False,
@@ -77,7 +77,7 @@ SWITCHES: Final[list[OcppSwitchDescription]] = [
         icon=ICON,
         on_action=HAChargerServices.service_availability.name,
         off_action=HAChargerServices.service_availability.name,
-        metric_state=HAChargerStatuses.status_connector.value,  # connector-level status
+        metric_state=HAChargerStatuses.status_connector,  # connector-level status
         metric_condition=[
             ChargePointStatus.available.value,
             ChargePointStatus.preparing.value,
@@ -221,7 +221,7 @@ class ChargePointSwitch(SwitchEntity):
                 self.connector_id
                 if (
                     self.entity_description.metric_state
-                    == HAChargerStatuses.status_connector.value
+                    == HAChargerStatuses.status_connector
                     or self.entity_description.per_connector
                 )
                 else None

--- a/tests/test_additional_charge_point_v16.py
+++ b/tests/test_additional_charge_point_v16.py
@@ -48,7 +48,7 @@ async def test_trigger_status_timeout_on_nonzero_adjusts_and_stops(
             await wait_ready(cs.charge_points[cp_id])
 
             srv_cp = cs.charge_points[cp_id]
-            srv_cp._metrics[0][cdet.connectors.value].value = 2
+            srv_cp._metrics[0][cdet.connectors].value = 2
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -64,7 +64,7 @@ async def test_trigger_status_timeout_on_nonzero_adjusts_and_stops(
             assert ok is False
             # Should stop after the failing connector
             assert attempts == [0, 1, 2]
-            assert int(srv_cp._metrics[0][cdet.connectors.value].value) == 1
+            assert int(srv_cp._metrics[0][cdet.connectors].value) == 1
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -248,7 +248,7 @@ async def test_measurands_manual_set_accepted_configures(
             # configure() should have been called with the accepted CSV
             assert (
                 called_configure
-                and called_configure[0][0] == ckey.meter_values_sampled_data.value
+                and called_configure[0][0] == ckey.meter_values_sampled_data
             )
         finally:
             task.cancel()
@@ -364,7 +364,7 @@ async def test_trigger_status_notification_connector_count_parse_exception(
             await wait_ready(cs.charge_points[cp_id])
             srv = cs.charge_points[cp_id]
             # Force parse error so n=1
-            srv._metrics[0][cdet.connectors.value].value = "bad"
+            srv._metrics[0][cdet.connectors].value = "bad"
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -234,7 +234,7 @@ async def test_get_available_paths(hass):
 
     # specific connector via per-connector metric, charger available
     cp = _install_dummy_cp(cs, status=STATE_OK)
-    meas = cstat.status_connector.value
+    meas = cstat.status_connector
     cp._metrics[(1, meas)] = M("Charging", None)
     assert cs.get_available("test_cpid", connector_id=1) is True
 

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -85,7 +85,7 @@ def _mk_cp(
     # Minimal fake connection
     conn = SimpleNamespace(state=State.CLOSED, close=lambda: asyncio.sleep(0))
     cp = ChargePoint("CP_A", conn, version, hass, entry, centr, chg)
-    cp._metrics[(0, csess.meter_start.value)].value = None
+    cp._metrics[(0, csess.meter_start)].value = None
     return cp
 
 
@@ -191,10 +191,10 @@ async def test_async_update_device_info_updates_metrics_and_registry(hass):
         firmware_version="1.2.3",
     )
 
-    assert cp._metrics[(0, cdet.model.value)].value == "Model X"
-    assert cp._metrics[(0, cdet.vendor.value)].value == "Acme"
-    assert cp._metrics[(0, cdet.firmware_version.value)].value == "1.2.3"
-    assert cp._metrics[(0, cdet.serial.value)].value == "SER123"
+    assert cp._metrics[(0, cdet.model)].value == "Model X"
+    assert cp._metrics[(0, cdet.vendor)].value == "Acme"
+    assert cp._metrics[(0, cdet.firmware_version)].value == "1.2.3"
+    assert cp._metrics[(0, cdet.serial)].value == "SER123"
 
     from homeassistant.helpers import device_registry
 
@@ -273,8 +273,8 @@ def test_get_energy_kwh_and_session_derive(hass):
     cp = _mk_cp(hass, version=OcppVersion.V201)  # != 1.6 to enable session derive
 
     # Starting meter (kWh)
-    cp._metrics[(1, csess.meter_start.value)].value = 10.0
-    cp._metrics[(1, csess.meter_start.value)].unit = HA_ENERGY_UNIT
+    cp._metrics[(1, csess.meter_start)].value = 10.0
+    cp._metrics[(1, csess.meter_start)].unit = HA_ENERGY_UNIT
 
     # Send EAIR in Wh (should normalize to kWh)
     mv = _mv(
@@ -287,10 +287,8 @@ def test_get_energy_kwh_and_session_derive(hass):
     assert cp._metrics[(1, "Energy.Active.Import.Register")].unit == HA_ENERGY_UNIT
 
     # Session energy derived = EAIR - meter_start
-    assert cp._metrics[(1, csess.session_energy.value)].value == pytest.approx(
-        0.5, 1e-12
-    )
-    assert cp._metrics[(1, csess.session_energy.value)].unit == HA_ENERGY_UNIT
+    assert cp._metrics[(1, csess.session_energy)].value == pytest.approx(0.5, 1e-12)
+    assert cp._metrics[(1, csess.session_energy)].unit == HA_ENERGY_UNIT
 
 
 @pytest.mark.asyncio

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -790,7 +790,7 @@ async def test_clear_profile_v16(hass, socket_enabled, cp_id, port, setup_config
         # Minimal clear: no filters -> clears any CS/CP max profiles
         await hass.services.async_call(
             OCPP_DOMAIN,
-            csvcs.service_clear_profile.value,
+            csvcs.service_clear_profile,
             service_data={"devid": cpid},
             blocking=True,
         )
@@ -1458,7 +1458,7 @@ async def test_get_diagnostics_and_data_transfer_v16(
         upload_url = "https://example.test/diag"
         await hass.services.async_call(
             OCPP_DOMAIN,
-            csvcs.service_get_diagnostics.value,
+            csvcs.service_get_diagnostics,
             service_data={"devid": cpid, "upload_url": upload_url},
             blocking=True,
         )
@@ -1469,7 +1469,7 @@ async def test_get_diagnostics_and_data_transfer_v16(
         payload = '{"hello":"world"}'
         await hass.services.async_call(
             OCPP_DOMAIN,
-            csvcs.service_data_transfer.value,
+            csvcs.service_data_transfer,
             service_data={
                 "devid": cpid,
                 "vendor_id": vendor_id,
@@ -1490,7 +1490,7 @@ async def test_get_diagnostics_and_data_transfer_v16(
         cp.accept = False
         await hass.services.async_call(
             OCPP_DOMAIN,
-            csvcs.service_data_transfer.value,
+            csvcs.service_data_transfer,
             service_data={
                 "devid": cpid,
                 "vendor_id": "VendorX",
@@ -1506,7 +1506,7 @@ async def test_get_diagnostics_and_data_transfer_v16(
         caplog.set_level(logging.WARNING)
         await hass.services.async_call(
             OCPP_DOMAIN,
-            csvcs.service_get_diagnostics.value,
+            csvcs.service_get_diagnostics,
             service_data={"devid": cpid, "upload_url": "not-a-valid-url"},
             blocking=True,
         )
@@ -1533,7 +1533,7 @@ async def test_get_diagnostics_and_data_transfer_v16(
         # Valid URL, but without FW support the handler should skip/return gracefully
         await hass.services.async_call(
             OCPP_DOMAIN,
-            csvcs.service_get_diagnostics.value,
+            csvcs.service_get_diagnostics,
             service_data={"devid": cpid, "upload_url": "https://example.com/diag2"},
             blocking=True,
         )
@@ -2903,7 +2903,7 @@ async def test_trigger_status_single_accepts(
 
             srv_cp = cs.charge_points[cp_id]
             # force single connector
-            srv_cp._metrics[0][cdet.connectors.value].value = 1
+            srv_cp._metrics[0][cdet.connectors].value = 1
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -2916,7 +2916,7 @@ async def test_trigger_status_single_accepts(
             ok = await srv_cp.trigger_status_notification()
             assert ok is True
             assert attempts == [1]
-            assert int(srv_cp._metrics[0][cdet.connectors.value].value) == 1
+            assert int(srv_cp._metrics[0][cdet.connectors].value) == 1
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -2949,7 +2949,7 @@ async def test_trigger_status_multi_all_accepts(
             await wait_ready(cs.charge_points[cp_id])
 
             srv_cp = cs.charge_points[cp_id]
-            srv_cp._metrics[0][cdet.connectors.value].value = 2
+            srv_cp._metrics[0][cdet.connectors].value = 2
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -2962,7 +2962,7 @@ async def test_trigger_status_multi_all_accepts(
             ok = await srv_cp.trigger_status_notification()
             assert ok is True
             assert attempts == [0, 1, 2]
-            assert srv_cp._metrics[0][cdet.connectors.value].value == 2
+            assert srv_cp._metrics[0][cdet.connectors].value == 2
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -2995,7 +2995,7 @@ async def test_trigger_status_reject_zero_but_accept_rest(
             await wait_ready(cs.charge_points[cp_id])
 
             srv_cp = cs.charge_points[cp_id]
-            srv_cp._metrics[0][cdet.connectors.value].value = 2
+            srv_cp._metrics[0][cdet.connectors].value = 2
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -3011,7 +3011,7 @@ async def test_trigger_status_reject_zero_but_accept_rest(
             assert ok is True
             assert attempts == [0, 1, 2]
             # should not downgrade connector count because only cid=0 rejected
-            assert int(srv_cp._metrics[0][cdet.connectors.value].value) == 2
+            assert int(srv_cp._metrics[0][cdet.connectors].value) == 2
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -3044,7 +3044,7 @@ async def test_trigger_status_reject_nonzero_adjusts_and_stops(
             await wait_ready(cs.charge_points[cp_id])
 
             srv_cp = cs.charge_points[cp_id]
-            srv_cp._metrics[0][cdet.connectors.value].value = 3
+            srv_cp._metrics[0][cdet.connectors].value = 3
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -3060,7 +3060,7 @@ async def test_trigger_status_reject_nonzero_adjusts_and_stops(
             assert ok is False
             assert attempts == [0, 1, 2]
             # reduced to cid-1 => 1
-            assert int(srv_cp._metrics[0][cdet.connectors.value].value) == 1
+            assert int(srv_cp._metrics[0][cdet.connectors].value) == 1
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -3093,7 +3093,7 @@ async def test_trigger_status_timeout_on_zero_continues(
             await wait_ready(cs.charge_points[cp_id])
 
             srv_cp = cs.charge_points[cp_id]
-            srv_cp._metrics[0][cdet.connectors.value].value = 2
+            srv_cp._metrics[0][cdet.connectors].value = 2
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -3108,7 +3108,7 @@ async def test_trigger_status_timeout_on_zero_continues(
             ok = await srv_cp.trigger_status_notification()
             assert ok is True
             assert attempts == [0, 1, 2]
-            assert int(srv_cp._metrics[0][cdet.connectors.value].value) == 2
+            assert int(srv_cp._metrics[0][cdet.connectors].value) == 2
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -3141,7 +3141,7 @@ async def test_trigger_status_timeout_on_nonzero_adjusts_and_stops(
             await wait_ready(cs.charge_points[cp_id])
 
             srv_cp = cs.charge_points[cp_id]
-            srv_cp._metrics[0][cdet.connectors.value].value = 2
+            srv_cp._metrics[0][cdet.connectors].value = 2
 
             async def fake_call(req):
                 if isinstance(req, call.TriggerMessage):
@@ -3157,7 +3157,7 @@ async def test_trigger_status_timeout_on_nonzero_adjusts_and_stops(
             assert ok is False
             # Should stop after the failing connector
             assert attempts == [0, 1, 2]
-            assert int(srv_cp._metrics[0][cdet.connectors.value].value) == 1
+            assert int(srv_cp._metrics[0][cdet.connectors].value) == 1
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -4022,10 +4022,10 @@ async def test_set_charge_rate_with_active_transaction(
             # Mock get_configuration so set_charge_rate doesn't hit srv.call for these
             async def fake_get_configuration(key: str = "") -> str:
                 # units: pretend charger supports Amps
-                if key == ckey.charging_schedule_allowed_charging_rate_unit.value:
+                if key == ckey.charging_schedule_allowed_charging_rate_unit:
                     return "A"  # same as om.current.value
                 # stack level
-                if key == ckey.charge_profile_max_stack_level.value:
+                if key == ckey.charge_profile_max_stack_level:
                     return "2"
                 return ""
 
@@ -4106,9 +4106,9 @@ async def test_set_charge_rate_exception_paths(
             srv._attr_supported_features = {prof.SMART}
 
             async def fake_get_configuration(key: str = "") -> str:
-                if key == ckey.charging_schedule_allowed_charging_rate_unit.value:
+                if key == ckey.charging_schedule_allowed_charging_rate_unit:
                     return "A"
-                if key == ckey.charge_profile_max_stack_level.value:
+                if key == ckey.charge_profile_max_stack_level:
                     return "2"
                 return ""
 
@@ -4390,7 +4390,7 @@ async def test_on_meter_values_exception_branches_are_handled(
             conn = 1
 
             # 1) Install a Metric subclass that trips the first int(...) then returns 0
-            tx_key = (conn, csess.transaction_id.value)
+            tx_key = (conn, csess.transaction_id)
             with contextlib.suppress(Exception):
                 del srv._active_tx[conn]
             srv._metrics[tx_key] = FlakyTxMetric()
@@ -4472,7 +4472,7 @@ async def test_on_meter_values_exception_branches_with_restore(
 
             with contextlib.suppress(Exception):
                 del srv._active_tx[conn]
-            srv._metrics[(conn, csess.transaction_id.value)] = FlakyTxMetric()
+            srv._metrics[(conn, csess.transaction_id)] = FlakyTxMetric()
             srv.num_connectors = BadInt()
             srv.active_transaction_id = BadInt()
 
@@ -4574,7 +4574,7 @@ async def test_change_availability_conn0_rejected_falls_back_to_conn1(
             assert conn_ids[:2] == [0, 1], f"Unexpected call order/targets: {conn_ids}"
 
             # Optionally assert that no pending marker was set for this Accepted outcome
-            m = srv._metrics.get((1, cstat.status_connector.value))
+            m = srv._metrics.get((1, cstat.status_connector))
             if m is not None:
                 assert "availability_pending" not in getattr(m, "extra_attr", {})
 
@@ -4998,7 +4998,7 @@ class ChargePoint(cpclass):
     @on(Action.get_configuration)
     def on_get_configuration(self, key, **kwargs):
         """Handle a get configuration requests."""
-        if key[0] == ckey.supported_feature_profiles.value:
+        if key[0] == ckey.supported_feature_profiles:
             if self.accept is True:
                 return call_result.GetConfiguration(
                     configuration_key=[
@@ -5012,17 +5012,17 @@ class ChargePoint(cpclass):
             else:
                 # use to test TypeError handling
                 return call_result.GetConfiguration(unknown_key=[key[0]])
-        if key[0] == ckey.heartbeat_interval.value:
+        if key[0] == ckey.heartbeat_interval:
             return call_result.GetConfiguration(
                 configuration_key=[{"key": key[0], "readonly": False, "value": "300"}]
             )
-        if key[0] == ckey.number_of_connectors.value:
+        if key[0] == ckey.number_of_connectors:
             return call_result.GetConfiguration(
                 configuration_key=[
                     {"key": key[0], "readonly": False, "value": f"{self.no_connectors}"}
                 ]
             )
-        if key[0] == ckey.web_socket_ping_interval.value:
+        if key[0] == ckey.web_socket_ping_interval:
             if self.accept is True:
                 return call_result.GetConfiguration(
                     configuration_key=[
@@ -5031,7 +5031,7 @@ class ChargePoint(cpclass):
                 )
             else:
                 return call_result.GetConfiguration(unknown_key=[key[0]])
-        if key[0] == ckey.meter_values_sampled_data.value:
+        if key[0] == ckey.meter_values_sampled_data:
             if self.accept is True:
                 return call_result.GetConfiguration(
                     configuration_key=[
@@ -5044,7 +5044,7 @@ class ChargePoint(cpclass):
                 )
             else:
                 pass
-        if key[0] == ckey.meter_value_sample_interval.value:
+        if key[0] == ckey.meter_value_sample_interval:
             if self.accept is True:
                 return call_result.GetConfiguration(
                     configuration_key=[
@@ -5055,7 +5055,7 @@ class ChargePoint(cpclass):
                 return call_result.GetConfiguration(
                     configuration_key=[{"key": key[0], "readonly": True, "value": "60"}]
                 )
-        if key[0] == ckey.charging_schedule_allowed_charging_rate_unit.value:
+        if key[0] == ckey.charging_schedule_allowed_charging_rate_unit:
             if self.accept is True:
                 return call_result.GetConfiguration(
                     configuration_key=[
@@ -5064,7 +5064,7 @@ class ChargePoint(cpclass):
                 )
             else:
                 return call_result.GetConfiguration(unknown_key=[key[0]])
-        if key[0] == ckey.authorize_remote_tx_requests.value:
+        if key[0] == ckey.authorize_remote_tx_requests:
             if self.accept is True:
                 return call_result.GetConfiguration(
                     configuration_key=[
@@ -5073,7 +5073,7 @@ class ChargePoint(cpclass):
                 )
             else:
                 return call_result.GetConfiguration(unknown_key=[key[0]])
-        if key[0] == ckey.charge_profile_max_stack_level.value:
+        if key[0] == ckey.charge_profile_max_stack_level:
             return call_result.GetConfiguration(
                 configuration_key=[{"key": key[0], "readonly": False, "value": "3"}]
             )
@@ -5085,7 +5085,7 @@ class ChargePoint(cpclass):
     def on_change_configuration(self, key, **kwargs):
         """Handle a get configuration request."""
         if self.accept is True:
-            if key == ckey.meter_values_sampled_data.value:
+            if key == ckey.meter_values_sampled_data:
                 return call_result.ChangeConfiguration(
                     ConfigurationStatus.reboot_required
                 )

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -421,9 +421,9 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
         "id_token": cs.charge_points[cs.cpids[cpid]]._remote_id_tag,
         "type": IdTokenEnumType.central.value,
     }
-    while cs.get_metric(cpid, csess.transaction_id.value) is None:
+    while cs.get_metric(cpid, csess.transaction_id) is None:
         await asyncio.sleep(0.1)
-    assert cs.get_metric(cpid, csess.transaction_id.value) == cp.remote_start_tx_id
+    assert cs.get_metric(cpid, csess.transaction_id) == cp.remote_start_tx_id
 
     tx_start_time = cp.tx_start_time
     await cp.call(
@@ -431,10 +431,7 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
             tx_start_time.isoformat(), ConnectorStatusEnumType.occupied, 1, 1
         )
     )
-    assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
-        == ChargePointStatusv16.preparing
-    )
+    assert cs.get_metric(cpid, cstat.status_connector) == ChargePointStatusv16.preparing
 
     await cp.call(
         call.TransactionEvent(
@@ -603,10 +600,7 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
             ],
         )
     )
-    assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
-        == ChargePointStatusv16.charging
-    )
+    assert cs.get_metric(cpid, cstat.status_connector) == ChargePointStatusv16.charging
     assert cs.get_metric(cpid, Measurand.current_export.value) == 0
     assert cs.get_metric(cpid, Measurand.current_import.value) == pytest.approx(2.2)
     assert cs.get_metric(cpid, Measurand.current_offered.value) == pytest.approx(12.2)
@@ -718,10 +712,7 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
             ],
         )
     )
-    assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
-        == ChargePointStatusv16.preparing
-    )
+    assert cs.get_metric(cpid, cstat.status_connector) == ChargePointStatusv16.preparing
     await cp.call(
         call.TransactionEvent(
             TransactionEventEnumType.updated.value,
@@ -761,8 +752,7 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
         )
     )
     assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
-        == ChargePointStatusv16.suspended_ev
+        cs.get_metric(cpid, cstat.status_connector) == ChargePointStatusv16.suspended_ev
     )
 
     await cp.call(
@@ -778,7 +768,7 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
         )
     )
     assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
+        cs.get_metric(cpid, cstat.status_connector)
         == ChargePointStatusv16.suspended_evse
     )
 
@@ -795,10 +785,7 @@ async def _test_transaction(hass: HomeAssistant, cs: CentralSystem, cp: ChargePo
             },
         )
     )
-    assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
-        == ChargePointStatusv16.available
-    )
+    assert cs.get_metric(cpid, cstat.status_connector) == ChargePointStatusv16.available
 
 
 async def _set_variable(
@@ -1072,23 +1059,23 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
     # Checking only the reply let a metric-less handler pass for the bug's
     # whole life: the sensor's backing metric must hold the same instant
     # the charger was told.
-    assert cs.get_metric(cpid, cstat.heartbeat.value) == heartbeat_time
+    assert cs.get_metric(cpid, cstat.heartbeat) == heartbeat_time
 
     await wait_ready(cs.charge_points[cp_id])
 
     # Junk report to be ignored
     await cp.call(call.NotifyReport(2, datetime.now(tz=UTC).isoformat(), 0))
 
-    assert cs.get_metric(cpid, cdet.serial.value, connector_id=0) == "SERIAL"
-    assert cs.get_metric(cpid, cdet.model.value, connector_id=0) == "MODEL"
-    assert cs.get_metric(cpid, cdet.vendor.value, connector_id=0) == "VENDOR"
-    assert cs.get_metric(cpid, cdet.firmware_version.value, connector_id=0) == "VERSION"
+    assert cs.get_metric(cpid, cdet.serial, connector_id=0) == "SERIAL"
+    assert cs.get_metric(cpid, cdet.model, connector_id=0) == "MODEL"
+    assert cs.get_metric(cpid, cdet.vendor, connector_id=0) == "VENDOR"
+    assert cs.get_metric(cpid, cdet.firmware_version, connector_id=0) == "VERSION"
     assert (
-        cs.get_metric(cpid, cdet.features.value, connector_id=0)
+        cs.get_metric(cpid, cdet.features, connector_id=0)
         == Profiles.CORE | Profiles.SMART | Profiles.RES | Profiles.AUTH
     )
     assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
+        cs.get_metric(cpid, cstat.status_connector)
         == ConnectorStatusEnumType.available.value
     )
     # The station-level notification landed on the charger-level Status metric
@@ -1096,14 +1083,14 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
     # switch reads) and did not overwrite the connector's own status above.
     server_cp = cs.charge_points[cp_id]
     assert (
-        server_cp._metrics[(0, cstat.status.value)].value
+        server_cp._metrics[(0, cstat.status)].value
         == ConnectorStatusEnumType.unavailable.value
     )
     # (0, Status.Connector) stays owned by the EVSE aggregation - a
     # station-level 'Unavailable' written there would mask the connector's real
     # state through the flattened sensor's fallback chain.
     assert (
-        server_cp._metrics[(0, cstat.status_connector.value)].value
+        server_cp._metrics[(0, cstat.status_connector)].value
         != ConnectorStatusEnumType.unavailable.value
     )
     assert cp.tx_updated_interval == DEFAULT_METER_INTERVAL
@@ -1139,7 +1126,7 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
         )
     )
     assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
+        cs.get_metric(cpid, cstat.status_connector)
         == ConnectorStatusEnumType.unavailable.value
     )
 
@@ -1149,7 +1136,7 @@ async def _run_test(hass: HomeAssistant, cs: CentralSystem, cp: ChargePoint):
         )
     )
     assert (
-        cs.get_metric(cpid, cstat.status_connector.value)
+        cs.get_metric(cpid, cstat.status_connector)
         == ConnectorStatusEnumType.faulted.value
     )
 
@@ -1200,7 +1187,7 @@ async def _extra_features_test(
     await wait_ready(cs.charge_points[cp_id])
 
     assert (
-        cs.get_metric(cpid, cdet.features.value, connector_id=0)
+        cs.get_metric(cpid, cdet.features, connector_id=0)
         == Profiles.CORE
         | Profiles.SMART
         | Profiles.RES
@@ -1298,7 +1285,7 @@ async def _unsupported_base_report_test(
     # test charger enables (tests/const.py). Before the override was honoured
     # on 2.0.1 this expectation omitted SMART.
     assert (
-        cs.get_metric(cpid, cdet.features.value, connector_id=0)
+        cs.get_metric(cpid, cdet.features, connector_id=0)
         == Profiles.CORE | Profiles.REM | Profiles.FW | Profiles.SMART
     )
 
@@ -1312,7 +1299,7 @@ async def _unsupported_base_report_test(
     # repair (issue #2008 companion). See get_number_of_connectors in ocppv201.
     server_cp = cs.charge_points[cp_id]
     assert server_cp.num_connectors >= 1
-    assert server_cp._metrics[(1, csess.session_time.value)].unit == UnitOfTime.MINUTES
+    assert server_cp._metrics[(1, csess.session_time)].unit == UnitOfTime.MINUTES
 
     # Creating the connector slots is only half the job: a StatusNotification
     # must still be routable to them. A GetBaseReport answered with a CallError
@@ -1328,7 +1315,7 @@ async def _unsupported_base_report_test(
         )
     )
     while (
-        cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
+        cs.get_metric(cpid, cstat.status_connector, connector_id=1)
         != ChargePointStatusv16.preparing.value
     ):
         await asyncio.sleep(0.1)
@@ -1383,14 +1370,14 @@ async def _incomplete_inventory_test(
     # Inventory reported zero connectors -> normalised to the topology
     # observed in the buffered StatusNotification: one real connector.
     assert server_cp.num_connectors == 1
-    assert server_cp._metrics[(1, csess.session_time.value)].unit == UnitOfTime.MINUTES
+    assert server_cp._metrics[(1, csess.session_time)].unit == UnitOfTime.MINUTES
     # The buffered StatusNotification must be applied once the fallback
     # connector map is built - not held in _pending_status_notifications -
     # and must land on global connector 1, i.e. the map must reflect the
     # charger's real (evse_id, connector_id) pair rather than an assumed
     # (1, 1).
     while (
-        cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
+        cs.get_metric(cpid, cstat.status_connector, connector_id=1)
         != ChargePointStatusv16.preparing.value
     ):
         await asyncio.sleep(0.1)
@@ -1402,7 +1389,7 @@ async def _incomplete_inventory_test(
     # owned by the EVSE aggregation and would mask the connector's state via
     # the flattened sensor's fallback chain.
     assert (
-        server_cp._metrics[(0, cstat.status.value)].value
+        server_cp._metrics[(0, cstat.status)].value
         == ConnectorStatusEnumType.available.value
     )
 
@@ -1451,7 +1438,7 @@ async def _incomplete_inventory_late_evidence_test(
         )
     )
     while (
-        cs.get_metric(cpid, cstat.status_connector.value, connector_id=1)
+        cs.get_metric(cpid, cstat.status_connector, connector_id=1)
         != ChargePointStatusv16.preparing.value
     ):
         await asyncio.sleep(0.1)

--- a/tests/test_sensor_stale_cleanup.py
+++ b/tests/test_sensor_stale_cleanup.py
@@ -63,7 +63,7 @@ async def test_setup_removes_the_stale_flat_entity_and_logs_it(
     stale = registry.async_get_or_create(
         "sensor",
         DOMAIN,
-        sensor_unique_id(cpid, cstat.status_connector.value),
+        sensor_unique_id(cpid, cstat.status_connector),
         suggested_object_id=f"{cpid}_status_connector_renamed",
     )
 
@@ -109,7 +109,7 @@ async def test_single_connector_setup_removes_nothing(hass, bypass_websockets, c
     live = registry.async_get_or_create(
         "sensor",
         DOMAIN,
-        sensor_unique_id("test_cpid", cstat.status_connector.value),
+        sensor_unique_id("test_cpid", cstat.status_connector),
         suggested_object_id="test_cpid_status_connector",
     )
 

--- a/tests/test_set_charge_rate_v16.py
+++ b/tests/test_set_charge_rate_v16.py
@@ -133,9 +133,9 @@ async def test_cpmax_exception_falls_back_to_txdefault_accepted_returns_true(
 
     # Allow both A and stack level
     async def fake_get_conf(key: str):
-        if key == ckey.charging_schedule_allowed_charging_rate_unit.value:
+        if key == ckey.charging_schedule_allowed_charging_rate_unit:
             return "Current"  # supports Amps
-        if key == ckey.charge_profile_max_stack_level.value:
+        if key == ckey.charge_profile_max_stack_level:
             return "2"
         pytest.fail(f"Unexpected get_configuration key: {key}")
 
@@ -169,9 +169,9 @@ async def test_cpmax_rejected_txdefault_accepted_returns_true(cp_v16, monkeypatc
     """4) CPMax rejected -> TxDefault accepted -> return True."""
 
     async def fake_get_conf(key: str):
-        if key == ckey.charging_schedule_allowed_charging_rate_unit.value:
+        if key == ckey.charging_schedule_allowed_charging_rate_unit:
             return "Current"
-        if key == ckey.charge_profile_max_stack_level.value:
+        if key == ckey.charge_profile_max_stack_level:
             return "3"
         pytest.fail(f"Unexpected get_configuration key: {key}")
 
@@ -214,18 +214,18 @@ def test_allowed_charging_rate_units_tokens():
 
 def _schedule_limit(req):
     profile = req.cs_charging_profiles
-    schedule = profile[om.charging_schedule.value]
-    period = schedule[om.charging_schedule_period.value][0]
-    return schedule[om.charging_rate_unit.value], period[om.limit.value]
+    schedule = profile[om.charging_schedule]
+    period = schedule[om.charging_schedule_period][0]
+    return schedule[om.charging_rate_unit], period[om.limit]
 
 
 async def _accept_first_profile(cp, monkeypatch, units: str):
     captured = []
 
     async def fake_get_conf(key: str):
-        if key == ckey.charging_schedule_allowed_charging_rate_unit.value:
+        if key == ckey.charging_schedule_allowed_charging_rate_unit:
             return units
-        if key == ckey.charge_profile_max_stack_level.value:
+        if key == ckey.charge_profile_max_stack_level:
             return "1"
         pytest.fail(f"Unexpected get_configuration key: {key}")
 

--- a/tests/test_v201_connector_charge_state.py
+++ b/tests/test_v201_connector_charge_state.py
@@ -89,11 +89,11 @@ def _mk_cp(hass):
 
 
 def _connector_status(cp, global_idx: int = 1):
-    return cp._metrics[(global_idx, cstat.status_connector.value)].value
+    return cp._metrics[(global_idx, cstat.status_connector)].value
 
 
 def _station_status(cp):
-    return cp._metrics[(0, cstat.status_connector.value)].value
+    return cp._metrics[(0, cstat.status_connector)].value
 
 
 def _tx_event(cp, charging_state: ChargingStateEnumType, connector_id: int = 1):
@@ -250,7 +250,7 @@ async def test_a_transaction_event_for_connector_zero_is_not_mapped(hass):
 
     assert dict(cp._evse_to_global) == before
     assert cp._tx_start_time == {}
-    assert cp._metrics[(1, csess.transaction_id.value)].value is None
+    assert cp._metrics[(1, csess.transaction_id)].value is None
     assert _connector_status(cp) is None
     # the charging state is still station-level news
     assert _station_status(cp) == ChargePointStatusv16.charging.value

--- a/tests/test_v201_connector_floor.py
+++ b/tests/test_v201_connector_floor.py
@@ -87,7 +87,7 @@ async def test_silent_charger_still_gets_the_floor(hass):
 
     assert total == 1
     assert cp._pending_status_notifications == []
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._metrics[(1, cstat.status_connector)].value == "Available"
 
 
 @pytest.mark.asyncio
@@ -149,8 +149,8 @@ async def test_second_post_connect_during_slow_inventory_does_not_poison_map(has
     cp._flush_pending_status_notifications()
 
     assert cp._evse_to_global == {(1, 1): 1, (2, 1): 2}
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
-    assert cp._metrics[(2, cstat.status_connector.value)].value == "Faulted"
+    assert cp._metrics[(1, cstat.status_connector)].value == "Available"
+    assert cp._metrics[(2, cstat.status_connector)].value == "Faulted"
 
 
 @pytest.mark.asyncio
@@ -203,7 +203,7 @@ async def test_status_buffered_during_refetch_is_drained_when_it_times_out(hass)
     assert cp._pending_status_notifications == [], (
         "settling the attempt must drain the buffer"
     )
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._metrics[(1, cstat.status_connector)].value == "Available"
     assert cp._evse_to_global == {(1, 2): 1}
     await asyncio.sleep(0)  # let the scheduled update task run
     assert updates, (
@@ -221,7 +221,7 @@ async def test_status_buffered_during_refetch_is_drained_when_it_times_out(hass)
     assert cp._pending_status_notifications == []
     # The per-connector metric speaks the OCPP 1.6 vocabulary, as the
     # charging-station-level one already did: Occupied maps to Preparing.
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Preparing"
+    assert cp._metrics[(1, cstat.status_connector)].value == "Preparing"
 
 
 @pytest.mark.asyncio
@@ -293,7 +293,7 @@ async def test_partial_topology_timeout_still_drains_buffered_statuses(hass):
     assert cp._pending_status_notifications == [], (
         "the drain must not live only in the zero-connector fallback"
     )
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._metrics[(1, cstat.status_connector)].value == "Available"
     assert cp._evse_to_global == {(1, 1): 1, (1, 2): 2}
 
 
@@ -361,7 +361,7 @@ async def test_failed_attempt_releases_ownership_for_the_next_one(hass):
         "even a failed attempt must drain on its way out - on a persistently "
         "failing charger the next attempt would strand these again"
     )
-    assert cp._metrics[(1, cstat.status_connector.value)].value == "Available"
+    assert cp._metrics[(1, cstat.status_connector)].value == "Available"
 
     total = await cp.get_number_of_connectors()
 

--- a/tests/test_v201_heartbeat_metric.py
+++ b/tests/test_v201_heartbeat_metric.py
@@ -111,7 +111,7 @@ async def test_a_heartbeat_writes_the_metric(hass):
     """The sensor's backing metric must move when the charger beats."""
     cp = _mk_cp(hass)
     stale = datetime(2026, 8, 8, 0, 41, 40, tzinfo=UTC)
-    cp._metrics[(0, cstat.heartbeat.value)].value = stale
+    cp._metrics[(0, cstat.heartbeat)].value = stale
 
     before = datetime.now(tz=UTC)
     with patch.object(ChargePoint, "update", AsyncMock()):
@@ -119,7 +119,7 @@ async def test_a_heartbeat_writes_the_metric(hass):
         await hass.async_block_till_done()
     after = datetime.now(tz=UTC)
 
-    recorded = cp._metrics[(0, cstat.heartbeat.value)].value
+    recorded = cp._metrics[(0, cstat.heartbeat)].value
     assert recorded != stale
     # Bounded by the test's own clock reads - no wall-clock window to flake.
     assert before <= recorded <= after
@@ -134,7 +134,7 @@ async def test_the_reply_and_the_metric_agree(hass):
         result = cp.on_heartbeat()
         await hass.async_block_till_done()
 
-    recorded = cp._metrics[(0, cstat.heartbeat.value)].value
+    recorded = cp._metrics[(0, cstat.heartbeat)].value
     assert result.current_time == recorded.isoformat()
 
 
@@ -160,7 +160,7 @@ def _register_metric_sensor(hass, metric, cpid="test_cpid", suffix="renamed"):
 
 def _register_heartbeat_sensor(hass, cpid="test_cpid"):
     """Register the heartbeat sensor under a deliberately renamed id."""
-    return _register_metric_sensor(hass, cstat.heartbeat.value, cpid, "pulse")
+    return _register_metric_sensor(hass, cstat.heartbeat, cpid, "pulse")
 
 
 def _capture_dispatches(hass):
@@ -220,7 +220,7 @@ async def test_the_v16_handler_refreshes_the_same_way(hass):
 
     update.assert_not_awaited()
     assert seen == [({entity_id},)]
-    assert cp16._metrics[0][cstat.heartbeat.value].value is not None
+    assert cp16._metrics[0][cstat.heartbeat].value is not None
 
 
 @pytest.mark.asyncio
@@ -285,8 +285,8 @@ async def test_the_ping_loop_publishes_the_latency_sensors(hass, monkeypatch):
     pushes exactly the two entities it wrote.
     """
     cp = _mk_cp(hass)
-    eid_ping = _register_metric_sensor(hass, cstat.latency_ping.value)
-    eid_pong = _register_metric_sensor(hass, cstat.latency_pong.value)
+    eid_ping = _register_metric_sensor(hass, cstat.latency_ping)
+    eid_pong = _register_metric_sensor(hass, cstat.latency_pong)
     seen = _capture_dispatches(hass)
 
     with patch.object(ChargePoint, "update", AsyncMock()) as update:
@@ -306,8 +306,8 @@ async def test_a_ping_timeout_also_publishes_the_latency_sensors(hass, monkeypat
     the latency sensors, so the degraded reading matters most.
     """
     cp = _mk_cp(hass)
-    eid_ping = _register_metric_sensor(hass, cstat.latency_ping.value)
-    eid_pong = _register_metric_sensor(hass, cstat.latency_pong.value)
+    eid_ping = _register_metric_sensor(hass, cstat.latency_ping)
+    eid_pong = _register_metric_sensor(hass, cstat.latency_pong)
     seen = _capture_dispatches(hass)
 
     with patch.object(ChargePoint, "update", AsyncMock()) as update:
@@ -350,7 +350,7 @@ async def test_a_partially_registered_pair_dispatches_what_resolved(hass, monkey
     platforms add entities; the resolved one still deserves its refresh.
     """
     cp = _mk_cp(hass)
-    eid_ping = _register_metric_sensor(hass, cstat.latency_ping.value)
+    eid_ping = _register_metric_sensor(hass, cstat.latency_ping)
     seen = _capture_dispatches(hass)
 
     with patch.object(ChargePoint, "update", AsyncMock()) as update:

--- a/tests/test_v201_probe_timeout.py
+++ b/tests/test_v201_probe_timeout.py
@@ -145,7 +145,7 @@ async def test_the_feature_metric_is_still_written(hass):
 
     await cp.fetch_supported_features()
 
-    assert cp._attr_supported_features == cp._metrics[(0, cdet.features.value)].value
+    assert cp._attr_supported_features == cp._metrics[(0, cdet.features)].value
     assert Profiles.SMART in cp._attr_supported_features
 
 

--- a/tests/test_v201_station_status.py
+++ b/tests/test_v201_station_status.py
@@ -81,7 +81,7 @@ async def test_station_level_status_applies_without_a_connector_map(hass):
     )
 
     assert cp._pending_status_notifications == []
-    assert cp._metrics[(0, cstat.status.value)].value == "Available"
+    assert cp._metrics[(0, cstat.status)].value == "Available"
 
 
 @pytest.mark.asyncio
@@ -106,5 +106,5 @@ async def test_malformed_ids_are_dropped_not_crashed_or_misattributed(
     )
 
     assert cp._pending_status_notifications == []
-    assert cp._metrics[(0, cstat.status.value)].value is None
+    assert cp._metrics[(0, cstat.status)].value is None
     assert cp._connector_status == []


### PR DESCRIPTION
## Summary

Follow-up to #2078, as requested: converts the seven `class X(str, Enum)`
declarations to `enum.StrEnum`, drops the `UP042` suppression that was holding
them in place, and then removes the 320 `.value` accesses that the conversion
makes redundant.

Ruff 0.16 flagged these once #2078 made the hooks actually run the pinned
version. Migrating them changes `__str__` and `__format__` for members that are
compared and serialised as strings across the integration, which was too broad
to fold into a routing fix — so it went into `lint.ignore` with a comment saying
it needed its own PR. This is that PR.

Two commits, reviewable separately: the base-class swap, then the `.value`
cleanup.

## 1. Migrate to `StrEnum`

**`custom_components/ocpp/enums.py`** — six classes now inherit `StrEnum`:
`HAChargerServices`, `HAChargerStatuses`, `HAChargerDetails`,
`HAChargerSession`, `OcppMisc`, `ConfigurationKey`. `Profiles` is an `IntFlag`
and is untouched.

**`custom_components/ocpp/chargepoint.py`** — `OcppVersion` now inherits
`StrEnum`. `SetVariableResult` is a plain `Enum` and is untouched.

**`.ruff.toml`** — the `UP042` entry and its four-line explanatory comment come
out of `lint.ignore`.

Three files, +9 / −13.

## 2. Drop the redundant `.value`

With the classes converted, `Member` and `Member.value` are interchangeable, so
the explicit accesses no longer carry meaning. All 320 are gone — 209 in
`custom_components/`, 111 in `tests/`. 19 files, +315 / −353.

This was done with an AST transform rather than a regex. For each
`X.member.value` the base is resolved through the module's import aliases
(`csvcs`, `cstat`, `cdet`, `csess`, `om`, `ckey`) and the member checked against
`__members__`, so only members of the seven converted classes are touched. Every
rewritten file is then asserted to parse to the same tree as the original with
exactly those nodes replaced, which fails loudly on a miss or an overreach.

Deliberately left alone:

- **The ocpp library's own enums.** `ChargingProfileKindType.relative.value`
  survives on lines whose neighbouring `OcppMisc` key was stripped — different
  class, and not a `StrEnum`.
- **`Metric.value`.** In `self._metrics[0][cdet.data_response].value` the inner
  enum access is stripped and the outer attribute kept.
- The 30 `.name` accesses, and `Profiles`.

## Why this is not a breaking change

A `StrEnum` member and its value are equal, hash equal, and both satisfy
`isinstance(x, str)`. `str()`, f-strings, `%s` and `+` all yield the value —
which is exactly what changes versus `(str, Enum)`, where those returned
`ClassName.member_name`.

`repr()` is the sole remaining difference. An AST scan finds **zero** `repr()`,
`!r` and `%r` sites in `custom_components/` and `tests/`. There are likewise no
`type(x) is str` and no `isinstance(x, Enum)` checks anywhere; the only
`isinstance(..., str)` uses are in `api.py`, which a `StrEnum` satisfies.

`_ConnectorAwareMetrics` dispatches on `isinstance(key, tuple)` /
`isinstance(key, int)`, so an enum key takes the same branch a plain string
does. Cross-referencing the 131 uncovered lines against enum usage turned up
exactly one — a `_metrics` lookup in `ocppv201.py` — which that dispatch covers.

The dicts in `ocppv16.py` that become wire payloads were checked end to end: a
`SetChargingProfile` built with enum keys and one built with `.value` keys
serialise to byte-identical JSON, and both pass the library's OCPP 1.6
jsonschema validation.

## Python version

`enum.StrEnum` requires Python 3.11. The integration already requires 3.11 or
newer — `datetime.UTC` is used in both `ocppv16.py` and `ocppv201.py`, and the
ruff target is `py312`. This introduces no new floor.

## Verification

```bash
pytest --cov=./ --cov-report=term --timeout=30 -n auto -p no:sugar tests
pre-commit run --all-files
```

314 passed, 0 failures. pyupgrade, `ruff check` and `ruff format` all pass, with
`UP042` now active.

Coverage is byte-identical to `main` — 3394 statements, 131 missed, 96.14%
before and after, with the same per-file breakdown. Expected: neither commit
adds or removes a statement.

## Checklist

- [x] Branched from `main`
- [x] Documentation updated — no change needed; nothing under `docs/` or in
      `README.md` references these declarations
- [x] Code lints — `pre-commit run --all-files` clean
- [x] Tested — full suite green, coverage unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal string-based enumerations to use the modern standard representation.
  * Preserved existing enum values and behavior for charging sessions, statuses, services, configuration, and OCPP-related settings.

* **Chores**
  * Updated code-quality checks to enforce the modern enum style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->