### PR TITLE
Fix single-connector availability status fallback

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -409,6 +409,44 @@ class CentralSystem:
 
         return None
 
+    def get_availability_status(self, id: str):
+        """Return the status that drives the charger availability switch.
+
+        A station-level status is authoritative when the charger reports one.
+        Some single-connector chargers only send StatusNotification for
+        connector 1, so use that connector's status only while the station
+        status is absent. Never apply this fallback to a charger known to have
+        multiple connectors.
+        """
+        _, _, cp, runtime_connectors = self._get_metrics(id)
+        if cp is None:
+            return None
+
+        station_status = self.get_metric(id, cstat.status, connector_id=0)
+        if station_status is not None:
+            # Metrics carry no observation timestamp, so presence is the only
+            # reliable precedence signal; once reported, station status stays
+            # authoritative over the connector fallback.
+            return station_status
+
+        configured_connectors = getattr(
+            getattr(cp, "settings", None), "num_connectors", 1
+        )
+        try:
+            configured_connectors = int(configured_connectors)
+        except (TypeError, ValueError):
+            configured_connectors = 1
+        if configured_connectors < 1:
+            configured_connectors = 1
+
+        # During startup the runtime count begins at one until discovery
+        # finishes. If either source already identifies a multi-connector
+        # charger, remain conservative and do not borrow connector 1's state.
+        if max(runtime_connectors, configured_connectors) != 1:
+            return None
+
+        return self.get_metric(id, cstat.status_connector, connector_id=1)
+
     def del_metric(self, id: str, measurand: str, connector_id: int | None = None):
         """Set given measurand to None."""
         cp_id, m, cp, n_connectors = self._get_metrics(id)

--- a/custom_components/ocpp/switch.py
+++ b/custom_components/ocpp/switch.py
@@ -43,6 +43,7 @@ class OcppSwitchDescription(SwitchEntityDescription):
     metric_condition: list[str] | None = None
     default_state: bool = False
     per_connector: bool = False
+    single_connector_status_fallback: bool = False
 
 
 SWITCHES: Final[list[OcppSwitchDescription]] = [
@@ -70,6 +71,7 @@ SWITCHES: Final[list[OcppSwitchDescription]] = [
         metric_condition=[ChargePointStatus.available.value],
         default_state=True,
         per_connector=False,
+        single_connector_status_fallback=True,
     ),
     OcppSwitchDescription(
         key="connnector_availability",
@@ -217,18 +219,21 @@ class ChargePointSwitch(SwitchEntity):
         """Return true if the switch is on."""
         """Test metric state against condition if present"""
         if self.entity_description.metric_state is not None:
-            metric_conn = (
-                self.connector_id
-                if (
-                    self.entity_description.metric_state
-                    == HAChargerStatuses.status_connector
-                    or self.entity_description.per_connector
+            if self.entity_description.single_connector_status_fallback:
+                resp = self.central_system.get_availability_status(self.cpid)
+            else:
+                metric_conn = (
+                    self.connector_id
+                    if (
+                        self.entity_description.metric_state
+                        == HAChargerStatuses.status_connector
+                        or self.entity_description.per_connector
+                    )
+                    else None
                 )
-                else None
-            )
-            resp = self.central_system.get_metric(
-                self.cpid, self.entity_description.metric_state, metric_conn
-            )
+                resp = self.central_system.get_metric(
+                    self.cpid, self.entity_description.metric_state, metric_conn
+                )
             if self.entity_description.metric_condition is not None:
                 self._state = resp in self.entity_description.metric_condition
             else:

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from ocpp.v16.enums import ChargePointStatus
 
 from homeassistant.const import STATE_OK, STATE_UNAVAILABLE
 from homeassistant.exceptions import HomeAssistantError
@@ -18,6 +19,7 @@ from custom_components.ocpp.enums import (
 )
 from custom_components.ocpp.chargepoint import Metric as M
 from custom_components.ocpp.chargepoint import SetVariableResult
+from custom_components.ocpp.switch import ChargePointSwitch, SWITCHES
 
 from tests.const import MOCK_CONFIG_DATA
 
@@ -247,6 +249,102 @@ async def test_get_available_paths(hass):
 
     # fall back to charger status if no info
     assert cs.get_available("agg", connector_id=3) is True  # charger STATE_OK
+
+
+@pytest.mark.asyncio
+async def test_single_connector_availability_status_missing(hass):
+    """Keep the switch off until either status source reports."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    cs = CentralSystem(hass, entry)
+    _install_dummy_cp(cs, num_connectors=1)
+    switch_desc = next(desc for desc in SWITCHES if desc.key == "availability")
+    entity = ChargePointSwitch(cs, "test_cpid", switch_desc)
+
+    assert cs.get_availability_status("test_cpid") is None
+    assert entity.is_on is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", list(ChargePointStatus))
+async def test_single_connector_availability_status_fallback(hass, status):
+    """Fallback changes the status source without redefining switch semantics."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    cs = CentralSystem(hass, entry)
+    cp = _install_dummy_cp(cs, num_connectors=1)
+    switch_desc = next(desc for desc in SWITCHES if desc.key == "availability")
+    entity = ChargePointSwitch(cs, "test_cpid", switch_desc)
+
+    cp._metrics[(1, cstat.status_connector)] = M(status.value, None)
+
+    assert cs.get_availability_status("test_cpid") == status.value
+    assert entity.is_on is (status is ChargePointStatus.available)
+
+
+@pytest.mark.asyncio
+async def test_station_status_takes_precedence_for_availability(hass):
+    """Never override a reported station status with connector 1."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    cs = CentralSystem(hass, entry)
+    cp = _install_dummy_cp(cs, num_connectors=1)
+    switch_desc = next(desc for desc in SWITCHES if desc.key == "availability")
+    entity = ChargePointSwitch(cs, "test_cpid", switch_desc)
+
+    cp._metrics[(0, cstat.status)] = M("Unavailable", None)
+    cp._metrics[(1, cstat.status_connector)] = M("Available", None)
+    assert cs.get_availability_status("test_cpid") == "Unavailable"
+    assert entity.is_on is False
+
+    cp._metrics[(0, cstat.status)].value = "Available"
+    cp._metrics[(1, cstat.status_connector)].value = "Unavailable"
+    assert cs.get_availability_status("test_cpid") == "Available"
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_availability_status_does_not_fallback_for_multiple_connectors(hass):
+    """Keep station status unknown when either topology source says multi."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    cs = CentralSystem(hass, entry)
+    cp = _install_dummy_cp(cs, num_connectors=2)
+    cp._metrics[(1, cstat.status_connector)] = M("Available", None)
+
+    assert cs.get_availability_status("test_cpid") is None
+
+    # Runtime discovery starts at one; the configured count must still prevent
+    # a transient fallback while a known multi-connector charger reconnects.
+    cp.num_connectors = 1
+    cp.settings = SimpleNamespace(num_connectors=2)
+    assert cs.get_availability_status("test_cpid") is None
+    assert cs.get_availability_status("missing") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("switch_key", "connector_status"),
+    [
+        ("charge_control", ChargePointStatus.charging.value),
+        ("connnector_availability", ChargePointStatus.preparing.value),
+    ],
+)
+async def test_other_switches_keep_using_their_metric_path(
+    hass, monkeypatch, switch_key, connector_status
+):
+    """The availability resolver must not intercept other switch types."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    cs = CentralSystem(hass, entry)
+    cp = _install_dummy_cp(cs, num_connectors=1)
+    cp._metrics[(1, cstat.status_connector)] = M(connector_status, None)
+
+    def unexpected_availability_lookup(*args, **kwargs):
+        raise AssertionError("availability resolver used by another switch")
+
+    monkeypatch.setattr(cs, "get_availability_status", unexpected_availability_lookup)
+    switch_desc = next(desc for desc in SWITCHES if desc.key == switch_key)
+    entity = ChargePointSwitch(
+        cs, "test_cpid", switch_desc, connector_id=1, flatten_single=True
+    )
+
+    assert entity.is_on is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -10,6 +10,7 @@ import time
 from types import SimpleNamespace
 
 import pytest
+from homeassistant.const import STATE_ON
 from homeassistant.exceptions import HomeAssistantError
 import websockets
 
@@ -2327,6 +2328,58 @@ async def test_set_availability_exception_branch(
             cp_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await cp_task
+            await ws.close()
+
+
+@pytest.mark.timeout(15)
+@pytest.mark.parametrize(
+    "setup_config_entry",
+    [
+        {
+            "port": 9397,
+            "cp_id": "CP_availability_status_fallback",
+            "cms": "cms_availability_status_fallback",
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_availability_status_fallback"])
+@pytest.mark.parametrize("port", [9397])
+async def test_availability_switch_falls_back_from_real_v16_status_handler(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """A connector-1 notification drives availability without mirroring Status."""
+    cs = setup_config_entry
+
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
+    ) as ws:
+        client = ChargePoint(f"{cp_id}_client", ws)
+        task = asyncio.create_task(client.start())
+        try:
+            await client.send_boot_notification()
+            await wait_ready(cs.charge_points[cp_id])
+            server = cs.charge_points[cp_id]
+
+            assert server._metrics[(0, cstat.status)].value is None
+            await client.call(
+                call.StatusNotification(
+                    connector_id=1,
+                    error_code=ChargePointErrorCode.no_error,
+                    status=ChargePointStatus.available,
+                    timestamp=datetime.now(tz=UTC).isoformat(),
+                )
+            )
+            await hass.async_block_till_done()
+
+            state = hass.states.get("switch.test_cpid_availability")
+            assert state is not None
+            assert state.state == STATE_ON
+            assert server._metrics[(0, cstat.status)].value is None
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
             await ws.close()
 
 


### PR DESCRIPTION
On a single-connector charger that only ever sends `StatusNotification` for `connectorId` 1, the Availability switch stays OFF no matter what `ChangeAvailability` returns. Reported in #1992 with the EPenguin.

**Root cause**

`StatusNotification` stores station status under `Status` and connector status under `Status.Connector`. The Availability switch reads the station key. The generic metric fallback does probe connector 1 when the station value is absent, but it probes with the *station* measurand name, so it looks up a key that no connector report ever writes and finds nothing.

**What changes**

- A purpose-built resolver, `get_availability_status`, keeps a reported station status authoritative and falls back to connector 1's status only when the station status is absent and both the configured and discovered connector counts say the charger has a single connector. Chargers known to have several connectors never borrow connector 1's state.
- The Availability switch opts into that resolver through a declarative `single_connector_status_fallback` field on its description. The other switches keep their existing metric path, and tests prove it.
- No handler mirroring: connector 1's report is not copied into the station key, so the distinction between charger and connector status is preserved, as @MetcomHA asked for.

**Why this is a restoration, not a new behaviour**

The switch read charger-level `Status` for two days in February 2022, then `Status.Connector` for four years. #1891 (February 2026) moved it back to charger-level `Status` inside an entity-id slugification change; its message, its description, and the two issues it cites give no reason for the semantic change. #1992 was filed five months later. This change gives single-connector chargers back the source they had for four years, with station precedence on top.

The same mechanism helps OCPP 2.0.1: there the charger-level `Status` key is written only for an explicit station-level (evseId 0) notification, while EVSE aggregation goes to `Status.Connector`, so a single-connector 2.0.1 charger that never sends a station-level notification is fixed by the same fallback.

**Semantics are deliberately unchanged**

The switch is ON only while the connector reports `Available`, exactly as it was before #1891, so it reads OFF while a vehicle is connected. Widening that condition would change four years of behaviour and is a separate decision.

**Out of scope**

- Multi-connector chargers that never report connector 0 are left as they are.
- Metrics carry no observation timestamp, so a station status, once reported, stays authoritative over the connector fallback. A charger that reports connector 0 once at boot and never again keeps that value.

**Tests**

Every OCPP 1.6 connector state through the fallback, station precedence, missing status, multi-connector exclusion, both unaffected switch types, and a regression through the real OCPP 1.6 WebSocket handler that asserts the station key stays untouched. Full suite green.

@MetcomHA has offered to test on the EPenguin.

Fixes #1992.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charger availability detection for single-connector chargers.
  * Availability now correctly reflects connector status when station-level status is unavailable.
  * Prevented incorrect fallback behavior for multi-connector chargers.
  * Preserved station-level availability when it is available.

* **Tests**
  * Added coverage for availability states, connector configurations, status precedence, and OCPP 1.6 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->