### PR TITLE
Send the managed 2.0.1 station profile to EVSE 0 regardless of conn_id

### DIFF
--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -699,8 +699,15 @@ class ChargePoint(cp):
     ) -> bool:
         """Set a charging profile with defined limit (OCPP 2.x).
 
-        - conn_id=0 (default) targets the Charging Station (evse_id=0).
-        - conn_id>0 targets the specific EVSE corresponding to the global connector index.
+        - A caller-supplied ``profile`` is sent to the EVSE mapped from
+          ``conn_id`` (0 = the Charging Station, evse_id 0); which EVSE is
+          valid depends on the profile's purpose.
+        - A managed ``limit_amps``/``limit_watts`` request below the maximum
+          builds a ChargingStationMaxProfile. OCPP 2.0.1 requires that profile
+          on evse_id 0, so ``conn_id`` is not used for it. This mirrors 1.6,
+          which sends its ChargePointMaxProfile on connector 0.
+        - A request at or above the maximum, or with no limit at all, clears
+          the station profile with ClearChargingProfile instead of sending one.
 
         Returns whether the charger honoured the request. Callers treat the
         result as a success flag - number.py logs a rejection when it is
@@ -710,11 +717,13 @@ class ChargePoint(cp):
         carries the charger's own status message.
         """
 
-        evse_target = 0
-        if conn_id and conn_id > 0:
-            with contextlib.suppress(Exception):
-                evse_target, _ = self._global_to_pair(int(conn_id))
         if profile is not None:
+            # A caller-supplied profile is an escape hatch: its purpose decides
+            # which EVSE is valid, so honour the requested connector's mapping.
+            evse_target = 0
+            if conn_id and conn_id > 0:
+                with contextlib.suppress(Exception):
+                    evse_target, _ = self._global_to_pair(int(conn_id))
             req = call.SetChargingProfile(evse_target, profile)
             resp: call_result.SetChargingProfile = await self.call(req)
             if resp.status != ChargingProfileStatusEnumType.accepted:
@@ -765,9 +774,10 @@ class ChargePoint(cp):
             "charging_schedule": [schedule],
         }
 
-        req: call.SetChargingProfile = call.SetChargingProfile(
-            evse_target, charging_profile
-        )
+        # ChargingStationMaxProfile describes the whole station and OCPP 2.0.1
+        # requires it on evseId 0, so conn_id has no meaning for it. 1.6 sends
+        # its ChargePointMaxProfile on connector 0 for the same reason.
+        req: call.SetChargingProfile = call.SetChargingProfile(0, charging_profile)
         resp: call_result.SetChargingProfile = await self.call(req)
         if resp.status != ChargingProfileStatusEnumType.accepted:
             raise HomeAssistantError(

--- a/custom_components/ocpp/services.yaml
+++ b/custom_components/ocpp/services.yaml
@@ -39,7 +39,7 @@ set_charge_rate:
       default: 22000
     conn_id:
       name: Connector identifier
-      description: Optional, 0 = all connectors (default), 1 is first connector
+      description: Selects the target connector, or mapped EVSE on OCPP 2.x, for custom_profile. Managed limits first target the whole charging station; OCPP 1.6 may use this connector for fallback profiles.
       required: false
       advanced: true
       example: 0

--- a/docs/Charge_automation.md
+++ b/docs/Charge_automation.md
@@ -50,7 +50,7 @@ On **OCPP 1.6** it first tries a station-wide `ChargePointMaxProfile` on connect
 
 So on a charger that accepts the station-wide profile, calling this on a short interval repeatedly exercises whatever storage path that firmware uses, and the limit can outlive the transaction rather than being session-scoped.
 
-On **OCPP 2.0.1** it always writes `ChargingStationMaxProfile` — there is no TxProfile fallback. Note also that the station-wide profile belongs on EVSE 0; passing a positive `conn_id` here targets an EVSE the charger may refuse it on.
+On **OCPP 2.0.1** a limit below the maximum writes a `ChargingStationMaxProfile` to EVSE 0, as the specification requires for a station-wide profile. A limit at or above the configured maximum current, or 22 kW for a watt limit, or a call with no limit at all, clears that profile instead of sending one. There is no TxProfile fallback, and `conn_id` is not used for this managed limit — it only selects the EVSE for a `custom_profile`.
 
 ```yaml
 - action: ocpp.set_charge_rate

--- a/tests/test_v201_set_charge_rate_return.py
+++ b/tests/test_v201_set_charge_rate_return.py
@@ -201,3 +201,75 @@ async def test_a_rejected_profile_still_raises(hass, kwargs):
         await cp.set_charge_rate(**kwargs)
 
     assert "charger said no" in str(excinfo.value.translation_placeholders)
+
+
+# --- #2101: the managed station profile must target EVSE 0 -------------------
+#
+# ChargingStationMaxProfile describes the whole station and OCPP 2.0.1 requires
+# it on evseId 0. The managed path used to route it to whatever EVSE conn_id
+# mapped to, so a compliant charger could refuse every call that passed a
+# positive connector. The invariant: every integration-generated
+# ChargingStationMaxProfile is sent with evse_id=0. A caller-supplied profile
+# keeps the requested connector's mapping, because its purpose decides which
+# EVSE is valid.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"limit_amps": 16}, {"limit_watts": 5000}],
+    ids=["amps", "watts"],
+)
+async def test_a_managed_limit_targets_the_station_whatever_the_connector(hass, kwargs):
+    """A managed limit below the maximum goes to EVSE 0, whichever connector is named.
+
+    Seeding global 2 -> EVSE 7 makes the wrong answer distinct from both 0
+    and the mapper's own (n, 1) fallback, so this cannot pass by coincidence:
+    the old code sent this request to EVSE 7.
+    """
+    cp = _mk_cp(hass)
+    cp._global_to_evse = {2: (7, 1)}
+
+    assert await cp.set_charge_rate(conn_id=2, **kwargs) is True
+
+    # Exactly one request and nothing behind it: a future rejection fallback
+    # must be a deliberate change that updates this line.
+    assert _sent(cp) == ["SetChargingProfile"]
+    req = cp.sent[0]
+    assert req.evse_id == 0
+    assert (
+        req.charging_profile["charging_profile_purpose"]
+        == ChargingProfilePurposeEnumType.charging_station_max_profile.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_custom_profile_keeps_the_requested_connectors_evse(hass):
+    """A caller-supplied profile still goes where conn_id maps.
+
+    The escape hatch is unchanged: a TxDefaultProfile may legitimately
+    target a positive EVSE, so it is sent to the mapped EVSE, here 7.
+    """
+    cp = _mk_cp(hass)
+    cp._global_to_evse = {2: (7, 1)}
+    profile = {
+        "id": 5,
+        "stack_level": 1,
+        "charging_profile_purpose": (
+            ChargingProfilePurposeEnumType.tx_default_profile.value
+        ),
+        "charging_profile_kind": "Relative",
+        "charging_schedule": [
+            {
+                "id": 5,
+                "charging_rate_unit": "A",
+                "charging_schedule_period": [{"start_period": 0, "limit": 10}],
+            }
+        ],
+    }
+
+    assert await cp.set_charge_rate(conn_id=2, profile=profile) is True
+
+    assert _sent(cp) == ["SetChargingProfile"]
+    assert cp.sent[0].evse_id == 7
+    assert cp.sent[0].charging_profile is profile


### PR DESCRIPTION
`set_charge_rate` on OCPP 2.0.1 computed the target EVSE from `conn_id` before distinguishing a caller-supplied profile from a managed `limit_amps`/`limit_watts` request. The managed path builds a `ChargingStationMaxProfile`, which describes the whole station and which OCPP 2.0.1 requires on `evseId = 0`. So any managed call that named a connector sent a station-wide profile to a positive EVSE, which a compliant charger is entitled to refuse, and the caller saw a `HomeAssistantError` every time. Reported in #2101.

**What changes**

- The `conn_id` to EVSE mapping now applies only to a custom profile, whose purpose decides which EVSE is valid. That path is otherwise unchanged.
- Every `ChargingStationMaxProfile` the managed path generates goes to EVSE 0. A limit at or above the maximum, or no limit at all, still takes the existing clear path rather than sending a profile.
- This keeps the same behaviour as 1.6, which sends its `ChargePointMaxProfile` on connector 0, per the direction on #2101.
- `services.yaml` now describes `conn_id` accurately for both versions, and the Charge_automation page's 2.0.1 caveat is replaced with the fixed behaviour, including the clear branch. The method docstring is updated to match.

**Tests**

The regression test seeds a non-trivial mapping, global connector 2 to EVSE 7, then sends managed amp and watt limits with `conn_id: 2`. That makes the wrong answer distinct from both 0 and the mapper's own `(n, 1)` fallback, so it cannot pass by coincidence; on the old code it fails with `evse_id == 7`. It also asserts that exactly one `SetChargingProfile` is sent, so any future fallback has to change that line deliberately. A second test sends a custom `TxDefaultProfile` with the same `conn_id` and proves it still reaches EVSE 7.

**Non-goal**

This change does not port OCPP 1.6's rejection fallback. That requires separate design because fallback acceptance cannot reliably express whether the current session is limited.

**Related**

#2110: on a multi-connector charger the per-connector maximum-current sliders all write this one station profile. That is pre-existing and cross-version, 1.6 does the same with profile 1000 on connector 0, and it is not changed here.

Fixes #2101.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected charging profile targeting for OCPP 2.0.1 managed limits, which now consistently apply at the station level.
  * Custom profiles continue to target the EVSE mapped to the selected connector.
  * Managed limits at or above the configured maximum are cleared as expected.

* **Documentation**
  * Clarified connector and EVSE behavior for the `set_charge_rate` service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->