### PR TITLE
Switch to session-energy mode instead of publishing negative session energy

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -1100,12 +1100,46 @@ class ChargePoint(cp):
                                     (target_cid, csess.session_energy)
                                 ].unit = unit
                             elif ms_metric.unit == unit:
-                                self._metrics[
-                                    (target_cid, csess.session_energy)
-                                ].value = round(1000 * (value - ms_metric.value)) / 1000
-                                self._metrics[
-                                    (target_cid, csess.session_energy)
-                                ].unit = unit
+                                derived = round(1000 * (value - ms_metric.value)) / 1000
+                                if derived < 0:
+                                    # A transaction-bound EAIR sample below
+                                    # meter_start cannot be a lifetime register
+                                    # reading. The charger is reporting SESSION
+                                    # energy in MeterValues while StartTransaction
+                                    # reported a lifetime meter_start, so the
+                                    # meter_start == 0 detection above never
+                                    # fired. Switch to session-energy mode and
+                                    # use the sample as-is, rather than
+                                    # publishing a negative to a
+                                    # total_increasing sensor.
+                                    _LOGGER.warning(
+                                        "%s[%s]: Energy.Active.Import.Register "
+                                        "sample %s %s is below meter_start %s %s "
+                                        "(would give session energy %s). Treating "
+                                        "this charger as reporting session energy "
+                                        "directly.",
+                                        csess.session_energy,
+                                        target_cid,
+                                        value,
+                                        unit,
+                                        ms_metric.value,
+                                        ms_metric.unit,
+                                        derived,
+                                    )
+                                    self._charger_reports_session_energy = True
+                                    self._metrics[
+                                        (target_cid, csess.session_energy)
+                                    ].value = value
+                                    self._metrics[
+                                        (target_cid, csess.session_energy)
+                                    ].unit = unit
+                                else:
+                                    self._metrics[
+                                        (target_cid, csess.session_energy)
+                                    ].value = derived
+                                    self._metrics[
+                                        (target_cid, csess.session_energy)
+                                    ].unit = unit
                 else:
                     unprocessed.append(sampled_value)
 

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -1044,6 +1044,38 @@ class ChargePoint(cp):
                     if is_eair and idx != best_eair_idx:
                         continue
 
+                    # A transaction-bound EAIR sample below meter_start cannot
+                    # be a lifetime register reading: the charger is reporting
+                    # SESSION energy in MeterValues while StartTransaction
+                    # reported a lifetime meter_start, so the meter_start == 0
+                    # detection above never fired. Switch mode here, before
+                    # skip_eair is evaluated, so the sample is neither written to
+                    # the lifetime metric nor published as a negative on a
+                    # total_increasing sensor.
+                    if (
+                        is_eair
+                        and is_transaction
+                        and not self._charger_reports_session_energy
+                    ):
+                        ms_metric = self._metrics[(target_cid, csess.meter_start)]
+                        if (
+                            ms_metric.value is not None
+                            and ms_metric.unit == unit
+                            and value < ms_metric.value
+                        ):
+                            _LOGGER.warning(
+                                "%s[%s]: Energy.Active.Import.Register sample "
+                                "%s %s is below meter_start %s %s. Treating this "
+                                "charger as reporting session energy directly.",
+                                csess.session_energy,
+                                target_cid,
+                                value,
+                                unit,
+                                ms_metric.value,
+                                ms_metric.unit,
+                            )
+                            self._charger_reports_session_energy = True
+
                     # Determine whether to skip writing EAIR to the main metric:
                     # - Skip only if this is an EAIR reading,
                     # - AND the charger reports session energy (meter_start == 0),
@@ -1100,46 +1132,12 @@ class ChargePoint(cp):
                                     (target_cid, csess.session_energy)
                                 ].unit = unit
                             elif ms_metric.unit == unit:
-                                derived = round(1000 * (value - ms_metric.value)) / 1000
-                                if derived < 0:
-                                    # A transaction-bound EAIR sample below
-                                    # meter_start cannot be a lifetime register
-                                    # reading. The charger is reporting SESSION
-                                    # energy in MeterValues while StartTransaction
-                                    # reported a lifetime meter_start, so the
-                                    # meter_start == 0 detection above never
-                                    # fired. Switch to session-energy mode and
-                                    # use the sample as-is, rather than
-                                    # publishing a negative to a
-                                    # total_increasing sensor.
-                                    _LOGGER.warning(
-                                        "%s[%s]: Energy.Active.Import.Register "
-                                        "sample %s %s is below meter_start %s %s "
-                                        "(would give session energy %s). Treating "
-                                        "this charger as reporting session energy "
-                                        "directly.",
-                                        csess.session_energy,
-                                        target_cid,
-                                        value,
-                                        unit,
-                                        ms_metric.value,
-                                        ms_metric.unit,
-                                        derived,
-                                    )
-                                    self._charger_reports_session_energy = True
-                                    self._metrics[
-                                        (target_cid, csess.session_energy)
-                                    ].value = value
-                                    self._metrics[
-                                        (target_cid, csess.session_energy)
-                                    ].unit = unit
-                                else:
-                                    self._metrics[
-                                        (target_cid, csess.session_energy)
-                                    ].value = derived
-                                    self._metrics[
-                                        (target_cid, csess.session_energy)
-                                    ].unit = unit
+                                self._metrics[
+                                    (target_cid, csess.session_energy)
+                                ].value = round(1000 * (value - ms_metric.value)) / 1000
+                                self._metrics[
+                                    (target_cid, csess.session_energy)
+                                ].unit = unit
                 else:
                     unprocessed.append(sampled_value)
 

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -4112,6 +4112,15 @@ async def test_eair_session_relative_against_lifetime_meter_start(
             assert s1 >= 0, f"session energy went negative: {s1}"
             assert s1 == pytest.approx(0.113, rel=1e-6)
 
+            # The session-relative sample must NOT land on the lifetime
+            # register metric. (Read only after the fact: _metrics is a
+            # defaultdict, so reading a key beforehand creates it and changes
+            # the behaviour under test.)
+            eair = cs.get_metric(cpid, "Energy.Active.Import.Register", connector_id=1)
+            assert eair != pytest.approx(0.113, rel=1e-6), (
+                f"lifetime register was overwritten with the session value: {eair}"
+            )
+
             # Subsequent samples keep tracking the session, still positive.
             mv2 = call.MeterValues(
                 connector_id=1,

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -4051,6 +4051,101 @@ async def test_eair_monotonic_increments_single_connector(
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "setup_config_entry",
+    [{"port": 9398, "cp_id": "CP_eair_session_relative", "cms": "cms_services"}],
+    indirect=True,
+)
+@pytest.mark.parametrize("cp_id", ["CP_eair_session_relative"])
+@pytest.mark.parametrize("port", [9398])
+async def test_eair_session_relative_against_lifetime_meter_start(
+    hass, socket_enabled, cp_id, port, setup_config_entry
+):
+    """Session energy must never go negative when EAIR is session-relative.
+
+    Some chargers report a LIFETIME register in StartTransaction but
+    SESSION-relative energy in the MeterValues that follow. The
+    ``meter_start == 0`` detection never fires for them, so the else-branch
+    derives ``session = EAIR - meter_start`` and produces a large negative
+    value on a ``total_increasing`` sensor.
+
+    Once a tx-bound sample lands below ``meter_start`` the charger cannot be
+    reporting a lifetime register, so we switch to session-energy mode and use
+    the sample as-is.
+    """
+    cs = setup_config_entry
+    async with websockets.connect(
+        f"ws://127.0.0.1:{port}/{cp_id}", subprotocols=["ocpp1.6"]
+    ) as ws:
+        client = ChargePoint(f"{cp_id}_client", ws)
+        task = asyncio.create_task(client.start())
+        try:
+            await client.send_boot_notification()
+            await wait_ready(cs.charge_points[cp_id])
+            srv = cs.charge_points[cp_id]
+            cpid = srv.settings.cpid
+
+            # StartTransaction reports the LIFETIME register: 4076447 Wh.
+            await client.send_start_transaction(meter_start=4076447)
+            txid = client.active_transactionId
+
+            # First in-transaction sample is SESSION-relative: 113 Wh.
+            # Naively this derives 0.113 - 4076.447 = -4076.334 kWh.
+            mv1 = call.MeterValues(
+                connector_id=1,
+                transaction_id=txid,
+                meter_value=[
+                    {
+                        "timestamp": datetime.now(tz=UTC).isoformat(),
+                        "sampledValue": [
+                            {
+                                "value": "113",
+                                "measurand": "Energy.Active.Import.Register",
+                                "unit": "Wh",
+                                "context": "Sample.Periodic",
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert await client.call(mv1) is not None
+            s1 = cs.get_metric(cpid, "Energy.Session", connector_id=1)
+            assert s1 is not None
+            assert s1 >= 0, f"session energy went negative: {s1}"
+            assert s1 == pytest.approx(0.113, rel=1e-6)
+
+            # Subsequent samples keep tracking the session, still positive.
+            mv2 = call.MeterValues(
+                connector_id=1,
+                transaction_id=txid,
+                meter_value=[
+                    {
+                        "timestamp": datetime.now(tz=UTC).isoformat(),
+                        "sampledValue": [
+                            {
+                                "value": "236",
+                                "measurand": "Energy.Active.Import.Register",
+                                "unit": "Wh",
+                                "context": "Sample.Periodic",
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert await client.call(mv2) is not None
+            s2 = cs.get_metric(cpid, "Energy.Session", connector_id=1)
+            assert s2 >= 0, f"session energy went negative: {s2}"
+            assert s2 == pytest.approx(0.236, rel=1e-6)
+            assert s2 >= s1
+
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await ws.close()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize(
+    "setup_config_entry",
     [{"port": 9351, "cp_id": "CP_set_rate_active_tx", "cms": "cms_services"}],
     indirect=True,
 )


### PR DESCRIPTION
Fixes #2093.

Per @drc38's direction on that issue, this is the **mode-switch fix only** — the measurand
configuration side is left alone.

## The problem

Some chargers report a **lifetime register** in `StartTransaction` but **session-relative** energy in
the `MeterValues` that follow. The `meter_start == 0` detection at `chargepoint.py:1029` never fires
for them, so the `else` branch derives `session = EAIR - meter_start` and publishes a large negative
value to a `state_class: total_increasing` sensor.

On my Grizzl-E that produced `-4076.334` where the true session energy was `0.113`.

Nothing is logged when it happens — no warning, no error. The only trace is the corrupted value,
which is why it went unnoticed for a long time.

## The change

Once a transaction-bound EAIR sample lands **below** `meter_start`, the charger cannot be reporting a
lifetime register. Rather than publishing the negative, we conclude what the sample proves: switch
`_charger_reports_session_energy` on and let the existing session-energy branch use the value as-is.

The detection sits immediately **before `skip_eair` is computed**, which matters. `skip_eair` is
evaluated ahead of the session-handling block, so a switch made later would come too late to stop
that first session-relative sample being written to the lifetime
`Energy.Active.Import.Register` metric. Placing it earlier prevents both the negative session value
*and* the clobbered lifetime register. (Thanks to CodeRabbit for catching the second one — an
earlier revision of this PR fixed only the first.)

Because the flag is set before the existing branches run, **the derivation branch needs no change at
all.** This diff is a pure addition — `+136 / -0`, modifying no existing line.

That fixes rather than mitigates: session energy tracks live for the whole charge instead of being
suppressed or frozen. Chargers that genuinely report a lifetime register are unaffected — the sample
is never below `meter_start` for them, so the new branch is never entered.

I deliberately did **not** scope this at the candidate pre-selector (`if kwh < 0.0 ...`, ~line 963).
Rejecting below-baseline EAIR globally would break the `_charger_reports_session_energy` path, where
a session legitimately starts at 0 and counts up.

## Prior art

This is close to a regression. #1710 (v0.10.2) added:

```python
# Compute positive delta only (guard against counter resets)
delta = value - ms_metric.value
if delta >= 0:
    self._metrics[sess_key].value = round(delta, 6)
```

#1722 (v0.10.3) removed it six days later as part of the multi-connector refactor — it isn't
mentioned in that PR's description and I don't think it was intentional. Verified per tag: present in
v0.10.2, absent from v0.10.3 onward.

The mode switch here is a superset of that guard: it prevents the negative *and* keeps the reading.

## Why the existing test doesn't catch it

`test_eair_monotonic_increments_single_connector` was added in the same PR that removed the guard,
and tests exactly this property — but its fixture feeds a monotonically increasing register
(1000 → 1500 → 1550 Wh) and never sends a sample below `meter_start`, so `derived` is never negative
and the branch is never reached.

The new test closes that gap: `StartTransaction` with a lifetime `meter_start` (4076447 Wh) followed
by session-relative MeterValues (113 Wh, 236 Wh). It asserts session energy stays non-negative and
tracks the samples, and that the lifetime register is not overwritten with the session value. It
fails on current `main` with `session energy went negative: -4076.334`, and passes with this change.

One note if you extend it: the lifetime-register check must be made **only after** the sample is
processed. `_metrics` is a `defaultdict`, so reading a key beforehand to capture a baseline creates
it and changes which branch runs.

## Verification

Running this on my own charger:

| | before | after |
|---|---|---|
| Session energy during charge | `-4076` every 60 s | tracks live |
| Warnings | none (silent) | exactly one, at the switch |

Longest run: **5.28 hours, 608 samples, 0.049 → 37.14 kWh, strictly monotonic, zero negatives** —
cross-checked against an independent CT clamp on the same circuit (7,188 W mean vs 7.02 kW derived,
~2%). Across five days and 1,040 recorded points there has not been a single negative.

For scale on the original problem: the same sensor's history holds **29,738 negative points out of
32,659** over the ten months before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session-energy sensors from reporting negative values when chargers provide session-relative readings alongside lifetime meter values.
  * Automatically switches to using the charger’s raw session-energy readings when a negative derived value is detected.
  * Prevented session-relative readings from overwriting lifetime energy totals.
  * Preserved existing behavior for valid, non-negative energy calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->