### PR TITLE
fix: replace non-existent DeviceRegistry.async_get_devices()

### DIFF
--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -694,15 +694,12 @@ class ChargePoint(cp):
         dr = device_registry.async_get(self.hass)
 
         identifiers = {(DOMAIN, cpid), (DOMAIN, self.id)}
-        root_dev = next(
-            iter(
-                dr.async_get_devices(
-                    identifiers=identifiers,
-                    config_entry_id=self.entry.entry_id,
-                )
-            ),
-            None,
-        )
+        # `DeviceRegistry.async_get_devices()` does not exist; use the singular
+        # lookup, which matches any of the given identifiers, and keep the
+        # original config entry filter.
+        root_dev = dr.async_get_device(identifiers=identifiers)
+        if root_dev is not None and self.entry.entry_id not in root_dev.config_entries:
+            root_dev = None
         if root_dev is None:
             return
 


### PR DESCRIPTION
## Problem

`ChargePoint.update()` calls a method that does not exist on Home Assistant's `DeviceRegistry`:

```python
root_dev = next(
    iter(
        dr.async_get_devices(
            identifiers=identifiers,
            config_entry_id=self.entry.entry_id,
        )
    ),
    None,
)
```

Every call raises:

```
Traceback (most recent call last):
  File "/config/custom_components/ocpp/chargepoint.py", line 699, in update
    dr.async_get_devices(
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DeviceRegistry' object has no attribute 'async_get_devices'. Did you mean: 'async_get_device'?
```

`DeviceRegistry` exposes `async_get_device()` (singular); the plural form only exists as the module-level helpers `async_entries_for_config_entry()` / `async_entries_for_area()`.

## Impact

`update()` runs on every inbound message, so the exception fires on each `MeterValues` and `StatusNotification`. No entity is ever refreshed and **all entities of the charge point go `unavailable`**, while the websocket link is perfectly healthy and the charger keeps sending data that the integration acknowledges normally. The failure therefore looks like a connectivity problem but is not one.

Same symptom as #2119 (closed), still reproducible on v0.11.4.

## Fix

Use the singular lookup, which matches any of the supplied identifiers, and keep the original config entry filter explicitly:

```python
root_dev = dr.async_get_device(identifiers=identifiers)
if root_dev is not None and self.entry.entry_id not in root_dev.config_entries:
    root_dev = None
```

Both original filters are preserved: identifier match, and membership of this config entry.

## Verification

Applied to a live instance (Home Assistant 2026.6.0, Wallbox Pulsar Plus PSP1-W-2-4, firmware 6.7.38, OCPP 1.6).

Before: all charge point entities `unavailable`, one `AttributeError` per inbound message.
After restart with the patch: entities populated normally, **0 `AttributeError` and 0 `Error doing job` over 18 inbound messages**, `status`, `status_connector`, `charge_control` and `maximum_current` all reporting real values again.

I have not run the full test suite; this is a targeted fix on a code path that could not execute at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device update handling to ensure updates are applied to the correct root device.
  * Preserved configuration-entry filtering during device updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->