### PR TITLE
docs: fix the charge automation examples and link the page

### DIFF
--- a/docs/Charge_automation.md
+++ b/docs/Charge_automation.md
@@ -1,4 +1,4 @@
-## Dynamically Adjusting EV Charge Current: A Smart Approach
+# Dynamically Adjusting EV Charge Current: A Smart Approach
 
 Dynamically adjusting the charge current of an electric vehicle (EV) within a home automation system offers significant advantages:
 
@@ -11,98 +11,320 @@ Dynamically adjusting the charge current of an electric vehicle (EV) within a ho
 * **Demand Response:**
     * When you have dynamic energy pricing, you can adjust charging rates based on time-of-use electricity pricing.
 
-This page provides several examples and hints to illustrate some of the many potential use cases."
+This page provides several examples and hints to illustrate some of the many potential use cases. They are examples to adapt, not a finished installation: the values that depend on your supply and your charger are called out as you go.
+
+## Entity names used on this page
+
+`<cpid>` is the charge point id you configured for your charger. The examples use the entity names of a **single-connector** charger.
+
+If your charger reports more than one connector, those charger-level entities do not exist — the integration creates per-connector entities instead and removes the flat ones. Use the connector that matches the `conn_id` you pass to the action:
+
+| Single connector | Two or more connectors |
+| --- | --- |
+| `sensor.<cpid>_transaction_id` | `sensor.<cpid>_connector_1_transaction_id` |
+| `sensor.<cpid>_current_import` | `sensor.<cpid>_connector_1_current_import` |
+| `number.<cpid>_maximum_current` | `number.<cpid>_connector_1_maximum_current` |
 
 ## Adjusting the charge current
 
-When the OCPP integration is added to your Home Assistant, you get a slider to control the maximum charge current named (or one per connector, if your charger has multiple connectors):
-<mark>number.<name_ocpp_charger>_maximum_current</mark>
+When the OCPP integration is added to your Home Assistant, you get a slider to control the maximum charge current named:
+`number.<cpid>_maximum_current`
 
-While using this entity in your automation might seem logical, it could potentially lead to permanent damage to your charger in the long run.
+While using this entity in an automation might seem logical, do not assume it is safe to update at control-loop frequency.
 This entity controls the OCPP ChargePointMaxProfile, which configures the maximum power or current available for the entire charging station.
-This setting is typically written to non-volatile storage (like EEPROM or flash memory) to persist across reboots.
-Frequent writes to these types of memory can accelerate wear, potentially shortening the lifespan of your charger. Ten updates per day is no problem at all, 1 update per 10s could break your charger somewhere between 3 days and 3 years depending on the HW solution.
+OCPP defines the profile's behaviour, but not where a charger stores it. Some charger firmware persists station-wide profiles in non-volatile memory; other firmware does not. If a charger writes every update to EEPROM or flash, a fast control loop can wear that storage. There is no universal safe update rate or lifetime estimate: confirm the implementation and supported update frequency with the charger manufacturer.
 
-⚠️ **Warning**: Using the maximum current slider in automations can lead to permanent hardware damage due to frequent writes to non-volatile memory.
+⚠️ **Warning**: Do not use the maximum-current slider as a high-frequency control loop unless the charger manufacturer confirms that repeated profile updates are safe. Debounce ordinary changes, require a meaningful change before sending another profile, and retain the ability to send an immediate safety reduction.
 
-### TXprofile
+### TxProfile
 
-Therefore, it is better to utilize a specific profile that is active exclusively during the current charging session. This approach allows you to adjust the charge current downwards while still respecting the upper limit defined by the ChargePointMaxProfile.
+For session-scoped control, use a profile that is active exclusively during the current charging session. This allows you to adjust the charge current downwards while still respecting the upper limit defined by the ChargePointMaxProfile.
 
 Essentially, the slider in your GUI maintains control over the absolute maximum current the charger can utilize.
 
-To dynamically set the session-specific charge current within an automation, use the following action code snippet:
+### What `ocpp.set_charge_rate` does with `limit_amps`
 
-    - action: ocpp.set_charge_rate
-      data:
-        custom_profile: |
-          {
-            "transactionId": {{ states('sensor.<name_ocpp_charger>_transaction_id') | int }},
-            "chargingProfileId": 1,
-            "stackLevel": 0,
-            "chargingProfilePurpose": "TxProfile",
-            "chargingProfileKind": "Relative",
-            "chargingSchedule": {
-              "chargingRateUnit": "A",
-              "chargingSchedulePeriod": [
-                {"startPeriod": 0, "limit": {{ states('entity_charge_limit') | int }}}
-              ]
-            }
-          }
-        conn_id: 1
+Before writing a profile by hand it is worth knowing what the built-in action does, because it is not simply a session-scoped limit.
 
+On **OCPP 1.6** it first tries a station-wide `ChargePointMaxProfile` on connector 0, the same profile purpose the slider writes. **If the charger accepts it, that is the end of the call.** Only if the charger *rejects* it does the action fall back to a `TxProfile` bound to the running transaction, plus a `TxDefaultProfile` for later sessions. Which of those happened depends on your charger, and the action reports success either way.
 
-Where <mark>entity_charge_limit</mark> refers to your chosen entity (e.g., a number or sensor) that holds the desired current value.
+So on a charger that accepts the station-wide profile, calling this on a short interval repeatedly exercises whatever storage path that firmware uses, and the limit can outlive the transaction rather than being session-scoped.
 
-NB! The action above only changes your current session limits. If you want to impact future sessions, run the same action, but replace <mark>"chargingProfilePurpose": "TxProfile"</mark> with <mark>"chargingProfilePurpose": "TxDefaultProfile"</mark>.
+On **OCPP 2.0.1** it always writes `ChargingStationMaxProfile` — there is no TxProfile fallback. Note also that the station-wide profile belongs on EVSE 0; passing a positive `conn_id` here targets an EVSE the charger may refuse it on.
 
-## solar current
-The solar system usually reports its production in Watts or kW. To convert this to amps available for your EV charger, simply divide the watts by the mains voltage (e.g., 230V for the EU)
+```yaml
+- action: ocpp.set_charge_rate
+  data:
+    devid: <cpid>
+    conn_id: 0
+    limit_amps: 16
+```
 
-You can create a template sensor for this:
+It remains the right tool for an occasional limit change, and it handles the details below for you. A hand-written `TxProfile` gives session scope, but OCPP does **not** guarantee that a charger keeps it out of non-volatile storage. Confirm the charger's behaviour before updating any profile frequently.
 
-    - platform: template
-      sensors:
-        solaredge_amps:
-        value_template: "{{ (states('sensor.solaredge_power') | round(0, 'floor')| float) / 230 }}"
-        unit_of_measurement: 'A'
+### Writing your own profile
+
+Everything below sends a raw profile through `custom_profile`, exactly as you write it. Pass `custom_profile` as a mapping, not as a JSON string under `custom_profile: |`. Keeping the profile structured preserves its field types and avoids reparsing charger-originated values as JSON.
+
+That escape hatch hands you three things the managed path was handling:
+
+* **The profile id.** A charger replaces an existing profile that has the same id. On OCPP 1.6 the integration uses `1000` for ChargePointMaxProfile, `2000+n` for TxDefaultProfile and `3000+n` for TxProfile, where `n` is the connector. On 2.0.1 it uses id `1` for the `ChargingStationMaxProfile` the slider writes. **Reusing `1` on 2.0.1 can replace the slider's ceiling with your session profile, which then disappears when the transaction ends.** Maintain your own charger-wide inventory and use a different integer for every connector and purpose.
+* **The stack level.** Among overlapping profiles of the same purpose, a higher supported level takes precedence. A profile can therefore be accepted but have no effect when another profile is above it. Do not assume that level 2 is valid or sufficient. On OCPP 1.6, query `ChargeProfileMaxStackLevel`; on 2.0.1, inspect the charger's smart-charging device-model variables. Coordinate the chosen level with every other system that writes profiles, and keep it within the maximum the charger reports.
+* **The rate unit and phase count.** See below.
+
+The examples take the ids and stack level as variables. The placeholders below are deliberately non-numeric, so an unedited snippet is rejected by schema validation instead of silently installing a colliding default. Replace them with integer values chosen for your charger. On OCPP 1.6, remember that the resulting rejection is visible only in the integration log and notification because the action itself still returns normally.
+
+```yaml
+variables:
+  # Replace these with different charger-wide integer ids.
+  tx_profile_id: <unique_integer_for_this_connector_and_purpose>
+  tx_default_profile_id: <different_unique_integer_for_this_connector_and_purpose>
+  # Replace this with an integer the charger supports and that is
+  # coordinated with every other profile writer.
+  stack_level: <supported_integer_stack_level>
+```
+
+Two more things apply to every action example below:
+
+* **Always pass `devid`.** Without it the action falls back to whichever charger happens to be first in the integration's internal ordering, which is not necessarily the one your template just read; with more than one central system configured, an omitted `devid` fails the call outright.
+* **The profile shape differs between OCPP 1.6 and 2.0.1.** The two are not interchangeable. After replacing the deliberately invalid integer placeholders, both shapes below validate against the OCPP schemas the integration uses.
+
+The snippets show only the action. `charge_current` is whatever your automation calculated - see [Designing your automation](#designing-your-automation) for the decisions that go into it.
+
+#### OCPP 1.6
+
+```yaml
+- action: ocpp.set_charge_rate
+  data:
+    devid: <cpid>
+    conn_id: 1
+    custom_profile:
+      transactionId: "{{ states('sensor.<cpid>_transaction_id') | int }}"
+      chargingProfileId: "{{ tx_profile_id }}"
+      stackLevel: "{{ stack_level }}"
+      chargingProfilePurpose: TxProfile
+      chargingProfileKind: Relative
+      chargingSchedule:
+        chargingRateUnit: A
+        chargingSchedulePeriod:
+          - startPeriod: 0
+            limit: "{{ charge_current | float }}"
+```
+
+#### OCPP 2.0.1
+
+On 2.0.1 the profile id field is `id` (not `chargingProfileId`), `chargingSchedule` is a **list**, and `transactionId` is a **string** — a number there is rejected by the schema before anything reaches the charger.
+
+Home Assistant normally converts a template containing only `"0"` to the number `0`. Because `"0"` is a valid string transaction id on 2.0.1, this example renders the complete mapping in one expression. That preserves the transaction id as a string while still delivering a dictionary, rather than a JSON string, to the integration. The charger-originated id is a dictionary value and cannot add or replace profile fields.
+
+```yaml
+- action: ocpp.set_charge_rate
+  data:
+    devid: <cpid>
+    conn_id: 1
+    custom_profile: >-
+      {{ {
+        'id': tx_profile_id,
+        'stackLevel': stack_level,
+        'chargingProfilePurpose': 'TxProfile',
+        'chargingProfileKind': 'Relative',
+        'transactionId': states('sensor.<cpid>_transaction_id'),
+        'chargingSchedule': [{
+          'id': 1,
+          'chargingRateUnit': 'A',
+          'chargingSchedulePeriod': [{
+            'startPeriod': 0,
+            'limit': charge_current | float
+          }]
+        }]
+      } }}
+```
+
+#### Check which rate unit your charger accepts
+
+The profiles above request a limit in amps (`"chargingRateUnit": "A"`). Not every charger accepts that: some are power-only and want watts. The integration negotiates this for the limits it sends itself, but a **custom profile is forwarded exactly as you wrote it**, so an unsupported unit is simply rejected.
+
+Ask the charger rather than assuming. `ocpp.get_configuration` answers with a response rather than changing anything, so the easiest place to run it is **Developer Tools → Actions**, which shows you the result. In an automation a response-only action must be given a `response_variable`, or Home Assistant refuses it:
+
+```yaml
+- action: ocpp.get_configuration
+  data:
+    devid: <cpid>
+    ocpp_key: ChargingScheduleAllowedChargingRateUnit
+  response_variable: allowed_units
+```
+
+That configuration key is **OCPP 1.6**. On 2.0.1 the same question is asked of the device model, and `ocpp_key` must be a `Component/Variable` path — the smart charging controller is `SmartChargingCtrlr` — so check your charger's device model for the variable it exposes. A key without a `/` is rejected on 2.0.1.
+
+If the charger reports power only, use `"chargingRateUnit": "W"` and convert your figure using the same voltage and phase count as below: watts = amps × voltage × phases.
+
+Say the phase count in the profile as well, with `"numberPhases": 1` (or 3) in the schedule period. Converting for one phase and then omitting the field does not tell the charger anything: an AC station that sees no `numberPhases` may assume three, divide your watts across them, and end up below the minimum current it will charge at.
+
+#### Only send a TxProfile when there is a transaction
+
+A `TxProfile` is bound to the running transaction. If the transaction sensor is `unknown` or `unavailable` — which happens around restarts and telemetry hiccups — there is nothing to bind to, and a profile sent anyway is rejected by the charger.
+
+That failure is quiet: on OCPP 1.6 the integration logs the rejection, but the action still returns normally, so an automation cannot tell that its limit was refused. Check for a transaction before sending, rather than letting a template substitute a placeholder value.
+
+On **OCPP 1.6** transaction ids are numbers and the integration writes `0` when a transaction ends, so zero means "no session":
+
+```yaml
+condition:
+  - condition: template
+    value_template: >-
+      {{ states('sensor.<cpid>_transaction_id') | int(0) > 0 }}
+```
+
+On **OCPP 2.0.1** the id is an arbitrary string chosen by the charger, and `"0"` is a perfectly valid one — excluding it would silence every update for that session. Check only that there is a value:
+
+```yaml
+condition:
+  - condition: template
+    value_template: >-
+      {{ has_value('sensor.<cpid>_transaction_id')
+         and states('sensor.<cpid>_transaction_id') not in ['None', ''] }}
+```
+
+### Limiting future sessions
+
+`transactionId` only means something for a `TxProfile`. To limit **future** sessions, send a `TxDefaultProfile` with no transaction binding at all — do not take the profile above and change only the purpose, as the leftover `transactionId` can get the profile rejected:
+
+```yaml
+- action: ocpp.set_charge_rate
+  data:
+    devid: <cpid>
+    conn_id: 1
+    custom_profile:
+      chargingProfileId: "{{ tx_default_profile_id }}"
+      stackLevel: "{{ stack_level }}"
+      chargingProfilePurpose: TxDefaultProfile
+      chargingProfileKind: Relative
+      chargingSchedule:
+        chargingRateUnit: A
+        chargingSchedulePeriod:
+          - startPeriod: 0
+            limit: "{{ charge_current | float }}"
+```
+
+For OCPP 2.0.1, use the 2.0.1 shape above with `"chargingProfilePurpose": "TxDefaultProfile"` and the `transactionId` line removed.
+
+## Units, voltage and phases
+
+The examples below convert power to a current, so they depend on three things you must set to match your installation:
+
+* **Units.** A power sensor may report W or kW. Check which, and convert: the examples note the unit they expect.
+* **Voltage.** The voltage the *charger* is fed at, which is not always what your meter reports per phase. On a line-to-neutral supply it is the phase voltage, e.g. 230 V in much of the EU. On a North American split-phase circuit the charger sits across two legs, so it sees 240 V even though each leg measures 120 V to neutral.
+* **Phases.** A charge current limit is **per phase**. On a balanced three-phase supply, a total power of P watts corresponds to `P / (3 × voltage)` amps per phase, not `P / voltage`.
+
+There are two easy ways to get this wrong, and both ask for more current than you meant:
+
+* Treating a three-phase supply as single-phase: 4600 W becomes `4600 / 230 = 20 A` instead of `4600 / (3 × 230) ≈ 6.7 A` — three times too much.
+* Using the line-to-neutral voltage on a split-phase circuit: a 7.2 kW charger becomes `7200 / 120 = 60 A` instead of `7200 / 240 = 30 A` — twice too much.
+
+Set `voltage` and `phases` in the examples below to match how your charger is actually fed: 230 and 1 for a single-phase EU supply, 230 and 3 for three-phase, 240 and 1 for North American split-phase. These formulas assume a balanced supply; if yours is not, measure the phase you are actually limiting.
+
+## Solar current
+
+The solar system usually reports its production in Watts or kW. To convert this to amps available for your EV charger, divide the watts by the line voltage and by the number of phases.
+
+You can create a template sensor for this. The `availability` template is what keeps a missing input from being read as a genuine zero — the sensor goes unavailable instead of quietly reporting 0 A:
+
+```yaml
+template:
+  - sensor:
+      - name: "Solar charge current"
+        unique_id: solar_charge_current
+        unit_of_measurement: "A"
         device_class: current
+        state_class: measurement
+        # is_number rejects unknown, unavailable and a meter that reports
+        # something like "error"; the age check catches one that has
+        # simply stopped publishing while still looking available.
+        availability: >-
+          {{ is_number(states('sensor.solaredge_power'))
+             and (now() - states.sensor.solaredge_power.last_reported).total_seconds() < 900 }}
+        state: >-
+          {% set phases = 3 %}
+          {% set voltage = 230 %}
+          {% set solar_w = states('sensor.solaredge_power') | float(0) %}
+          {{ (solar_w / (voltage * phases)) | round(0, 'floor') }}
+```
 
-This sensor contains the solar current in amps rounded down to the nearest whole number. It could be directly used in the action above.
+This sensor contains the solar current in amps per phase, rounded down so it never asks for more than is actually available.
 
 ## Smart-meter
+
 The paragraph above suggests that nearly all the solar current is prioritized for the EV charger. However, this can lead to situations where other high-demand appliances, such as a washing machine or hot tub, still draw power from the grid even when solar energy is available.
 
-To avoid this, you can use the data provided by your smart meter sensors. By integrating smart meter data into your home automation system, you can dynamically adjust the EV charging rate based on real-time energy consumption. This ensures that the EV primarily charges using excess solar power while minimizing reliance on grid electricity during periods of high household demand.you might have it as power.
+To avoid this, you can use the data provided by your smart meter sensors. By integrating smart meter data into your home automation system, you can dynamically adjust the EV charging rate based on real-time energy consumption. This ensures that the EV primarily charges using excess solar power while minimizing reliance on grid electricity during periods of high household demand.
 
-For this it is important to know the current you deliver or receive from the grid. Depending on you smart meter sensors you might have this current available in a sensor or you might have this as power. The example below uses power to and from the grid and converts it to a current which is negative when receiving from the grid.
-In this example the power is in kW and the current is calculated using at actual mains voltage.
-This template sensor gives the right value:
+For this it is important to know the current you deliver or receive from the grid. Depending on your smart meter sensors you might have this current available in a sensor, or you might have it as power. The example below uses power to and from the grid (in kW) and converts it to a current which is negative when receiving from the grid.
 
-        - platform: template
-          sensors:
-             grid_current_available:  # Calculate the current still available to use, can be negative
-              value_template: >-
-              {{((states('sensor.p1_meter_p1_returned') | float - states('sensor.p1_meter_p1_power') | float )*1000
-              / (states('sensor.p1_meter_p1_voltage') | float )) }}
-              unit_of_measurement: 'A'
-              device_class: current
+Every input is checked in `availability`, not just defaulted in `state`. `is_number` is used rather than `has_value` because a meter can stay "available" while publishing something that is not a number at all. Each input carries its own `last_reported` age because they can freeze independently: an export reading stuck at 5 kW while import keeps ticking looks entirely healthy if you timestamp only one of them. `last_reported` is used instead of `last_updated` so repeated reports of the same valid value count as fresh.
 
-For solar charging a positive grid current avaiable means you can increase your EV charge number with this number, when negative you need to decrease. This means you need to know the actual charge current and modify this. To do this easily you can use a variable inside your automation to store the actual charge current.
+This example assumes the meter reports at least every 10 seconds. It allows 30 seconds without a report and runs a watchdog every 10 seconds, so a frozen input becomes unavailable less than 40 seconds after its last report. Change both figures to match the real reporting interval, allowing only a small number of missed samples. The state triggers react immediately to changed readings; the watchdog also catches a sensor that simply stops publishing. A renamed or dropped import sensor would otherwise read as `0 kW` — indistinguishable from a house drawing nothing — and the correction would quietly stop working. The voltage is range-checked too: a meter that publishes a literal `0 V` while restarting converts perfectly well to the number zero, so `| float(230)` would not save you from dividing by it.
 
-   variables:
-     actual_charge_current: "{{ (states('sensor.charge_current') | float) }}"
-     new_amps: "{{ actual_charge_current + (states('sensor.grid_current_available') | float) }}
+```yaml
+template:
+  - triggers:
+      - trigger: state
+        entity_id:
+          - sensor.p1_meter_p1_voltage
+          - sensor.p1_meter_p1_returned
+          - sensor.p1_meter_p1_power
+      - trigger: time_pattern
+        seconds: "/10"
+    sensor:
+      # The current still available to use; negative means you are
+      # already importing from the grid.
+      - name: "Grid current available"
+        unique_id: grid_current_available
+        unit_of_measurement: "A"
+        device_class: current
+        state_class: measurement
+        availability: >-
+          {% set max_age_seconds = 30 %}
+          {{ is_number(states('sensor.p1_meter_p1_voltage'))
+             and is_number(states('sensor.p1_meter_p1_returned'))
+             and is_number(states('sensor.p1_meter_p1_power'))
+             and states('sensor.p1_meter_p1_voltage') | float(0) > 100
+             and states('sensor.p1_meter_p1_voltage') | float(0) < 300
+             and (now() - states.sensor.p1_meter_p1_voltage.last_reported).total_seconds() < max_age_seconds
+             and (now() - states.sensor.p1_meter_p1_returned.last_reported).total_seconds() < max_age_seconds
+             and (now() - states.sensor.p1_meter_p1_power.last_reported).total_seconds() < max_age_seconds }}
+        state: >-
+          {% set phases = 3 %}
+          {% set voltage = states('sensor.p1_meter_p1_voltage') | float(230) %}
+          {% set exported_kw = states('sensor.p1_meter_p1_returned') | float(0) %}
+          {% set imported_kw = states('sensor.p1_meter_p1_power') | float(0) %}
+          {{ ((exported_kw - imported_kw) * 1000 / (voltage * phases)) | round(1) }}
+```
 
-This could lead to a negative charge current, to avoid this create a new variable with a minimum value:
+A positive value means you can increase the EV charge current by that much; a negative value means you need to decrease it.
 
-    charge_current: "{{ [new_amps, 0] | max }}"
+(designing-your-automation)=
+## Designing your automation
 
-The `max` filter ensures the charge current never goes below 0 amps, which would be invalid for the charging station.
+The pieces above are deliberately building blocks rather than a finished control loop. What to do with the numbers depends on your supply, your charger and your tolerance for getting it wrong, and the details that decide whether such an automation is safe cannot be captured in a snippet. Before you wire one up, work through these:
 
-## maximum charge
-A simular solution could be used to check how much power is still available from the grid substracting all power used by other appliances in your house. This way you can charge you EV as fast as possible without overloading your main fuse.
+* **Fail safe, not open.** Decide what happens when a sensor is unavailable. Falling back to "leave the limit where it was" is the wrong direction for overload protection: the moment you cannot see the grid is the moment to be cautious. Send a current your supply can always carry instead, and make sure every input the calculation uses is checked — including the charger's own current sensor, which is just as capable of going unavailable as the meter is.
 
-:exclamation: By specificatiomn your main fuse can withand 1.2 its rate current for at least 1 hour
+* **Do not let a safety update be dropped.** An automation triggered only by the meter never runs when the meter stops updating, and `mode: single` discards a new trigger while a previous run is still waiting on the charger. Trigger when the derived safety sensor becomes unavailable, add a periodic watchdog, trigger on the transaction as well as the meter, choose the mode deliberately, and test what happens when the charger is slow to answer.
 
-So a response time up to a minute is usually no problem if the overload is limited.
+* **Control retries and update volume.** Coalesce superseded increases, allow only one profile write to be in flight, and use a minimum change and a minimum interval for ordinary adjustments. Do not delay an overload reduction behind that interval. After a timeout, use bounded retries with backoff and jitter; an unbounded retry loop can keep a charger and Home Assistant busy throughout an outage while still leaving the old limit active.
+
+* **Clamp to what the installation allows.** Most chargers refuse to charge below about 6 A, so a calculated 4 A is not a gentle reduction — it is a rejected profile and the previous limit staying in force. Cap the upper end at the supply's per-phase rating too, and decide explicitly whether "below the minimum" means suspend the session or leave it at the minimum.
+
+* **A rejected profile is not visible on OCPP 1.6.** The integration logs it, but the action returns normally, so your automation cannot tell. Treat a sent profile as a request, not a confirmation. Watching `sensor.<cpid>_current_import` afterwards can tell you a limit is being *exceeded*, but it cannot confirm one was accepted: a car that is tapering, paused, or simply charging slowly sits below the limit whether or not the charger ever installed it.
+
+* **Match the protocol version.** The two profile shapes above are not interchangeable, and neither is the transaction id's type.
+
+## Maximum charge
+
+A similar solution could be used to check how much power is still available from the grid, subtracting all power used by other appliances in your house. This way you can charge your EV as fast as possible without overloading your main fuse.
+
+Whatever you compute, clamp the result to what your installation and charger actually allow — the supply's per-phase rating and the charger's own minimum and maximum current. Most chargers will not charge below about 6 A.
+
+How long a supply tolerates a given overload before its protection opens depends on the device — fuse class, breaker curve, ambient temperature, conductor and termination ratings — and on local rules, so there is no universal figure to design against. Treat the rated current as the limit for normal operation rather than something to exceed briefly, and take any timing assumption from the data sheet of the device actually installed, or from a qualified electrician.
+
+That matters more than it sounds: if the protection does open, it takes Home Assistant, your network and the charger with it, so nothing is left to correct the overload.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -14,6 +14,7 @@ Contents
 * [Supported devices](supported-devices)
 * [Multiple central systems](multiple-central-systems)
 * [User guide](user-guide)
+* [Charge automation](Charge_automation)
 * [Support](support)
 * [Development](development)
 * [Debugging](debugging)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Contents
 * [Supported devices](supported-devices.md)
 * [Multiple central systems](multiple-central-systems.md)
 * [User guide](user-guide.md)
+* [Charge automation](Charge_automation.md)
 * [Support](support.md)
 * [Development](development.md)
 * [Debugging](debugging.md)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Table of Contents
    supported-devices
    multiple-central-systems
    user-guide
+   Charge_automation
    support
    debugging
    development


### PR DESCRIPTION
The separate PR you asked for on #2098: Charge_automation.md fixed and linked from all three contents pages.

The page was published but linked from nowhere, and every example on it was broken — none of the three YAML snippets could load at all (mis-indented sensor fields, an under-indented block scalar, an unterminated quote). Fixing the syntax exposed deeper problems, so this went through several review rounds; the result claims less and verifies more.

## What the rewrite fixes

**Protocol correctness.** The profile was 1.6-shaped on a version-neutral page. There is now a validated example per protocol: on 2.0.1 the id field is `id`, `chargingSchedule` is a list, and `transactionId` is a string (a number is rejected by the schema). Both shapes are validated against the OCPP schemas the integration ships.

**Profiles are passed as mappings, not JSON strings.** A charger-supplied transaction id interpolated into hand-written JSON invited field injection (a crafted id could rewrite `stackLevel` and still pass the schema); as a mapping value it is inert data. This also sidesteps #2100 entirely. The 2.0.1 example builds its mapping in a single template expression so a transaction id of `"0"` — valid on 2.0.1 — survives as a string instead of being native-typed to a number.

**No copyable footguns.** Profile ids and stack levels are deliberately non-numeric placeholders: an unedited snippet is rejected by schema validation instead of silently installing something that collides with the integration's own profiles (the reserved ranges are documented — reusing the 2.0.1 slider's id `1` replaces the standing ceiling with a session profile). `devid` on every action. Version-specific transaction checks (1.6's `0` means no session; on 2.0.1 `"0"` is a legal id and must not be excluded).

**What `set_charge_rate` actually does.** The page now says plainly that `limit_amps` on 1.6 tries `ChargePointMaxProfile` first and only falls back to TxProfile on rejection, reports success either way, and on 2.0.1 always writes `ChargingStationMaxProfile` (with `conn_id: 0`, per #2101).

**Electrical maths.** The old formulas assumed a single phase at line-to-neutral voltage: 3× over-command on three-phase, 2× on split-phase. Units, voltage and phase count are now explicit with worked examples both ways, plus `numberPhases` for W-based schedules.

**Sensors fail safe.** Template sensors validate inputs in `availability:` — `is_number` (a meter can publish "error" while staying available), voltage range-checked (a literal `0` converts fine, so a default can't prevent the division), and per-input `last_reported` ages with a trigger-based watchdog so inputs that stop reporting take the sensor to `unavailable` instead of freezing a plausible number. The flash-wear warning now claims only what OCPP actually specifies, leaving update-rate limits to the manufacturer.

**No copy-paste control loop.** Earlier drafts grew a complete automation; review kept finding that its safety depended on charger capabilities, trigger/mode race behaviour and installation limits that no snippet can settle. It was replaced with a "Designing your automation" section naming those decisions (fail safe not open, don't drop safety updates, control retry volume, clamp to real limits, rejected profiles are invisible on 1.6).

## Verification

Everything checkable was checked by machine: all YAML parses; both profile shapes render through Home Assistant's template engine and validate against the ocpp package's schemas (including transaction ids `tx-9`, `"0"`, an embedded quote, and an injection-shaped value); unedited placeholders fail validation on both shapes; the template sensors were instantiated through `async_setup_component` and proven to go `unavailable` for junk input, implausible voltage, and — via time advance — inputs that silently stop reporting; the `get_configuration` snippet's fields match services.yaml.

Two integration issues found during this review are filed separately: #2100 (custom_profile apostrophe rewriting) and #2101 (ChargingStationMaxProfile sent to the connector's EVSE instead of EVSE 0). This page is written to be correct under current behaviour and under the likely fixes for both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for automating EV charging.
  * Documented charger naming conventions, maximum-current controls, OCPP 1.6 and 2.0.1 behavior, custom charging profiles, rate units, phases, and voltage.
  * Added guidance for solar charging, smart-meter integration, transaction handling, future-session limits, persistence, and automation design.
  * Added the new charge automation guide to the documentation navigation and contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->