### PR TITLE
Tidy the docs-to-wiki publishing workflow

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -6,33 +6,102 @@ on:
       - docs/**
     branches:
       - main
-      
+
+# Least privilege for the default token: this job only reads the repo.
+# The wiki push uses WIKI_ACTION_TOKEN, a separate credential.
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-publish
+  cancel-in-progress: false
+
 env:
-  USER_TOKEN: ${{ secrets.WIKI_ACTION_TOKEN }}
   USER_NAME: ocpp
   USER_EMAIL: ocpp@lbbrhzn.nl
-  OWNER: ${{ github.event.repository.owner.name }}
-  REPOSITORY_NAME: ${{ github.event.repository.name }}
 
 jobs:
   publish_docs_to_wiki:
     runs-on: ubuntu-latest
-    steps:  
+    timeout-minutes: 10
+    steps:
     - uses: actions/checkout@v7
+      with:
+        # Nothing here pushes to the main repo; do not leave the default
+        # token in the checkout's git config.
+        persist-credentials: false
 
-    - name: Pull wiki
+    - name: Stage wiki content
       run: |
-         mkdir tmp_wiki
-         cd tmp_wiki
-         git init
-         git config user.name $USER_NAME
-         git config user.email $USER_EMAIL
-         git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
+        # Build the new page set BEFORE the live mirror is touched, so a
+        # copy that fails partway leaves the wiki as it was instead of
+        # publishing half a mirror. xargs propagates such a failure;
+        # find -exec cp ... \; would not - find exits 0 however many
+        # invocations failed.
+        #
+        # -type f is load-bearing, not cosmetic: it copies regular files
+        # only. A symlink under docs/ pointing at the wiki clone's
+        # .git/config would otherwise be dereferenced into a page and
+        # publish the wiki token.
+        #
+        # Only the Markdown pages belong in the wiki. docs/ also carries
+        # the Sphinx machinery for Read the Docs (conf.py, Makefile,
+        # index.rst, requirements.txt) and its own README, which describes
+        # the folder rather than the wiki.
+        mkdir wiki_staging
+        find docs -maxdepth 1 -type f -name '*.md' ! -name 'README.md' -print0 \
+          | xargs -0 -I PAGE cp -- PAGE wiki_staging/
+        # The wiki front page must be among them, or something is wrong.
+        test -f wiki_staging/Home.md
 
-    - name: Push wiki
+    - name: Publish to wiki
+      env:
+        WIKI_TOKEN: ${{ secrets.WIKI_ACTION_TOKEN }}
       run: |
-        rsync -av --delete docs/ tmp_wiki/ --exclude .git
+        # Transport is retried a few times: a transient failure here used
+        # to leave the wiki stale until the next docs commit. Errors are
+        # not classified - matching git stderr is fragile, and a retried
+        # auth failure just fails three times a few seconds apart. The
+        # backoff carries jitter because a GitHub-wide incident fails
+        # every repository's workflows at once: without it they would all
+        # retry on the same 10s and 20s beat and hit the recovering
+        # service together. (The concurrency group above only serialises
+        # this repository's own runs.)
+        retry() {
+          label="$1"; shift
+          attempt=1
+          until "$@"; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "$label failed after $attempt attempts" >&2
+              return 1
+            fi
+            delay=$((attempt * 10 + RANDOM % 10))
+            echo "$label failed (attempt $attempt), retrying in ${delay}s" >&2
+            sleep "$delay"
+            attempt=$((attempt + 1))
+          done
+        }
+
+        WIKI_URL="https://${WIKI_TOKEN}@github.com/${{ github.repository }}.wiki.git"
+        # Nothing below echoes the command: the URL carries the token.
+        clone_wiki() {
+          rm -rf tmp_wiki
+          git clone --quiet "$WIKI_URL" tmp_wiki
+        }
+        retry "wiki clone" clone_wiki
+
+        # Replace the mirror's contents wholesale, keeping .git: a page
+        # deleted from docs/ has to disappear from the wiki too.
+        find tmp_wiki -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+        mv wiki_staging/*.md tmp_wiki/
+
         cd tmp_wiki
+        git config user.name "$USER_NAME"
+        git config user.email "$USER_EMAIL"
         git add .
+        if git diff --cached --quiet; then
+          echo "Wiki already up to date - nothing to publish"
+          exit 0
+        fi
         git commit -m "Update Wiki content"
-        git push -f --set-upstream https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git master
+        retry "wiki push" git push

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,6 +12,7 @@ Contents
 <!-- links within the wiki should not use a file extension! -->
 * [Installation](installation)
 * [Supported devices](supported-devices)
+* [Multiple central systems](multiple-central-systems)
 * [User guide](user-guide)
 * [Support](support)
 * [Development](development)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Contents
 ========
 * [Installation](installation.md)
 * [Supported devices](supported-devices.md)
+* [Multiple central systems](multiple-central-systems.md)
 * [User guide](user-guide.md)
 * [Support](support.md)
 * [Development](development.md)


### PR DESCRIPTION
Picking up the "could still do with a bit of a tidy up" from #2091, now that the token side is fixed.

## The mirror was carrying the Sphinx machinery

The workflow rsynced `docs/` into the wiki verbatim with only `.git` excluded, so the wiki also held `Makefile`, `conf.py`, `index.rst`, `requirements.txt` and the folder's own `README.md`. It now publishes only the Markdown pages (minus `README.md`, which describes the `docs/` folder rather than the wiki); the first run after merge purges what was mirrored before, because the sync still has whole-tree delete semantics.

## Publishing is now staged, which fixes a silent failure mode

The new page set is built and checked **before** the live mirror is touched, so a copy that fails partway leaves the wiki exactly as it was.

The copy also moved from `find -exec cp ... \;` to `xargs`, because **`find` exits 0 however many `-exec` invocations failed** (verified locally: replacing `cp` with `false` for every file still exits 0). Under the old form, one unreadable page would have been committed as a page *deletion* and the run would have reported success. A missing `Home.md` now aborts for the same reason.

## Security

The copy is `find -type f`, which is load-bearing rather than cosmetic: a symlink under `docs/` pointing at the wiki clone's `.git/config` is dereferenced by a plain `cp docs/*.md` and publishes `WIKI_ACTION_TOKEN` as a wiki page. I reproduced that before fixing it. Also added `permissions: contents: read`, `persist-credentials: false` on checkout, and a job timeout.

A `workflow_dispatch` trigger was considered and **rejected**: it would let anyone with write access run their own branch's workflow with the repository token, and a ref check inside the workflow can't help when the branch controls that file. Push-to-main stays the only trigger, as before — a manual resync is a re-run of the last run, which is how you applied the token fix.

Two things deliberately left for you, since they need repo-admin rights or are judgement calls:
- Scoping `WIKI_ACTION_TOKEN` to a `main`-restricted environment is the belt-and-braces version if `workflow_dispatch` is ever wanted back.
- The token stays in the clone URL rather than an `http.extraheader`: after the `-type f` fix it is unreachable by the publish copy, and the base64 extraheader form is **not** auto-masked in logs, which would be a worse exposure on error.

## Robustness

Clone and push retry three times with jittered backoff — a transient failure previously left the wiki stale until the next docs commit. Jitter because a GitHub-wide incident fails every repository's workflows at once and they would otherwise all retry on the same beat; the concurrency group only serialises this repo's own runs. Errors are not classified: matching git stderr is fragile, and a retried auth failure just fails three times seconds apart.

## Navigation drift the blind mirror was hiding

The wiki Home page and `docs/README.md` were both missing `multiple-central-systems`, which has been on Read the Docs since it merged. Added to both.

## Verification

The shell was extracted from this workflow file and run end to end against a real local git remote seeded with the wiki's current (untidy) state: pages synced, content updated, Sphinx files and README purged, a page deleted from `docs/` removed from the wiki, a symlink attack not published, `.git` intact, unchanged docs a clean no-op, an unreadable page aborting before the mirror is touched, the `Home.md` gate firing, and the retry loop exercised for real (two jittered sleeps, then a clean failure). The push leg against GitHub itself can only be proven by the first docs merge after this lands.

## Also worth knowing

`docs/Charge_automation.md` is published but linked from no contents page, and its three YAML examples are malformed (sibling-indented sensor fields, a broken block scalar, an unterminated quote) — a user copying them gets a config that fails validation. Deliberately not touched here: it wants a content PR that fixes and links it together, rather than this one advertising broken config. Happy to do that separately if you'd like.

Refs #2091.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Multiple central systems” to the documentation table of contents.
  * Improved consistency between documentation navigation pages.

* **Chores**
  * Updated documentation publishing to include only relevant Markdown pages.
  * Added safer publishing behavior, including validation, retries, and skipping unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->