### PR TITLE
Parse custom_profile as JSON first so apostrophes and mappings survive

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -81,7 +81,10 @@ CHRGR_SERVICE_DATA_SCHEMA = vol.Schema(
         vol.Optional("limit_amps"): cv.positive_float,
         vol.Optional("limit_watts"): cv.positive_int,
         vol.Optional("conn_id"): cv.positive_int,
-        vol.Optional("custom_profile"): vol.Any(cv.string, dict),
+        # Keep a mapping returned by Home Assistant's template engine as a
+        # mapping. cv.string deliberately unwraps ResultWrapper dictionaries
+        # to their rendered text, so it must be tried after dict.
+        vol.Optional("custom_profile"): vol.Any(dict, cv.string),
     }
 )
 CUSTMSG_SERVICE_DATA_SCHEMA = vol.Schema(
@@ -99,6 +102,72 @@ CLEAR_PROFILE_SERVICE_DATA_SCHEMA = vol.Schema(
 
 def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9]", "", str(s).lower())
+
+
+def _invalid_custom_profile(message: str) -> HomeAssistantError:
+    """Create a caller-visible error without exposing the supplied profile."""
+    return HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="invalid_custom_profile",
+        translation_placeholders={"message": message},
+    )
+
+
+def _json_error_message(error: json.JSONDecodeError) -> str:
+    """Describe a JSON syntax error without including the input document."""
+    return f"invalid JSON: {error.msg} at line {error.lineno}, column {error.colno}"
+
+
+def _parse_custom_profile(custom_profile: dict | str, cp_id: str) -> dict:
+    """Return a custom profile mapping, preserving valid JSON verbatim."""
+    if isinstance(custom_profile, dict):
+        return custom_profile
+
+    if not isinstance(custom_profile, str):
+        raise _invalid_custom_profile(
+            f"expected a mapping or JSON object, got {type(custom_profile).__name__}"
+        )
+
+    used_legacy_fallback = False
+    try:
+        profile = json.loads(custom_profile)
+    except json.JSONDecodeError as original_error:
+        if "'" not in custom_profile:
+            raise _invalid_custom_profile(
+                _json_error_message(original_error)
+            ) from original_error
+
+        try:
+            profile = json.loads(custom_profile.replace("'", '"'))
+        except json.JSONDecodeError as legacy_error:
+            raise _invalid_custom_profile(
+                f"{_json_error_message(original_error)}; "
+                "legacy single-quote compatibility parsing also failed"
+            ) from legacy_error
+        except (ValueError, RecursionError) as legacy_error:
+            raise _invalid_custom_profile(
+                f"{_json_error_message(original_error)}; legacy single-quote "
+                "compatibility parsing exceeded JSON parser limits"
+            ) from legacy_error
+        used_legacy_fallback = True
+    except (ValueError, RecursionError) as parser_error:
+        raise _invalid_custom_profile(
+            "JSON could not be decoded within parser limits"
+        ) from parser_error
+
+    if not isinstance(profile, dict):
+        raise _invalid_custom_profile(
+            f"expected a JSON object, got {type(profile).__name__}"
+        )
+
+    if used_legacy_fallback:
+        _LOGGER.debug(
+            "%s: parsed custom_profile using legacy single-quote compatibility; "
+            "prefer a mapping or valid JSON object",
+            cp_id,
+        )
+
+    return profile
 
 
 class CentralSystem:
@@ -760,20 +829,18 @@ class CentralSystem:
 
     @check_charger_available
     async def handle_set_charge_rate(self, call, cp):
-        """Handle the data transfer service call."""
+        """Handle the charge-rate service call."""
         amps = call.data.get("limit_amps", None)
         watts = call.data.get("limit_watts", None)
-        id = call.data.get("conn_id", 0)
+        conn_id = call.data.get("conn_id", 0)
         custom_profile = call.data.get("custom_profile", None)
         if custom_profile is not None:
-            if type(custom_profile) is str:
-                custom_profile = custom_profile.replace("'", '"')
-                custom_profile = json.loads(custom_profile)
-            await cp.set_charge_rate(profile=custom_profile, conn_id=id)
+            profile = _parse_custom_profile(custom_profile, cp.id)
+            await cp.set_charge_rate(profile=profile, conn_id=conn_id)
         elif watts is not None:
-            await cp.set_charge_rate(limit_watts=watts, conn_id=id)
+            await cp.set_charge_rate(limit_watts=watts, conn_id=conn_id)
         elif amps is not None:
-            await cp.set_charge_rate(limit_amps=amps, conn_id=id)
+            await cp.set_charge_rate(limit_amps=amps, conn_id=conn_id)
 
     @check_charger_available
     async def handle_configure(self, call, cp) -> ServiceResponse:

--- a/custom_components/ocpp/services.yaml
+++ b/custom_components/ocpp/services.yaml
@@ -46,7 +46,7 @@ set_charge_rate:
       default: 0
     custom_profile:
       name: Custom profile
-      description: Used to send a custom charge profile to charger (for advanced users only use >- or '' to ensure profile is a string variable)
+      description: Raw OCPP charging profile. Prefer a YAML mapping, including a template that returns a mapping. A valid JSON object string is also accepted; single-quoted object strings remain supported for compatibility.
       required: false
       advanced: true
       example: '{"chargingProfileId":8,"stackLevel":0,"chargingProfileKind":"Relative","chargingProfilePurpose":"ChargePointMaxProfile","chargingSchedule":{"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16}]}}'

--- a/custom_components/ocpp/translations/en.json
+++ b/custom_components/ocpp/translations/en.json
@@ -112,6 +112,9 @@
         "set_charge_rate_error": {
             "message": "Failed to set charging current limit: {message}"
         },
+        "invalid_custom_profile": {
+            "message": "Invalid custom charging profile: {message}"
+        },
         "unavailable": {
             "message": "Charger is currently unavailable: {message}"
         },

--- a/custom_components/ocpp/translations/i-default.json
+++ b/custom_components/ocpp/translations/i-default.json
@@ -115,6 +115,9 @@
         "set_charge_rate_error": {
             "message": "Failed to set charging current limit: {message}"
         },
+        "invalid_custom_profile": {
+            "message": "Invalid custom charging profile: {message}"
+        },
         "not_found": {
             "message": "No charger found for device id {message}. Check the devid matches the HA charger id (cpid) or the OCPP charger id."
         },

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -1,6 +1,8 @@
 """Test exceptions paths in api.py."""
 
 import contextlib
+import json
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -9,9 +11,11 @@ from ocpp.v16.enums import ChargePointStatus
 
 from homeassistant.const import STATE_OK, STATE_UNAVAILABLE
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import template as template_helper
+from homeassistant.util.yaml.objects import NodeStrClass
 from websockets import NegotiationError
 
-from custom_components.ocpp.api import CentralSystem
+from custom_components.ocpp.api import CHRGR_SERVICE_DATA_SCHEMA, CentralSystem
 from custom_components.ocpp.const import DOMAIN
 from custom_components.ocpp.enums import (
     HAChargerServices as csvcs,
@@ -118,9 +122,17 @@ def _install_dummy_cp(
     cs: CentralSystem, *, cpid="test_cpid", cp_id="CP_DUMMY", **kw
 ) -> DummyCP:
     cp = DummyCP(**kw)
+    cp.id = cp_id
     cs.charge_points[cp_id] = cp
     cs.cpids[cpid] = cp_id
     return cp
+
+
+def _available_central_system(hass) -> tuple[CentralSystem, DummyCP]:
+    """Create a central system with one available charge point."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    cs = CentralSystem(hass, entry)
+    return cs, _install_dummy_cp(cs, cpid="ok", cp_id="CP_OK")
 
 
 @pytest.mark.asyncio
@@ -479,6 +491,307 @@ async def test_check_charger_available_decorator_and_services(hass):
         SimpleNamespace(data={"devid": "ok", "ocpp_key": "Foo"}),
     )
     assert resp == {"value": "value-for:Foo"}
+
+
+@pytest.mark.asyncio
+async def test_custom_profile_mapping_bypasses_string_parsing(hass):
+    """A structured profile reaches the charge point as the same mapping."""
+    cs, cp = _available_central_system(hass)
+    profile = {"id": 1, "transactionId": "session'42"}
+
+    await cs.handle_set_charge_rate(
+        SimpleNamespace(data={"devid": "ok", "conn_id": 2, "custom_profile": profile})
+    )
+
+    assert cp.calls == [("set_charge_rate", {"profile": profile, "conn_id": 2})]
+    assert cp.calls[0][1]["profile"] is profile
+
+
+@pytest.mark.asyncio
+async def test_custom_profile_literal_yaml_string_is_parsed(hass):
+    """Annotated YAML strings must not be sent raw to the OCPP layer."""
+    cs, cp = _available_central_system(hass)
+    profile = NodeStrClass('{"id":1,"transactionId":"session\'42"}')
+    data = CHRGR_SERVICE_DATA_SCHEMA(
+        {"devid": "ok", "conn_id": 1, "custom_profile": profile}
+    )
+
+    assert data["custom_profile"] is profile
+    await cs.handle_set_charge_rate(SimpleNamespace(data=data))
+
+    assert cp.calls == [
+        (
+            "set_charge_rate",
+            {
+                "profile": {"id": 1, "transactionId": "session'42"},
+                "conn_id": 1,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_valid_json_custom_profile_preserves_apostrophe(hass):
+    """A legal apostrophe in a JSON string must not prevent dispatch."""
+    cs, cp = _available_central_system(hass)
+
+    await cs.handle_set_charge_rate(
+        SimpleNamespace(
+            data={
+                "devid": "ok",
+                "custom_profile": '{"id":1,"transactionId":"session\'42"}',
+            }
+        )
+    )
+
+    assert cp.calls == [
+        (
+            "set_charge_rate",
+            {
+                "profile": {"id": 1, "transactionId": "session'42"},
+                "conn_id": 0,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_valid_json_custom_profile_cannot_redirect_fields(hass):
+    """Charger text inside valid JSON remains data rather than structure."""
+    cs, cp = _available_central_system(hass)
+    transaction_id = "x','id':2,'transactionId':'y"
+
+    await cs.handle_set_charge_rate(
+        SimpleNamespace(
+            data={
+                "devid": "ok",
+                "custom_profile": (
+                    "{\"id\":1,\"transactionId\":\"x','id':2,'transactionId':'y\"}"
+                ),
+            }
+        )
+    )
+
+    assert cp.calls == [
+        (
+            "set_charge_rate",
+            {
+                "profile": {"id": 1, "transactionId": transaction_id},
+                "conn_id": 0,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_template_result_mapping_stays_structured(hass):
+    """The service schema must not turn a rendered mapping back into text."""
+    cs, cp = _available_central_system(hass)
+    transaction_id = "x','id':2,'transactionId':'y"
+    profile = {"id": 1, "transactionId": transaction_id}
+    wrapper = template_helper._parse_result(repr(profile))
+
+    assert isinstance(wrapper, dict)
+    data = CHRGR_SERVICE_DATA_SCHEMA(
+        {"devid": "ok", "conn_id": 2, "custom_profile": wrapper}
+    )
+    assert data["custom_profile"] is wrapper
+
+    await cs.handle_set_charge_rate(SimpleNamespace(data=data))
+
+    assert cp.calls == [("set_charge_rate", {"profile": profile, "conn_id": 2})]
+    assert cp.calls[0][1]["profile"] is wrapper
+
+
+@pytest.mark.asyncio
+async def test_legacy_custom_profile_logs_payload_free_debug(hass, caplog):
+    """Keep legacy parsing while making its use diagnosable without payloads."""
+    cs, cp = _available_central_system(hass)
+    transaction_id = "legacy-session"
+    custom_profile = f"{{'id':2,'transactionId':'{transaction_id}'}}"
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.ocpp"):
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": custom_profile})
+        )
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "legacy single-quote compatibility" in record.getMessage()
+    ]
+    assert cp.calls == [
+        (
+            "set_charge_rate",
+            {
+                "profile": {"id": 2, "transactionId": transaction_id},
+                "conn_id": 0,
+            },
+        )
+    ]
+    assert len(messages) == 1
+    assert "CP_OK" in messages[0]
+    assert custom_profile not in messages[0]
+    assert transaction_id not in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_invalid_custom_profile_reports_original_json_position(hass):
+    """Syntax errors describe the caller's JSON and never dispatch a limit."""
+    cs, cp = _available_central_system(hass)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(
+                data={
+                    "devid": "ok",
+                    "custom_profile": "{'id':",
+                    "limit_amps": 16,
+                }
+            )
+        )
+
+    assert exc_info.value.translation_key == "invalid_custom_profile"
+    message = exc_info.value.translation_placeholders["message"]
+    assert "Expecting property name enclosed in double quotes" in message
+    assert "line 1, column 2" in message
+    assert "legacy single-quote compatibility parsing also failed" in message
+    assert cp.calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_without_apostrophe_skips_legacy_fallback(hass):
+    """Plain malformed JSON reports its location without claiming a fallback."""
+    cs, cp = _available_central_system(hass)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": '{"id":'})
+        )
+
+    message = exc_info.value.translation_placeholders["message"]
+    assert exc_info.value.translation_key == "invalid_custom_profile"
+    assert "Expecting value" in message
+    assert "line 1, column 7" in message
+    assert "legacy" not in message
+    assert cp.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [ValueError, RecursionError])
+async def test_json_parser_limit_error_is_translated(hass, monkeypatch, error_type):
+    """Non-syntax decoder limits must not escape as unexpected errors."""
+    cs, cp = _available_central_system(hass)
+
+    def exceed_parser_limit(_custom_profile):
+        raise error_type("parser detail must not reach the caller")
+
+    monkeypatch.setattr("custom_components.ocpp.api.json.loads", exceed_parser_limit)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": '{"id":1}'})
+        )
+
+    assert exc_info.value.translation_key == "invalid_custom_profile"
+    assert exc_info.value.translation_placeholders["message"] == (
+        "JSON could not be decoded within parser limits"
+    )
+    assert cp.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [ValueError, RecursionError])
+async def test_legacy_json_parser_limit_error_is_translated(
+    hass, monkeypatch, error_type
+):
+    """A parser limit in the legacy candidate retains the original location."""
+    cs, cp = _available_central_system(hass)
+    parse_attempts = 0
+
+    def exceed_legacy_parser_limit(custom_profile):
+        nonlocal parse_attempts
+        parse_attempts += 1
+        if parse_attempts == 1:
+            raise json.JSONDecodeError(
+                "Expecting property name enclosed in double quotes",
+                custom_profile,
+                1,
+            )
+        raise error_type("parser detail must not reach the caller")
+
+    monkeypatch.setattr(
+        "custom_components.ocpp.api.json.loads", exceed_legacy_parser_limit
+    )
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": "{'id':1}"})
+        )
+
+    message = exc_info.value.translation_placeholders["message"]
+    assert exc_info.value.translation_key == "invalid_custom_profile"
+    assert "Expecting property name enclosed in double quotes" in message
+    assert "line 1, column 2" in message
+    assert "compatibility parsing exceeded JSON parser limits" in message
+    assert "parser detail" not in message
+    assert parse_attempts == 2
+    assert cp.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unexpected_custom_profile_type_is_rejected(hass):
+    """Keep direct handler calls from forwarding an unsupported value type."""
+    cs, cp = _available_central_system(hass)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": ["profile"]})
+        )
+
+    assert exc_info.value.translation_key == "invalid_custom_profile"
+    assert exc_info.value.translation_placeholders["message"] == (
+        "expected a mapping or JSON object, got list"
+    )
+    assert cp.calls == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_non_object_is_rejected_without_success_log(hass, caplog):
+    """A syntactically compatible scalar is not a successful legacy profile."""
+    cs, cp = _available_central_system(hass)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="custom_components.ocpp"),
+        pytest.raises(HomeAssistantError),
+    ):
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": "['profile']"})
+        )
+
+    assert not any(
+        "legacy single-quote compatibility" in record.getMessage()
+        for record in caplog.records
+    )
+    assert cp.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("custom_profile", ["null", "[]", "42", "true", '"text"'])
+async def test_non_object_custom_profile_is_rejected(hass, custom_profile):
+    """Only JSON objects can cross the custom-profile service boundary."""
+    cs, cp = _available_central_system(hass)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await cs.handle_set_charge_rate(
+            SimpleNamespace(data={"devid": "ok", "custom_profile": custom_profile})
+        )
+
+    assert exc_info.value.translation_key == "invalid_custom_profile"
+    assert "expected a JSON object" in str(
+        exc_info.value.translation_placeholders["message"]
+    )
+    assert cp.calls == []
 
 
 def test_del_metric_variants(hass):

--- a/tests/test_charge_point_v201.py
+++ b/tests/test_charge_point_v201.py
@@ -3,10 +3,12 @@
 import asyncio
 import copy
 from datetime import datetime, timedelta, UTC
+import json
 
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import template as template_helper
 from ocpp.v16.enums import Measurand
 
 from custom_components.ocpp.const import CONF_CPIDS, CONF_CPID, DOMAIN
@@ -985,8 +987,61 @@ async def _test_charge_profiles(
         ],
     }
 
-    await set_number(hass, cpid, "maximum_current", 12)
+    transaction_id = "x','id':2,'transactionId':'y"
+
+    def custom_tx_profile(profile_id: int) -> dict:
+        return {
+            "id": profile_id,
+            "stackLevel": 1,
+            "chargingProfilePurpose": "TxProfile",
+            "chargingProfileKind": "Relative",
+            "transactionId": transaction_id,
+            "chargingSchedule": [
+                {
+                    "id": 1,
+                    "chargingRateUnit": "A",
+                    "chargingSchedulePeriod": [{"startPeriod": 0, "limit": 6}],
+                }
+            ],
+        }
+
+    json_profile = custom_tx_profile(3)
+    error = await _set_charge_rate_service(
+        hass,
+        {
+            "devid": cpid,
+            "conn_id": 1,
+            "custom_profile": json.dumps(json_profile),
+        },
+    )
+    assert error is None
     assert len(cp.charge_profiles_set) == 4
+    assert cp.charge_profiles_set[-1].evse_id == 1
+    assert cp.charge_profiles_set[-1].charging_profile["id"] == 3
+    assert (
+        cp.charge_profiles_set[-1].charging_profile["transaction_id"] == transaction_id
+    )
+
+    wrapped_profile = template_helper._parse_result(repr(custom_tx_profile(4)))
+    assert isinstance(wrapped_profile, dict)
+    error = await _set_charge_rate_service(
+        hass,
+        {
+            "devid": cpid,
+            "conn_id": 1,
+            "custom_profile": wrapped_profile,
+        },
+    )
+    assert error is None
+    assert len(cp.charge_profiles_set) == 5
+    assert cp.charge_profiles_set[-1].evse_id == 1
+    assert cp.charge_profiles_set[-1].charging_profile["id"] == 4
+    assert (
+        cp.charge_profiles_set[-1].charging_profile["transaction_id"] == transaction_id
+    )
+
+    await set_number(hass, cpid, "maximum_current", 12)
+    assert len(cp.charge_profiles_set) == 6
     assert cp.charge_profiles_set[-1].evse_id == 0
     assert cp.charge_profiles_set[-1].charging_profile == {
         "id": 1,


### PR DESCRIPTION
Closes #2100

`ocpp.set_charge_rate` rewrote every `'` in a string `custom_profile` to `"` before calling `json.loads`. A legal apostrophe inside a JSON string value therefore broke the document or, worse, turned charger-originated text into structure (a 2.0.1 `transactionId` is a free-form string). The service schema had the same blind spot from the other side: `vol.Any(cv.string, dict)` tried `cv.string` first, which unwraps a template-rendered mapping to its text form, so a caller who passed a mapping still ended up on the string path.

**What changes**

- A `custom_profile` string is parsed with `json.loads` first, verbatim. The single-quote replacement is kept only as a compatibility fallback, tried when the document is not valid JSON and contains a `'`, and its use is logged at debug level without the payload.
- The schema tries `dict` before `cv.string`, so a mapping (including one returned by a template) reaches the charge point unchanged.
- A profile that does not parse, or parses to something other than an object, now raises `HomeAssistantError` with a new `invalid_custom_profile` translation (the position of the syntax error, never the payload) instead of an unhandled `JSONDecodeError`. Decoder limit errors (`ValueError`, `RecursionError`) are translated the same way. Both translation files carry the new key.
- The `custom_profile` description in `services.yaml` now recommends a mapping and says which strings are accepted.

**Tests**

- `tests/test_api_paths.py`: mapping passthrough with identity preserved, YAML `NodeStrClass` strings, apostrophe preservation, charger text inside valid JSON staying data rather than becoming fields, template `ResultWrapper` mappings staying structured, the legacy fallback with its payload-free debug line, error position reporting with and without the fallback, decoder-limit translation, and rejection of non-object and unexpected-type inputs.
- `tests/test_charge_point_v201.py`: a custom TxProfile carrying an apostrophe-laden `transactionId`, sent both as a JSON string and as a wrapped mapping, arrives at the charger verbatim on the requested EVSE.

The 1.6 and 2.0.1 `set_charge_rate` implementations are untouched; only the parsing at the service boundary changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom charging profiles now accept YAML mappings, template-generated mappings, valid JSON objects, and legacy single-quoted object strings.
  * Charging profile validation provides clearer, translated error messages for invalid or unsupported input.
  * Profile values, including embedded quotes and transaction identifiers, are preserved correctly.

* **Documentation**
  * Updated service guidance to describe supported custom-profile formats.

* **Tests**
  * Added coverage for profile parsing, validation, templates, malformed input, and charge-profile submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->