### PR TITLE
Fix reconnect session ownership and bound retirement

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -279,6 +279,8 @@ class ChargePoint(cp):
         # resolved; bounds the full-update fallback to the startup window.
         self._targeted_refresh_ready = False
         self.tasks = None
+        self._session = None
+        self._reconnect_token = None
         self._charger_reports_session_energy = False
 
         # Connector-aware, but backwards compatible:
@@ -575,8 +577,12 @@ class ChargePoint(cp):
     async def run(self, tasks):
         """Run a specified list of tasks."""
         self.tasks = [asyncio.ensure_future(task) for task in tasks]
+        # Capture ownership before yielding; a retiring run must never stop a
+        # replacement that has since overwritten self._connection/self.tasks.
+        self._session = None
+        session = self._get_session()
         try:
-            await asyncio.gather(*self.tasks)
+            await asyncio.gather(*session["tasks"])
         except TimeoutError:
             pass
         except WebSocketException as websocket_exception:
@@ -587,32 +593,148 @@ class ChargePoint(cp):
                 exc_info=True,
             )
         finally:
-            await self.stop()
+            await self._stop_session(session)
+
+    def _get_session(self):
+        """Snapshot the transport and task set, including stop before start."""
+        if self._session is None:
+            self._session = {
+                "connection": self._connection,
+                "tasks": tuple(self.tasks or ()),
+                "cleanup": None,
+            }
+        return self._session
+
+    async def _close_session(self, session, caller):
+        """Bound the aggregate close/child join; retain, never abandon, survivors."""
+        connection = session["connection"]
+        tasks = [task for task in session["tasks"] if task is not caller]
+
+        async def close():
+            try:
+                if connection.state is State.OPEN:
+                    _LOGGER.debug(f"Closing websocket to '{self.id}'")
+                    await connection.close()
+            finally:
+                for task in tasks:
+                    task.cancel()
+
+        close_task = asyncio.create_task(close())
+        retirement = session["retirement"] = (*session["tasks"], close_task)
+        if not hasattr(self, "_retirement_tasks"):
+            self._retirement_tasks = set()
+
+        def observed(task):
+            self._retirement_tasks.discard(task)
+            if not task.cancelled():
+                task.exception()
+
+        for task in retirement:
+            self._retirement_tasks.add(task)
+            task.add_done_callback(observed)
+        # asyncio.wait does not wait for cancellation acknowledgement. Unlike
+        # wait_for/gather, this deadline includes a hostile close implementation.
+        _, pending = await asyncio.wait(
+            [close_task, *tasks],
+            timeout=getattr(self, "_retirement_timeout", 10.0),
+        )
+        if pending:
+            session["fault"] = True
+            for task in pending:
+                task.cancel()
+            raise TimeoutError("OCPP session retirement timed out; replacement fenced")
+        close_task.result()
+
+    async def _stop_session(self, session):
+        """Share teardown and finish it even if a waiter is repeatedly cancelled."""
+        if session is self._session:
+            self.status = STATE_UNAVAILABLE
+        if session["cleanup"] is None:
+            session["cleanup"] = asyncio.create_task(
+                self._close_session(session, asyncio.current_task())
+            )
+            session["cleanup"].add_done_callback(
+                lambda task: None if task.cancelled() else task.exception()
+            )
+        elif asyncio.current_task() in session["tasks"]:
+            # An owned child's finally may call stop while the shared cleanup
+            # is gathering that child. Let it finish instead of forming a cycle;
+            # the external stopper / run finalizer still awaits full teardown.
+            return
+        cleanup = session["cleanup"]
+        cancelled = False
+        while not cleanup.done():
+            try:
+                # wait() leaves cleanup running when this waiter is cancelled.
+                # Unlike shield(), it doesn't install Python 3.14's late-error
+                # logger on cancellation; cleanup.result() below owns errors.
+                await asyncio.wait({cleanup})
+            except asyncio.CancelledError:
+                cancelled = True
+        # Observe errors even when cancellation raced completion. Teardown
+        # errors take precedence; otherwise preserve the waiter's cancellation.
+        cleanup.result()
+        if cancelled:
+            raise asyncio.CancelledError
 
     async def stop(self):
-        """Close connection and cancel ongoing tasks."""
-        self.status = STATE_UNAVAILABLE
-        try:
-            if self._connection.state is State.OPEN:
-                _LOGGER.debug(f"Closing websocket to '{self.id}'")
-                await self._connection.close()
-        finally:
-            # Cancel regardless of how the close went: a close that raises or
-            # is cancelled must not leave monitor_connection running against a
-            # connection this charge point no longer owns.
-            for task in self.tasks or []:
-                task.cancel()
+        """Stop the current session and invalidate already pending reconnects."""
+        self._reconnect_token = None
+        await self._stop_session(self._get_session())
 
     async def reconnect(self, connection: ServerConnection):
-        """Reconnect charge point."""
+        """Retire the previous session before publishing the newest replacement."""
         _LOGGER.debug(f"Reconnect websocket to {self.id}")
-
-        await self.stop()
-        self.status = STATE_OK
-        self._connection = connection
-        self._metrics[(0, cstat.reconnects)].value += 1
-        # post connect now handled on receiving boot notification or with backstop in monitor connection
-        await self.run([super().start(), self.monitor_connection()])
+        token = self._reconnect_token = object()
+        candidate = {"connection": connection, "tasks": (), "cleanup": None}
+        installed = False
+        try:
+            session = self._get_session()
+            cleanup = session["cleanup"]
+            if (
+                cleanup is not None
+                and cleanup.done()
+                and any(
+                    not task.done()
+                    for task in session.get("retirement", session["tasks"])
+                )
+            ):
+                session["fault"] = True
+                self.status = STATE_UNAVAILABLE
+                raise TimeoutError(
+                    "OCPP retirement survivors still active; replacement fenced"
+                )
+            if (
+                cleanup is not None
+                and cleanup.done()
+                and (cleanup.cancelled() or cleanup.exception() is not None)
+            ):
+                # A failed close must reject this attempt, not poison every
+                # future reconnect. Keep old waiters' teardown outcome intact.
+                self._session = None
+                session = self._get_session()
+            await self._stop_session(session)
+            if any(
+                not task.done() for task in session.get("retirement", session["tasks"])
+            ):
+                session["fault"] = True
+                raise TimeoutError(
+                    "OCPP retirement survivors still active; replacement fenced"
+                )
+            # No await between checking admission, installing, and run capturing
+            # its task set. An overlapping reconnect supersedes this candidate;
+            # an explicit stop invalidates every request already in progress.
+            if self._reconnect_token is not token:
+                return
+            self.status = STATE_OK
+            self._connection = connection
+            self._metrics[(0, cstat.reconnects)].value += 1
+            installed = True
+            # post connect remains handled by boot notification / monitor backstop
+            await self.run([super().start(), self.monitor_connection()])
+        finally:
+            if not installed:
+                await self._stop_session(candidate)
 
     async def async_update_device_info(
         self, serial: str, vendor: str, model: str, firmware_version: str

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -281,6 +281,7 @@ class ChargePoint(cp):
         self.tasks = None
         self._session = None
         self._reconnect_token = None
+        self._retirement_tasks: set[asyncio.Task] = set()
         self._charger_reports_session_energy = False
 
         # Connector-aware, but backwards compatible:
@@ -611,6 +612,7 @@ class ChargePoint(cp):
         tasks = [task for task in session["tasks"] if task is not caller]
 
         async def close():
+            """Close this session's socket and cancel only its captured children."""
             try:
                 if connection.state is State.OPEN:
                     _LOGGER.debug(f"Closing websocket to '{self.id}'")
@@ -621,10 +623,9 @@ class ChargePoint(cp):
 
         close_task = asyncio.create_task(close())
         retirement = session["retirement"] = (*session["tasks"], close_task)
-        if not hasattr(self, "_retirement_tasks"):
-            self._retirement_tasks = set()
 
         def observed(task):
+            """Retrieve a retired task's outcome before releasing owner tracking."""
             self._retirement_tasks.discard(task)
             if not task.cancelled():
                 task.exception()
@@ -639,7 +640,6 @@ class ChargePoint(cp):
             timeout=getattr(self, "_retirement_timeout", 10.0),
         )
         if pending:
-            session["fault"] = True
             for task in pending:
                 task.cancel()
             raise TimeoutError("OCPP session retirement timed out; replacement fenced")
@@ -699,7 +699,6 @@ class ChargePoint(cp):
                     for task in session.get("retirement", session["tasks"])
                 )
             ):
-                session["fault"] = True
                 self.status = STATE_UNAVAILABLE
                 raise TimeoutError(
                     "OCPP retirement survivors still active; replacement fenced"
@@ -717,7 +716,6 @@ class ChargePoint(cp):
             if any(
                 not task.done() for task in session.get("retirement", session["tasks"])
             ):
-                session["fault"] = True
                 raise TimeoutError(
                     "OCPP retirement survivors still active; replacement fenced"
                 )

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,10 @@ transports exercise delayed finalizers, overlapping reconnects, repeated cancell
 close failures, child-initiated stop, and cancellation-resistant cleanup. A separate
 loopback WebSocket test uses real receive, Ping/Pong and Close without a charger.
 One regression deliberately exercises the production 10-second retirement deadline.
+That parameter is marked `slow`, but remains included in default runs and CI.
+For quick local iteration only, add `-m 'not slow'`; run the unfiltered suite before
+submitting changes. The loopback Ping/Pong is client-initiated, not a test of the
+integration's delayed monitor ping loop.
 
 A runner's cleanup owns its captured socket and children, not a replacement's mutable
 fields. Retirement has one aggregate deadline for socket close and child settlement.

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,3 +5,32 @@ It is recommended to use Visual Studio Code, and run home assistant in a devcont
 See [https://hacs.xyz/docs/developer/devcontainer](https://hacs.xyz/docs/developer/devcontainer)
 
 Online development is supported through [GitHub Codespaces](https://github.com/features/codespaces)
+
+## Reconnect lifecycle regression tests
+
+Run the native Home Assistant tests for session ownership and bounded retirement:
+
+```sh
+pytest tests/test_reconnect_lifecycle.py --no-cov --timeout=30
+```
+
+These tests use the integration's real constructor and lifecycle methods. Controlled
+transports exercise delayed finalizers, overlapping reconnects, repeated cancellation,
+close failures, child-initiated stop, and cancellation-resistant cleanup. A separate
+loopback WebSocket test uses real receive, Ping/Pong and Close without a charger.
+One regression deliberately exercises the production 10-second retirement deadline.
+
+A runner's cleanup owns its captured socket and children, not a replacement's mutable
+fields. Retirement has one aggregate deadline for socket close and child settlement.
+A timeout raises `TimeoutError`, retains and observes surviving tasks, and prevents
+same-object replacement while those tasks remain alive. A rejected incoming socket
+has its own cleanup budget, so a failed reconnect can consume two retirement budgets.
+Cancellation cannot interrupt settlement; a cleanup error takes precedence over caller
+cancellation. This bounds caller latency on a responsive event loop, not task lifetime
+or complete process shutdown.
+
+This is not a fence for separately scheduled `post_connect` or external service work.
+It also does not change the central system's different-protocol object-rebuild fallback:
+that fallback can construct a separate object after an old object's stop fails. Do not
+infer cross-object isolation, command replay, or charger recovery guarantees from these
+tests.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ console_output_style = count
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
+    slow: exercises the real production retirement deadline; included in CI and default runs
     allow_lifecycle_errors: this test deliberately provokes swallowed lifecycle errors (see tests/lifecycle_asserts.py)
 
 [coverage:report]

--- a/tests/test_charge_point_core.py
+++ b/tests/test_charge_point_core.py
@@ -365,10 +365,8 @@ async def test_handle_call_wraps_notimplementederror_and_sends(hass):
 # stop() must always cancel tasks
 # -----------------------------
 def _mk_task():
-    """Return a task-like object that records cancellation."""
-    task = SimpleNamespace(cancelled=False)
-    task.cancel = lambda t=task: setattr(t, "cancelled", True)
-    return task
+    """Return real owned work so cancellation and settlement are exercised."""
+    return asyncio.create_task(asyncio.Event().wait())
 
 
 @pytest.mark.asyncio
@@ -392,7 +390,7 @@ async def test_stop_cancels_tasks_when_close_fails(hass):
     with pytest.raises(OSError):
         await cp.stop()
 
-    assert all(task.cancelled for task in cp.tasks), (
+    assert all(task.cancelled() for task in cp.tasks), (
         "tasks must be cancelled even when the websocket close raises"
     )
     assert cp.status == STATE_UNAVAILABLE
@@ -419,7 +417,7 @@ async def test_stop_cancels_tasks_when_close_is_cancelled(hass):
     with pytest.raises(asyncio.CancelledError):
         await cp.stop()
 
-    assert all(task.cancelled for task in cp.tasks), (
+    assert all(task.cancelled() for task in cp.tasks), (
         "tasks must be cancelled even when the websocket close is cancelled"
     )
     assert cp.status == STATE_UNAVAILABLE
@@ -452,4 +450,4 @@ async def test_stop_closes_connection_and_cancels_tasks(hass):
     await cp.stop()
 
     assert closed == [True]
-    assert all(task.cancelled for task in cp.tasks)
+    assert all(task.cancelled() for task in cp.tasks)

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -164,6 +164,7 @@ async def test_run_handles_timeout_and_other_exception(
             stopped = {"count": 0}
 
             async def fake_stop_session(session):
+                """Count finalization of the runner's captured session."""
                 stopped["count"] += 1
 
             monkeypatch.setattr(srv, "_stop_session", fake_stop_session, raising=True)

--- a/tests/test_more_coverage_chargepoint.py
+++ b/tests/test_more_coverage_chargepoint.py
@@ -163,10 +163,10 @@ async def test_run_handles_timeout_and_other_exception(
 
             stopped = {"count": 0}
 
-            async def fake_stop():
+            async def fake_stop_session(session):
                 stopped["count"] += 1
 
-            monkeypatch.setattr(srv, "stop", fake_stop, raising=True)
+            monkeypatch.setattr(srv, "_stop_session", fake_stop_session, raising=True)
 
             async def raises_timeout():
                 await asyncio.sleep(0)

--- a/tests/test_reconnect_lifecycle.py
+++ b/tests/test_reconnect_lifecycle.py
@@ -1,0 +1,390 @@
+"""Session retirement regressions using the imported integration and HA fixtures."""
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+from ocpp.charge_point import ChargePoint as LibCP
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
+from websockets.protocol import State
+
+from homeassistant.const import STATE_UNAVAILABLE
+
+from custom_components.ocpp.enums import HAChargerStatuses as cstat
+
+from .test_charge_point_core import _mk_cp
+
+
+class Socket:
+    """Controllable transport; no external network or charger access."""
+
+    def __init__(self):
+        """Initialize an open socket with an initially unblocked close."""
+        self.state = State.OPEN
+        self.ended = asyncio.Event()
+        self.close_entered = asyncio.Event()
+        self.close_release = asyncio.Event()
+        self.close_release.set()
+        self.close_error = None
+        self.closes = 0
+
+    async def close(self):
+        """Expose a deterministic retirement barrier."""
+        self.closes += 1
+        self.close_entered.set()
+        await self.close_release.wait()
+        self.state = State.CLOSED
+        self.ended.set()
+        if self.close_error:
+            raise self.close_error
+
+
+async def ticks():
+    """Drain ready callbacks without advancing wall-clock deadlines."""
+    for _ in range(30):
+        await asyncio.sleep(0)
+
+
+@pytest.fixture
+async def lifecycle(hass, monkeypatch):
+    """Construct a real ChargePoint; replace only protocol and monitor I/O."""
+    cp = _mk_cp(hass)
+    cp._connection = Socket()
+    cp._retirement_timeout = 0.05
+    sockets = [cp._connection]
+    runners = []
+    started = {}
+    releases = []
+
+    async def receive(self):
+        connection = self._connection
+        started.setdefault(connection, asyncio.Event()).set()
+        await connection.ended.wait()
+
+    async def monitor():
+        connection = cp._connection
+        await connection.ended.wait()
+
+    monkeypatch.setattr(LibCP, "start", receive)
+    monkeypatch.setattr(cp, "monitor_connection", monitor)
+
+    def spawn(coro, name=None):
+        task = asyncio.create_task(coro, name=name)
+        runners.append(task)
+        return task
+
+    def socket():
+        connection = Socket()
+        sockets.append(connection)
+        return connection
+
+    async def began(connection):
+        await ticks()
+        assert connection in started, "replacement runner never started"
+
+    yield cp, socket, spawn, began, releases
+    for release in releases:
+        release.set()
+    for connection in sockets:
+        connection.close_release.set()
+        connection.close_error = None
+        connection.ended.set()
+    # Release hostile work before asking runners to exit, including on RED.
+    await ticks()
+    for task in runners:
+        task.cancel()
+    await asyncio.gather(*runners, return_exceptions=True)
+    await ticks()
+
+
+async def test_stale_finalizer_cannot_close_replacement(lifecycle, monkeypatch):
+    """A's delayed finally must never close B or cancel B's children."""
+    cp, socket, spawn, began, releases = lifecycle
+    old = cp._connection
+    entered, release = asyncio.Event(), asyncio.Event()
+    releases.append(release)
+    # Instrument the cleanup boundary on both upstream and fixed source.
+    method = "_stop_session" if hasattr(cp, "_stop_session") else "stop"
+    original = getattr(cp, method)
+
+    async def paused(*args):
+        if asyncio.current_task().get_name() == "old-run":
+            entered.set()
+            await release.wait()
+        return await original(*args)
+
+    monkeypatch.setattr(cp, method, paused)
+    old_runner = spawn(cp.start(), "old-run")
+    await began(old)
+    new = socket()
+    replacement = spawn(cp.reconnect(new))
+    await asyncio.wait_for(entered.wait(), 1)
+    await began(new)
+    release.set()
+    # Join the old runner, including its finalizer, before observing B. Its
+    # cancellation is expected when reconnect retires A's receive/monitor tasks.
+    await asyncio.wait_for(asyncio.gather(old_runner, return_exceptions=True), 1)
+    assert old_runner.cancelled() or old_runner.exception() is None
+    assert old.state is State.CLOSED
+    assert cp._connection is new
+    assert new.state is State.OPEN, "stale finalizer closed replacement"
+    assert cp.status == "ok"
+    assert not replacement.done()
+    assert all(not task.done() for task in cp.tasks)
+
+
+async def test_clean_reconnect_and_stop(lifecycle):
+    """Ordinary replacement remains available until explicit stop."""
+    cp, socket, spawn, began, _ = lifecycle
+    spawn(cp.start())
+    await began(cp._connection)
+    new = socket()
+    spawn(cp.reconnect(new))
+    await began(new)
+    assert cp.status == "ok"
+    assert new.state is State.OPEN
+    assert cp._metrics[(0, cstat.reconnects)].value == 1
+    await cp.stop()
+    assert new.state is State.CLOSED
+    assert cp.status == STATE_UNAVAILABLE
+    assert all(task.done() for task in cp.tasks)
+
+
+@pytest.mark.parametrize("explicit_stop", [False, True])
+async def test_overlapping_admission(lifecycle, explicit_stop):
+    """Newest reconnect wins; an explicit stop invalidates pending requests."""
+    cp, socket, spawn, began, _ = lifecycle
+    old = cp._connection
+    spawn(cp.start())
+    await began(old)
+    old.close_release.clear()
+    first, latest = socket(), socket()
+    spawn(cp.reconnect(first))
+    await old.close_entered.wait()
+    if explicit_stop:
+        spawn(cp.stop())
+    else:
+        spawn(cp.reconnect(latest))
+    await ticks()
+    old.close_release.set()
+    await ticks()
+    assert first.state is State.CLOSED
+    assert old.closes == 1
+    if explicit_stop:
+        assert cp._connection is old
+        assert cp.status == STATE_UNAVAILABLE
+    else:
+        await began(latest)
+        assert cp._connection is latest
+        assert latest.state is State.OPEN
+
+
+async def test_concurrent_stop_is_shared_and_cancellation_atomic(lifecycle):
+    """Repeated cancellation cannot interrupt shared close/child settlement."""
+    cp, _, spawn, began, _ = lifecycle
+    old = cp._connection
+    spawn(cp.start())
+    await began(old)
+    old.close_release.clear()
+    first = spawn(cp.stop())
+    await old.close_entered.wait()
+    second = spawn(cp.stop())
+    for _ in range(2):
+        first.cancel()
+        await ticks()
+    old.close_release.set()
+    await asyncio.gather(first, second, return_exceptions=True)
+    assert first.cancelled()
+    assert not second.cancelled()
+    assert second.exception() is None
+    assert old.closes == 1
+    assert all(task.done() for task in cp.tasks)
+
+
+async def test_close_error_rejects_candidate_and_allows_retry(lifecycle):
+    """A failed close is surfaced without poisoning all future reconnects."""
+    cp, socket, spawn, began, _ = lifecycle
+    old = cp._connection
+    spawn(cp.start())
+    await began(old)
+    old.close_error = OSError("injected close failure")
+    rejected = socket()
+    with pytest.raises(OSError, match="injected close failure"):
+        await cp.reconnect(rejected)
+    assert rejected.state is State.CLOSED
+    assert all(task.done() for task in cp.tasks)
+    old.close_error = None
+    new = socket()
+    spawn(cp.reconnect(new))
+    await began(new)
+    assert new.state is State.OPEN
+
+
+async def test_hostile_child_is_retained_observed_and_fences_retry(lifecycle):
+    """Timeout bounds callers, not cancellation acknowledgement from children."""
+    cp, socket, spawn, began, releases = lifecycle
+    old = cp._connection
+    entered, release, retiring = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    releases.append(release)
+
+    async def hostile():
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            retiring.set()
+            while not release.is_set():
+                with suppress(asyncio.CancelledError):
+                    await release.wait()
+            assert cp._connection is old
+            raise RuntimeError("injected late survivor failure")
+
+    runner = spawn(cp.run([hostile()]))
+    await entered.wait()
+    child = cp.tasks[0]
+    stop = spawn(cp.stop())
+    await retiring.wait()
+    for _ in range(2):
+        stop.cancel()
+        await ticks()
+    _, pending = await asyncio.wait({stop}, timeout=0.3)
+    assert not pending, "stop exceeded aggregate retirement deadline"
+    assert not stop.cancelled(), "retirement failure must outrank cancellation"
+    assert isinstance(stop.exception(), TimeoutError)
+    assert child in cp._retirement_tasks
+    assert cp.status == STATE_UNAVAILABLE
+    for _ in range(2):
+        rejected = socket()
+        with pytest.raises(TimeoutError):
+            await cp.reconnect(rejected)
+        assert rejected.state is State.CLOSED
+        assert cp._connection is old
+    release.set()
+    await asyncio.gather(runner, return_exceptions=True)
+    await ticks()
+    assert child not in cp._retirement_tasks
+    # CPython's exception-observation flag: mere strong retention is insufficient.
+    assert not child._log_traceback
+    new = socket()
+    spawn(cp.reconnect(new))
+    await began(new)
+    assert new.state is State.OPEN
+
+
+@pytest.mark.parametrize("production_deadline", [False, True])
+async def test_hostile_close_has_aggregate_deadline(lifecycle, production_deadline):
+    """Even a close that suppresses cancellation is retained and bounded."""
+    cp, socket, spawn, _, releases = lifecycle
+    old = cp._connection
+    release = asyncio.Event()
+    releases.append(release)
+    if production_deadline:
+        del cp._retirement_timeout
+    budget = 10.0 if production_deadline else 0.05
+
+    async def close():
+        old.close_entered.set()
+        while not release.is_set():
+            with suppress(asyncio.CancelledError):
+                await release.wait()
+        old.state = State.CLOSED
+
+    old.close = close
+    start = asyncio.get_running_loop().time()
+    stop = spawn(cp.stop())
+    await old.close_entered.wait()
+    for _ in range(2):
+        stop.cancel()
+        await ticks()
+    _, pending = await asyncio.wait({stop}, timeout=budget + 0.5)
+    assert not pending, "hostile close escaped aggregate bound"
+    assert not stop.cancelled(), "cleanup timeout must outrank caller cancellation"
+    assert isinstance(stop.exception(), TimeoutError)
+    elapsed = asyncio.get_running_loop().time() - start
+    assert budget <= elapsed < budget + 0.5
+    assert cp._retirement_tasks
+    with pytest.raises(TimeoutError):
+        await cp.reconnect(socket())
+    assert cp._connection is old
+    release.set()
+    await ticks()
+    assert not cp._retirement_tasks
+
+
+@pytest.mark.parametrize("child_initiates", [False, True])
+async def test_child_stop_cannot_self_join_or_publish_early(lifecycle, child_initiates):
+    """Exclude a stopper from its own join, but not from admission fencing."""
+    cp, socket, spawn, _, releases = lifecycle
+    entered, stopped, release = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    releases.append(release)
+
+    async def child():
+        entered.set()
+        if child_initiates:
+            await cp.stop()
+            stopped.set()
+            await release.wait()
+        else:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await cp.stop()
+                stopped.set()
+
+    spawn(cp.run([child()]))
+    await entered.wait()
+    if not child_initiates:
+        await cp.stop()
+    await asyncio.wait_for(stopped.wait(), 0.3)
+    if child_initiates:
+        rejected = socket()
+        with pytest.raises(TimeoutError):
+            await cp.reconnect(rejected)
+        assert rejected.state is State.CLOSED
+
+
+async def test_localhost_idle_reconnect_keeps_replacement_open(hass, socket_enabled):
+    """Exercise real recv, Ping/Pong and Close on loopback, without OCPP calls."""
+    cp = _mk_cp(hass)
+    cp.post_connect_success = True
+    cp.cs_settings.websocket_ping_interval = 0.01
+    cp.cs_settings.websocket_ping_timeout = 1
+    accepted = asyncio.Queue()
+
+    async def handler(connection):
+        await accepted.put(connection)
+        await connection.wait_closed()
+
+    async with serve(handler, "127.0.0.1", 0, ping_interval=None) as server:
+        port = server.sockets[0].getsockname()[1]
+        async with connect(f"ws://127.0.0.1:{port}", ping_interval=None) as first:
+            cp._connection = await accepted.get()
+            old = cp._connection
+            runner = asyncio.create_task(cp.start())
+            replacement = None
+            try:
+                await ticks()
+                async with connect(
+                    f"ws://127.0.0.1:{port}", ping_interval=None
+                ) as second:
+                    new = await accepted.get()
+                    replacement = asyncio.create_task(cp.reconnect(new))
+                    await asyncio.wait_for(first.wait_closed(), 1)
+                    await ticks()
+                    assert old.state is State.CLOSED
+                    assert cp._connection is new
+                    assert new.state is State.OPEN
+                    assert cp.status == "ok"
+                    pong = await second.ping()
+                    await asyncio.wait_for(pong, 1)
+                    assert not replacement.done()
+                    await cp.stop()
+                    await asyncio.wait_for(second.wait_closed(), 1)
+            finally:
+                await cp.stop()
+                await asyncio.gather(
+                    runner,
+                    *([replacement] if replacement else []),
+                    return_exceptions=True,
+                )

--- a/tests/test_reconnect_lifecycle.py
+++ b/tests/test_reconnect_lifecycle.py
@@ -58,11 +58,13 @@ async def lifecycle(hass, monkeypatch):
     releases = []
 
     async def receive(self):
+        """Signal runner admission and wait for its captured socket to end."""
         connection = self._connection
         started.setdefault(connection, asyncio.Event()).set()
         await connection.ended.wait()
 
     async def monitor():
+        """Keep the monitor bound to the socket captured at startup."""
         connection = cp._connection
         await connection.ended.wait()
 
@@ -70,16 +72,19 @@ async def lifecycle(hass, monkeypatch):
     monkeypatch.setattr(cp, "monitor_connection", monitor)
 
     def spawn(coro, name=None):
+        """Track a runner so fixture teardown can cancel and join it."""
         task = asyncio.create_task(coro, name=name)
         runners.append(task)
         return task
 
     def socket():
+        """Register a controllable socket for unconditional fixture cleanup."""
         connection = Socket()
         sockets.append(connection)
         return connection
 
     async def began(connection):
+        """Require the replacement's receive task to reach its startup barrier."""
         await ticks()
         assert connection in started, "replacement runner never started"
 
@@ -104,17 +109,17 @@ async def test_stale_finalizer_cannot_close_replacement(lifecycle, monkeypatch):
     old = cp._connection
     entered, release = asyncio.Event(), asyncio.Event()
     releases.append(release)
-    # Instrument the cleanup boundary on both upstream and fixed source.
-    method = "_stop_session" if hasattr(cp, "_stop_session") else "stop"
-    original = getattr(cp, method)
+    # Fail loudly if the session-owned cleanup boundary is removed or renamed.
+    original = cp._stop_session
 
     async def paused(*args):
+        """Hold only the old runner's finalizer until replacement admission."""
         if asyncio.current_task().get_name() == "old-run":
             entered.set()
             await release.wait()
         return await original(*args)
 
-    monkeypatch.setattr(cp, method, paused)
+    monkeypatch.setattr(cp, "_stop_session", paused)
     old_runner = spawn(cp.start(), "old-run")
     await began(old)
     new = socket()
@@ -132,6 +137,12 @@ async def test_stale_finalizer_cannot_close_replacement(lifecycle, monkeypatch):
     assert cp.status == "ok"
     assert not replacement.done()
     assert all(not task.done() for task in cp.tasks)
+
+
+async def test_retirement_tracking_exists_before_start(hass):
+    """A fresh owner exposes an empty survivor registry before any teardown."""
+    cp = _mk_cp(hass)
+    assert cp._retirement_tasks == set()
 
 
 async def test_clean_reconnect_and_stop(lifecycle):
@@ -229,6 +240,7 @@ async def test_hostile_child_is_retained_observed_and_fences_retry(lifecycle):
     releases.append(release)
 
     async def hostile():
+        """Resist retirement cancellation, then fail after explicit release."""
         entered.set()
         try:
             await asyncio.Event().wait()
@@ -264,15 +276,63 @@ async def test_hostile_child_is_retained_observed_and_fences_retry(lifecycle):
     await asyncio.gather(runner, return_exceptions=True)
     await ticks()
     assert child not in cp._retirement_tasks
-    # CPython's exception-observation flag: mere strong retention is insufficient.
-    assert not child._log_traceback
+    assert child.done()
+    error = child.exception()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "injected late survivor failure"
     new = socket()
     spawn(cp.reconnect(new))
     await began(new)
     assert new.state is State.OPEN
 
 
-@pytest.mark.parametrize("production_deadline", [False, True])
+async def test_retirement_callback_retrieves_late_failure(lifecycle):
+    """Prove owner observation without a gather or test retrieving the exception."""
+    cp, _, _, _, releases = lifecycle
+    entered, release = asyncio.Event(), asyncio.Event()
+    releases.append(release)
+    observations = []
+
+    class ObservedTask(asyncio.Task):
+        """Record calls to the public exception API without CPython internals."""
+
+        def exception(self):
+            """Record outcome retrieval by the owner before returning the error."""
+            error = super().exception()
+            observations.append(error)
+            return error
+
+    async def hostile():
+        """Fail only after retirement has timed out and abandoned its join."""
+        entered.set()
+        while not release.is_set():
+            with suppress(asyncio.CancelledError):
+                await release.wait()
+        raise RuntimeError("late callback failure")
+
+    child = ObservedTask(hostile())
+    session = {"connection": cp._connection, "tasks": (child,), "cleanup": None}
+    try:
+        await entered.wait()
+        with pytest.raises(TimeoutError):
+            await cp._close_session(session, asyncio.current_task())
+        assert child in cp._retirement_tasks
+        assert not observations
+        release.set()
+        await ticks()
+        assert child.done()
+        assert child not in cp._retirement_tasks
+        assert len(observations) == 1
+        assert isinstance(observations[0], RuntimeError)
+        assert str(observations[0]) == "late callback failure"
+    finally:
+        release.set()
+        await asyncio.gather(child, return_exceptions=True)
+
+
+@pytest.mark.parametrize(
+    "production_deadline", [False, pytest.param(True, marks=pytest.mark.slow)]
+)
 async def test_hostile_close_has_aggregate_deadline(lifecycle, production_deadline):
     """Even a close that suppresses cancellation is retained and bounded."""
     cp, socket, spawn, _, releases = lifecycle
@@ -284,6 +344,7 @@ async def test_hostile_close_has_aggregate_deadline(lifecycle, production_deadli
     budget = 10.0 if production_deadline else 0.05
 
     async def close():
+        """Keep the transport close pending despite repeated cancellation."""
         old.close_entered.set()
         while not release.is_set():
             with suppress(asyncio.CancelledError):
@@ -320,6 +381,7 @@ async def test_child_stop_cannot_self_join_or_publish_early(lifecycle, child_ini
     releases.append(release)
 
     async def child():
+        """Exercise child-initiated stop or joining an external teardown."""
         entered.set()
         if child_initiates:
             await cp.stop()
@@ -344,15 +406,57 @@ async def test_child_stop_cannot_self_join_or_publish_early(lifecycle, child_ini
         assert rejected.state is State.CLOSED
 
 
+async def test_reconnect_waiting_for_child_stop_rejects_surviving_initiator(lifecycle):
+    """Recheck child settlement after joining an in-progress successful cleanup."""
+    cp, socket, spawn, _, releases = lifecycle
+    old = cp._connection
+    old.close_release.clear()
+    stopped, release = asyncio.Event(), asyncio.Event()
+    releases.append(release)
+
+    async def child():
+        """Initiate teardown, then remain alive beyond its successful completion."""
+        await cp.stop()
+        stopped.set()
+        await release.wait()
+
+    runner = spawn(cp.run([child()]))
+    await asyncio.wait_for(old.close_entered.wait(), 1)
+    session = cp._session
+    cleanup = session["cleanup"]
+    assert not cleanup.done()
+    rejected = socket()
+    reconnect = spawn(cp.reconnect(rejected))
+    await ticks()
+    assert not reconnect.done()
+    assert session["cleanup"] is cleanup
+    old.close_release.set()
+    await asyncio.wait_for(stopped.wait(), 1)
+    with pytest.raises(TimeoutError, match="retirement survivors still active"):
+        await asyncio.wait_for(reconnect, 1)
+    assert cleanup.done() and cleanup.exception() is None
+    assert not cp.tasks[0].done()
+    assert cp.tasks[0] in cp._retirement_tasks
+    assert cp._connection is old
+    assert cp.status == STATE_UNAVAILABLE
+    assert cp._metrics[(0, cstat.reconnects)].value == 0
+    assert rejected.state is State.CLOSED
+    assert rejected.closes == 1
+    release.set()
+    await asyncio.wait_for(runner, 1)
+    await ticks()
+    assert not cp._retirement_tasks
+
+
 async def test_localhost_idle_reconnect_keeps_replacement_open(hass, socket_enabled):
-    """Exercise real recv, Ping/Pong and Close on loopback, without OCPP calls."""
+    """Exercise real recv, client Ping/Pong and Close without OCPP calls."""
     cp = _mk_cp(hass)
     cp.post_connect_success = True
-    cp.cs_settings.websocket_ping_interval = 0.01
-    cp.cs_settings.websocket_ping_timeout = 1
+
     accepted = asyncio.Queue()
 
     async def handler(connection):
+        """Expose each accepted loopback socket until its peer closes."""
         await accepted.put(connection)
         await connection.wait_closed()
 


### PR DESCRIPTION
## Problem

A retiring `run()` calls `stop()` through mutable `self._connection` and `self.tasks`. If a reconnect has already installed a replacement, the old runner's delayed `finally` can close the replacement socket, cancel its tasks, and mark the charge point unavailable.

## Changes

- Capture each session's socket and task ownership so old cleanup cannot close its replacement.
- Share teardown between stop callers and bound socket-close/child-settlement with an aggregate 10-second deadline.
- Retain and observe cancellation-resistant survivors, preventing same-object replacement until old work settles.
- Handle overlapping reconnects, repeated cancellation, child-initiated stop, and retries after retirement settles.
- Add native regression tests and document the lifecycle contract.

No command queue/replay, firmware, charging-profile or energy-policy changes are included.

## Reproduction: failing before, passing after

The decisive regression starts connection A, holds its final cleanup behind an explicit barrier, installs B, releases A's cleanup, and waits for A's runner/finalizer to finish before checking B. On the original code it fails specifically with **`stale finalizer closed replacement`**; with the fix it passes. Expected cancellation is retrieved and unexpected runner exceptions fail the test.

From this PR checkout, install the repository's test requirements in `.venv`, then run:

```sh
# Fixed candidate: expected PASS.
.venv/bin/python -m pytest tests/test_reconnect_lifecycle.py::test_stale_finalizer_cannot_close_replacement --no-cov --timeout=30 -p no:cacheprovider -o addopts='' -q

# Original upstream with explicit old cleanup-boundary adaptation.
# Production source remains unchanged; candidate tests have no fallback.
CANDIDATE="$PWD"
BASELINE=$(mktemp -d)
git archive bc5d879c6f49d90bc1ffd6d72107a4aa8dc00ead -o "$BASELINE/base.tar"
tar -xf "$BASELINE/base.tar" -C "$BASELINE"
cp tests/test_reconnect_lifecycle.py "$BASELINE/tests/test_reconnect_lifecycle.py"
python3 - "$BASELINE/tests/test_reconnect_lifecycle.py" <<'PY'
from pathlib import Path
import sys
p = Path(sys.argv[1])
s = p.read_text()
assert s.count('original = cp._stop_session') == 1
assert s.count('monkeypatch.setattr(cp, "_stop_session", paused)') == 1
s = s.replace('original = cp._stop_session', 'original = cp.stop')
s = s.replace('monkeypatch.setattr(cp, "_stop_session", paused)', 'monkeypatch.setattr(cp, "stop", paused)')
p.write_text(s)
PY
(
  cd "$BASELINE" || exit 1
  # Expected exit 1 at the stale-finalizer assertion, not a teardown failure.
  "$CANDIDATE/.venv/bin/python" -m pytest tests/test_reconnect_lifecycle.py::test_stale_finalizer_cannot_close_replacement --no-cov --timeout=30 -p no:cacheprovider -o addopts='' -q
)
```

## Verification

Results were recorded against a frozen source/test snapshot; current files were checked against that snapshot before publication:

- Original upstream with explicit old cleanup-boundary adaptation: the selected stale-finalizer regression **fails at `stale finalizer closed replacement`**. Candidate test directly targets `_stop_session`, so renames cannot silently switch the boundary.
- Fixed candidate, focused lifecycle/compatibility tests: **37 passed**.
- Full project suite: **369 passed** in 246.06 seconds; **96.20% coverage**, above the 95% gate.
- Ruff lint/format and diff whitespace checks passed.
- No pending-task destruction, unretrieved-exception or teardown-leak diagnostics were found in these runs.

```sh
.venv/bin/python -m pytest tests/test_reconnect_lifecycle.py tests/test_charge_point_core.py tests/test_more_coverage_chargepoint.py --no-cov --timeout=30 -p no:cacheprovider -o addopts='' -q
.venv/bin/python -m pytest --cov=./ --cov-report=xml --cov-report=term --timeout=30 --durations=10 -n 8 -p no:sugar -rA tests
.venv/bin/ruff check --no-cache custom_components/ocpp/chargepoint.py tests/test_reconnect_lifecycle.py tests/test_charge_point_core.py tests/test_more_coverage_chargepoint.py
.venv/bin/ruff format --check --no-cache custom_components/ocpp/chargepoint.py tests/test_reconnect_lifecycle.py tests/test_charge_point_core.py tests/test_more_coverage_chargepoint.py
```

Environment: Python 3.14.5, Home Assistant 2026.9.0b4, ocpp 2.1.0, websockets 17.1, pytest 9.0.3. The final full suite used eight workers rather than CI's automatic worker count; its OCPP 2.0.1 integration test takes about 211 seconds, so a 180-second whole-command limit is insufficient. HACS, Hassfest and pre-commit were not rerun locally for the final snapshot; hosted CI is separate from these local results.

Native tests exercise the actual integration with HA fixtures and controlled transports. The localhost WebSocket test covers real receive/Ping/Pong/Close with no application traffic; it is not physical-charger qualification. Python 3.14 cancellation behavior is covered: cleanup uses `asyncio.wait` plus explicit result retrieval rather than leaving a cancelled `shield()` wrapper to log a late inner exception.

## Review follow-up

- Addressed six CodeRabbit nits and added useful docstrings. The production-deadline test is marked `slow` but remains in default and CI runs.
- Added explicit public-API evidence that the retirement owner retrieves late task exceptions.
- Reproduced Codecov’s two uncovered changed lines: the unused fault assignment (removed) and the post-await survivor rejection. Added a regression that fails when that guard is removed.
- Local full-suite coverage intersects **80/80 changed executable `chargepoint.py` lines**, with no exclusions or threshold changes. Hosted Codecov results must rerun after publication.

## Scope and limitations for review

- Deadlines bound caller latency on a responsive event loop, not complete task/process termination. Surviving work intentionally blocks replacement on the same object.
- A rejected reconnect can consume separate budgets for old-session retirement and closing the unpublished incoming socket.
- Separately scheduled `post_connect`, external service work, inherited sends, and different-protocol object-rebuild fallback are not comprehensively fenced by this change.
- This does not claim to fix every charger disconnect or provide hardware recovery. No real charger or live HA deployment was used to qualify this exact upstream candidate.
- The separate queue/replay proposal in #2001 also touches reconnect; this PR deliberately does not add that behavior.

Prepared against upstream `main` at `bc5d879c6f49d90bc1ffd6d72107a4aa8dc00ead`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting a charge point’s station charge rate.

* **Bug Fixes**
  * Improved connection recovery and replacement handling during reconnects.
  * Prevented outdated reconnect attempts or cleanup operations from disrupting newer connections.
  * Improved shutdown reliability when connections close slowly, fail, or are cancelled.
  * Rejected unsafe replacement connections and invalidated pending reconnects when stopping.
  * Prevented delayed initial starts from restoring stale sessions after a stop or reconnect.

* **Documentation**
  * Added guidance covering reconnect lifecycle behavior, cleanup timeouts, cancellation handling, and known limitations.
  * Documented reconnect lifecycle regression testing and slow test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->