### PR TITLE
Fix zero-valued phase placeholders in charge-rate conversion

### DIFF
--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -479,7 +479,14 @@ class ChargePoint(cp):
         return _DEFAULT_LINE_VOLTAGE
 
     def _phase_count(self, conn_id: int) -> int:
-        """Count explicitly reported phases; conservatively default to one."""
+        """Count electrically active phases; conservatively default to one.
+
+        Some chargers publish placeholders for every phase even on a
+        single-phase installation.  Counting those keys turns a 16 A limit
+        into 16 A * 230 V * 3 for power-only chargers, although L2 and L3 are
+        explicitly reported as zero.  Count only phase values that carry a
+        meaningful voltage/current instead.
+        """
         measurands = (
             Measurand.voltage.value,
             Measurand.current_import.value,
@@ -490,9 +497,21 @@ class ChargePoint(cp):
             metric = self._lookup_metric(measurand, conn_id)
             if metric is None:
                 continue
-            keys = {str(k) for k in (metric.extra_attr or {})}
+            phase_values = {
+                str(key): value for key, value in (metric.extra_attr or {}).items()
+            }
+            threshold = 50.0 if measurand == Measurand.voltage.value else 0.1
             for group in _PHASE_KEY_GROUPS:
-                n = len(keys & group)
+                n = 0
+                for phase in group:
+                    if phase not in phase_values:
+                        continue
+                    try:
+                        value = abs(float(phase_values[phase]))
+                    except (TypeError, ValueError):
+                        continue
+                    if value >= threshold:
+                        n += 1
                 if n > best:
                     best = n
         return best if best > 0 else _DEFAULT_PHASES

--- a/tests/test_set_charge_rate_v16.py
+++ b/tests/test_set_charge_rate_v16.py
@@ -286,6 +286,35 @@ async def test_power_only_single_phase_uses_one_phase(cp_v16, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_power_only_single_phase_ignores_zero_phase_placeholders(
+    cp_v16, monkeypatch
+):
+    """Zero-valued L2/L3 placeholders must not make a charger three-phase."""
+    captured = await _accept_first_profile(cp_v16, monkeypatch, "power")
+    voltage = Metric(230.0, "V")
+    voltage.extra_attr = {"L1-N": 230.0, "L2-N": 0.0, "L3-N": 0.0}
+    current = Metric(16.0, "A")
+    current.extra_attr = {"L1": 16.0, "L2": 0.0, "L3": 0.0}
+    cp_v16._metrics[(1, Measurand.voltage.value)] = voltage
+    cp_v16._metrics[(1, Measurand.current_import.value)] = current
+
+    ok = await cp_v16.set_charge_rate(limit_amps=16, conn_id=1)
+    assert ok is True
+    unit, limit = _schedule_limit(captured[0])
+    assert unit == ChargingRateUnitType.watts.value
+    assert limit == 3680.0  # 16 A * 230 V * 1 active phase
+
+
+def test_phase_count_defaults_to_one_when_all_phase_values_are_zero(cp_v16):
+    """An idle placeholder-only sample keeps the conservative one-phase default."""
+    current = Metric(0.0, "A")
+    current.extra_attr = {"L1": 0.0, "L2": 0.0, "L3": 0.0}
+    cp_v16._metrics[(1, Measurand.current_import.value)] = current
+
+    assert cp_v16._phase_count(1) == 1
+
+
+@pytest.mark.asyncio
 async def test_power_only_ignores_uncorrelated_cached_power_and_current(
     cp_v16, monkeypatch
 ):


### PR DESCRIPTION
Fixes #2117.

## Summary

- Count electrically active phase values instead of merely counting phase keys during OCPP 1.6 current/power conversion.
- Ignore zero-valued L2/L3 placeholders reported by some single-phase chargers.
- Preserve the existing conservative one-phase fallback when no active phase can be established.
- Add regression coverage for the observed placeholder shape and for an all-zero idle sample.

## Why

The current conversion introduced in #2084 correctly supports chargers that accept only power-based charging schedules. However, `_phase_count()` treats every published phase key as active.

A single-phase charger may report:

```text
Voltage: L1-N=230.0, L2-N=0.0, L3-N=0.0
Current: L1=16.0, L2=0.0, L3=0.0
```

Counting the keys converts 16 A to 11040 W instead of 3680 W. The charger can accept the over-capacity profile while applying no effective limit, leaving the Home Assistant number entity in a misleading accepted state.

The change uses a small noise floor: 50 V for voltage values and 0.1 A for current values. A genuine three-phase voltage sample continues to count as three phases; an indeterminate/all-zero sample falls back to one phase as before.

## Validation

Against current upstream `main`:

- `ruff check`: passed
- `ruff format --check`: passed
- focused `tests/test_set_charge_rate_v16.py`: 24 passed
- full test suite: 353 passed, 96% coverage

Sanitized live protocol validation on a power-only OCPP 1.6 single-phase charger:

- Maximum Current 16 A emitted `SetChargingProfile` with `chargingRateUnit=W` and `limit=3680.0`.
- Restoring 32 A emitted `limit=7360.0`.
- Both profiles were accepted and the OCPP connection remained healthy.

No network addresses, charger identifiers, credentials, or user data are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phase detection so zero, invalid, or insignificant voltage and current readings no longer inflate a charger’s phase count.
  * Corrected amp-to-watt conversion for power-only chargers with inactive phase placeholders.
  * Ensured chargers default to one active phase when no meaningful phase readings are available.

* **Tests**
  * Added coverage for zero-valued phase placeholders and single-phase conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->