### PR TITLE
OCPP 1.6: allocate unique transaction ids and stop guessing on unknown StopTransaction

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -478,6 +478,27 @@ class CentralSystem:
 
         return None
 
+    def is_transaction_indeterminate(
+        self, id: str, connector_id: int | None = None
+    ) -> bool:
+        """Return whether a connector's transaction state is held as unresolved.
+
+        An OCPP 1.6 charge point holds a connector when a StopTransaction
+        could not be attributed to it with certainty; controls that act on
+        the connector's transaction stay unavailable until the charger's
+        next status report settles it.
+        """
+        cp_id = self.cpids.get(id, id)
+        cp = self.charge_points.get(cp_id)
+        unsafe = getattr(cp, "transaction_is_unsafe", None)
+        if unsafe is None:
+            held = getattr(cp, "_tx_indeterminate", None)
+            return bool(held) and connector_id in held
+        # The same rule stop_transaction applies: held, or sharing its id
+        # with a held connector, so the entity never offers a stop that the
+        # charge point would refuse.
+        return bool(unsafe(connector_id))
+
     def get_availability_status(self, id: str):
         """Return the status that drives the charger availability switch.
 

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -1,13 +1,17 @@
 """Representation of a OCPP 1.6 charging station."""
 
 from datetime import datetime, timedelta, UTC
+import hashlib
 import logging
+import math
 
 import time
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.const import UnitOfTime
+from homeassistant.helpers.storage import Store
+from homeassistant.util import slugify
 import voluptuous as vol
 from websockets.asyncio.server import ServerConnection
 
@@ -59,6 +63,7 @@ from .const import (
     ChargerSystemSettings,
     DEFAULT_MEASURAND,
     DEFAULT_MAX_CURRENT,
+    DOMAIN,
     HA_ENERGY_UNIT,
     MEASURANDS,
 )
@@ -89,6 +94,44 @@ _DEFAULT_PHASES = 1
 
 # Limit connectors to prevent OOM in case a corrupted charger reports an invalid number.
 _MAX_CONNECTORS = 10
+
+# Persisted transaction identity: the last id handed out (so ids stay unique
+# across restarts) and each running transaction's start time (so a session
+# adopted after a restart keeps its real duration). Best effort by design: a
+# handler never waits for the write, because charging must not depend on
+# Home Assistant's disk.
+_TX_STORE_VERSION = 1
+_TX_STORE_SAVE_DELAY = 1.0
+
+# Connector statuses that prove a transaction is running, and ones that prove
+# the connector has none. Anything else - Faulted, Preparing - says nothing
+# either way about a transaction the connector was holding.
+_TX_RUNNING_STATUSES = (
+    ChargePointStatus.charging.value,
+    ChargePointStatus.suspended_ev.value,
+    ChargePointStatus.suspended_evse.value,
+)
+_TX_ENDED_STATUSES = (
+    ChargePointStatus.available.value,
+    ChargePointStatus.finishing.value,
+    ChargePointStatus.unavailable.value,
+    ChargePointStatus.reserved.value,
+)
+# Ids adopted from a charger above this are outside the range the integration
+# allocates in, so there is nothing to stay clear of.
+_TX_ID_CEILING = 2**31 - 2
+
+
+def tx_store_key(entry_id: str, cp_id: str) -> str:
+    """Return the storage key for a charge point's transaction state.
+
+    slugify alone would collide: "CP-A", "CP_A" and "CP A" all become "cp_a",
+    and two chargers of one entry would then overwrite each other's state. A
+    digest of the raw id keeps the key readable and distinct.
+    """
+    digest = hashlib.sha256(cp_id.encode()).hexdigest()[:8]
+    return f"{DOMAIN}.v16_transactions.{entry_id}.{slugify(cp_id)}_{digest}"
+
 
 _AMPS_UNIT_TOKENS = frozenset({"current", "a", "amp", "amps", "ampere", "amperes"})
 _WATTS_UNIT_TOKENS = frozenset({"power", "w", "watt", "watts"})
@@ -140,6 +183,369 @@ class ChargePoint(cp):
         )
         self._active_tx: dict[int, int] = {}  # connector_id -> transaction_id
         self._ended_tx: dict[int, int] = {}  # connector_id -> last stopped tx
+        # Transaction identity and timing (#2123). The id was int(time.time())
+        # and doubled as the session start epoch: two connectors starting in
+        # the same second collided, and a charger-supplied id adopted by the
+        # self-heal path made the session timer count from a bogus reference.
+        self._last_tx_id: int = 0
+        self._tx_started_at: dict[int, float] = {}  # connector_id -> epoch
+        # Connectors whose transaction state could not be resolved from a
+        # StopTransaction: timer frozen, settled by the next status report.
+        self._tx_indeterminate: set[int] = set()
+        # connector_id -> (tx_id, started_at) as persisted before a restart
+        self._persisted_tx: dict[int, tuple[int, float]] = {}
+        # Payloads of StopTransactions that could not be attributed yet, each
+        # with the held connectors it could belong to. One is applied only when
+        # a settled connector is its sole possible owner; otherwise the final
+        # figures are omitted rather than knowingly cross-applied.
+        self._pending_stops: list[dict] = []
+        # Not atomic on purpose: Home Assistant's atomic writes fsync, which it
+        # documents as able to block for seconds, and this state is best
+        # effort - the loader tolerates a torn file and the clock still bounds
+        # new ids. An fsync per session on an SD-card install is not worth it.
+        self._tx_store = Store(
+            hass, _TX_STORE_VERSION, tx_store_key(entry.entry_id, id)
+        )
+        self._tx_store_load = None
+
+    # ------------------------------------------------------------------
+    # Transaction identity, timing and containment (#2123)
+    # ------------------------------------------------------------------
+
+    async def start(self):
+        """Start the charge point once its persisted transaction state is in.
+
+        The message loop would otherwise race the load: a StartTransaction
+        could allocate an id below the persisted ceiling, and MeterValues
+        could settle on an estimated start for the very session whose real
+        start was persisted. Writes stay asynchronous; only the one-time load
+        is waited for, and a broken store resolves immediately.
+        """
+        await self._async_tx_store_ready()
+        await super().start()
+
+    async def _async_tx_store_ready(self) -> None:
+        """Wait for the one-time load; safe to call repeatedly."""
+        self._ensure_tx_store_loaded()
+        await self._tx_store_load
+
+    def _ensure_tx_store_loaded(self) -> None:
+        """Start loading persisted transaction state once, without blocking.
+
+        start() awaits the load before the first message; handlers call this
+        as a backstop for paths that bypass start(), where the reconciliation
+        in the loader repairs anything decided before it finished.
+        """
+        if self._tx_store_load is None:
+            self._tx_store_load = self.hass.async_create_task(
+                self._async_load_tx_store()
+            )
+
+    async def _async_load_tx_store(self) -> None:
+        """Adopt the persisted last id and start times, tolerating any failure."""
+        try:
+            data = await self._tx_store.async_load()
+        except Exception as ex:  # a broken store must never stop charging
+            _LOGGER.warning("%s: could not load transaction state: %s", self.id, ex)
+            data = None
+        if not isinstance(data, dict):
+            return
+        try:
+            persisted_last = int(data.get("last_tx_id", 0) or 0)
+        except (TypeError, ValueError):
+            persisted_last = 0
+        # Never hand out an id at or below one returned before the restart.
+        self._last_tx_id = max(self._last_tx_id, persisted_last)
+        connectors = data.get("connectors", {})
+        if not isinstance(connectors, dict):
+            return
+        for key, item in connectors.items():
+            try:
+                conn, tx, started = (
+                    int(key),
+                    int(item["tx_id"]),
+                    float(item["started_at"]),
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+            self._note_transaction_id(tx)
+            # NaN and infinities parse as floats but would make every later
+            # session-time calculation raise; treat them as no start at all,
+            # which leaves the session with an estimated start instead.
+            if not math.isfinite(started) or started <= 0:
+                continue
+            self._persisted_tx[conn] = (tx, started)
+            # A session adopted before this finished settled on an estimated
+            # start; if it is the persisted one, give it its real start.
+            metric = self._metrics[(conn, csess.session_time)]
+            if self._active_tx.get(conn) == tx and metric.extra_attr.get(
+                "start_time_estimated"
+            ):
+                self._set_session_start(conn, started, estimated=False)
+
+    def _note_transaction_id(self, transaction_id) -> None:
+        """Keep allocations clear of an id that is live on some connector.
+
+        A transaction restored from Home Assistant state or adopted from
+        MeterValues is live but was not allocated here; without this, a
+        StartTransaction in the same second could hand out its id again.
+        """
+        try:
+            tx = int(transaction_id or 0)
+        except (TypeError, ValueError):
+            return
+        if 0 < tx <= _TX_ID_CEILING:
+            self._last_tx_id = max(self._last_tx_id, tx)
+
+    def _tx_store_snapshot(self) -> dict:
+        """Serialise what a restart needs: the last id and running sessions."""
+        return {
+            "last_tx_id": int(self._last_tx_id),
+            "connectors": {
+                str(conn): {
+                    "tx_id": int(tx),
+                    "started_at": float(self._tx_started_at[conn]),
+                }
+                for conn, tx in self._active_tx.items()
+                if tx and conn in self._tx_started_at
+            },
+        }
+
+    def _schedule_tx_store_save(self) -> None:
+        """Persist best-effort: coalesced, and never awaited by a handler."""
+        try:
+            self._tx_store.async_delay_save(
+                self._tx_store_snapshot, _TX_STORE_SAVE_DELAY
+            )
+        except Exception as ex:
+            _LOGGER.debug("%s: transaction state not persisted: %s", self.id, ex)
+
+    def _allocate_transaction_id(self) -> int:
+        """Return an id unique for this charge point, even within one second."""
+        tx_id = max(int(time.time()), self._last_tx_id + 1)
+        self._last_tx_id = tx_id
+        return tx_id
+
+    def _set_session_start(
+        self, connector_id: int, started_at: float, *, estimated: bool
+    ) -> None:
+        """Record when the connector's transaction began, flagging a guess."""
+        self._tx_started_at[connector_id] = started_at
+        metric = self._metrics[(connector_id, csess.session_time)]
+        metric.extra_attr = {"start_time_estimated": True} if estimated else {}
+
+    def _ensure_session_start(self, connector_id: int, transaction_id: int) -> float:
+        """Return the transaction's start time, adopting one if none is known.
+
+        A transaction learned from MeterValues rather than StartTransaction has
+        no recorded start. If it is the one persisted before a restart, its
+        real start is used; otherwise the first observation is, and the
+        session-time sensor says so with `start_time_estimated`.
+        """
+        started = self._tx_started_at.get(connector_id)
+        if started is not None:
+            return started
+        persisted = self._persisted_tx.get(connector_id)
+        if persisted is not None and persisted[0] == int(transaction_id or 0):
+            self._set_session_start(connector_id, persisted[1], estimated=False)
+        else:
+            self._set_session_start(connector_id, time.time(), estimated=True)
+        return self._tx_started_at[connector_id]
+
+    def _metric_transaction(self, connector_id: int) -> int:
+        """Return the transaction id the connector's metric holds, or 0."""
+        try:
+            return int(self._metrics[(connector_id, csess.transaction_id)].value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _live_connectors(self) -> list[int]:
+        """Return the connectors that have a transaction recorded anywhere."""
+        live = {c for c, tx in self._active_tx.items() if tx}
+        for conn in range(1, int(self.num_connectors or 1) + 1):
+            if self._metric_transaction(conn):
+                live.add(conn)
+        return sorted(live)
+
+    def _resolve_stop_connector(self, transaction_id: int) -> int | None:
+        """Find the connector a StopTransaction belongs to, or None if unsure.
+
+        Never guesses: applying a stop to the wrong connector ends a session
+        that is still running and files the other one's energy against it.
+        None means the caller must contain the uncertainty instead.
+        """
+        tx = int(transaction_id or 0)
+        by_map = [c for c, t in self._active_tx.items() if t and int(t) == tx]
+        if len(by_map) == 1:
+            return by_map[0]
+        if by_map:
+            return None  # duplicate ids on several connectors: cannot tell
+        by_metric = [
+            c
+            for c in range(1, int(self.num_connectors or 1) + 1)
+            if self._metric_transaction(c) == tx
+        ]
+        if len(by_metric) == 1:
+            return by_metric[0]
+        if by_metric:
+            return None
+        live = self._live_connectors()
+        if len(live) == 1:
+            _LOGGER.info(
+                "%s: StopTransaction for unrecorded id=%s applied to connector %s, "
+                "the only one with a transaction",
+                self.id,
+                tx,
+                live[0],
+            )
+            return live[0]
+        return None
+
+    def _clear_transaction_state(
+        self, connector_id: int, transaction_id: int, stop_reason=None
+    ) -> None:
+        """Forget the connector's transaction: the per-connector part of a stop."""
+        self._ended_tx[connector_id] = int(transaction_id or 0)
+        self._active_tx[connector_id] = 0
+        self._tx_started_at.pop(connector_id, None)
+        self._tx_indeterminate.discard(connector_id)
+        self._metrics[(connector_id, cstat.id_tag)].value = ""
+        self._metrics[(connector_id, csess.transaction_id)].value = 0
+        self._metrics[(connector_id, cstat.stop_reason)].value = stop_reason
+
+    def _apply_stop_energy(self, connector_id: int, meter_stop) -> None:
+        """Set the session's energy from the meter reading at its stop."""
+        ms_key = (connector_id, csess.meter_start)
+        if self._metrics[ms_key].value is None or self._charger_reports_session_energy:
+            return
+        try:
+            session_kwh = int(meter_stop) / 1000.0 - float(self._metrics[ms_key].value)
+        except Exception:
+            session_kwh = 0.0
+        self._metrics[(connector_id, csess.session_energy)].value = session_kwh
+
+    def _forget_stop_candidate(self, connector_id: int) -> None:
+        """Record that this connector can no longer own any pending stop.
+
+        Used when the connector proves its transaction is still running: the
+        stop was not its, so it is kept for the remaining candidates.
+        """
+        for pending in self._pending_stops:
+            pending["candidates"].discard(connector_id)
+        self._pending_stops = [p for p in self._pending_stops if p["candidates"]]
+
+    def _invalidate_pending_stops(self, connector_id: int, evidence: str) -> None:
+        """Drop every pending stop this connector could have owned.
+
+        Evidence that a candidate's transaction ended by another route - its
+        own StopTransaction, its closing values, a new transaction starting on
+        it - means an unattributed stop naming it may have been a malformed
+        duplicate for it, so no other candidate can be shown to own it.
+        """
+        remaining = [
+            p for p in self._pending_stops if connector_id not in p["candidates"]
+        ]
+        dropped = len(self._pending_stops) - len(remaining)
+        self._pending_stops = remaining
+        if dropped:
+            _LOGGER.warning(
+                "%s: connector %s %s; %s unattributed stop(s) that could have been "
+                "its can no longer be attributed and are discarded",
+                self.id,
+                connector_id,
+                evidence,
+                dropped,
+            )
+
+    def transaction_is_unsafe(self, connector_id: int | None) -> bool:
+        """Return whether a remote stop of this connector would be refused.
+
+        True while the connector is held, and also while it shares its id with
+        a held connector: the same rule stop_transaction applies, so an
+        entity gating on this never offers a stop that cannot be sent.
+        """
+        if connector_id is None:
+            return False
+        if connector_id in self._tx_indeterminate:
+            return True
+        tx = int(self._active_tx.get(connector_id, 0) or 0)
+        return bool(tx) and tx in self._unsafe_transaction_ids()
+
+    def _claim_pending_stop(self, connector_id: int) -> dict | None:
+        """Return the one unattributed stop this connector can own, if any.
+
+        A stop is applied only when the settled connector is a candidate for
+        exactly one pending stop and no other evidence has since shown how a
+        candidate's transaction ended. With two unattributed stops outstanding,
+        neither can be shown to belong to whichever connector reports idle
+        first, so both sessions keep their last periodic figures rather than
+        knowingly receiving another session's final reading and reason.
+        """
+        mine = [p for p in self._pending_stops if connector_id in p["candidates"]]
+        self._forget_stop_candidate(connector_id)
+        if len(mine) == 1:
+            self._pending_stops = [p for p in self._pending_stops if p is not mine[0]]
+            return mine[0]
+        if mine:
+            _LOGGER.warning(
+                "%s: %s unattributed stops could belong to connector %s; its final "
+                "energy and stop reason are not recorded",
+                self.id,
+                len(mine),
+                connector_id,
+            )
+        return None
+
+    def _unsafe_transaction_ids(self) -> set[int]:
+        """Return ids a held connector may still own; never stop these remotely."""
+        unsafe = set()
+        for conn in self._tx_indeterminate:
+            unsafe.add(int(self._active_tx.get(conn, 0) or 0))
+            unsafe.add(self._metric_transaction(conn))
+        unsafe.discard(0)
+        return unsafe
+
+    def _resolve_indeterminate(
+        self, connector_id: int, *, running: bool, claim: bool = True
+    ) -> None:
+        """Settle a connector whose transaction state was held as unresolved.
+
+        `claim` is True only for a status report saying the connector is idle
+        with nothing else known: then a pending stop may be attributed to it.
+        Any other evidence that its transaction ended (closing values) passes
+        claim=False, and the stops it could have owned are discarded instead.
+        """
+        if connector_id not in self._tx_indeterminate:
+            return
+        if running:
+            self._tx_indeterminate.discard(connector_id)
+            # It did not end, so no unattributed stop can be its.
+            self._forget_stop_candidate(connector_id)
+            _LOGGER.info(
+                "%s: connector %s is still in its transaction", self.id, connector_id
+            )
+        else:
+            _LOGGER.info(
+                "%s: connector %s reports no transaction; ending the one it held",
+                self.id,
+                connector_id,
+            )
+            if claim:
+                pending = self._claim_pending_stop(connector_id)
+            else:
+                pending = None
+                self._invalidate_pending_stops(
+                    connector_id, "sent its own closing meter values"
+                )
+            self._clear_transaction_state(
+                connector_id,
+                self._active_tx.get(connector_id, 0),
+                pending.get("reason") if pending else None,
+            )
+            if pending is not None:
+                self._apply_stop_energy(connector_id, pending.get("meter_stop"))
+            self._zero_flow_measurands(connector_id)
+        self._schedule_tx_store_save()
 
     async def get_number_of_connectors(self) -> int:
         """Return number of connectors on this charger."""
@@ -655,10 +1061,14 @@ class ChargePoint(cp):
         # Target connector (default 1 if unspecified/0)
         target_cid = int(conn_id) if conn_id and int(conn_id) > 0 else 1
 
-        # Read active transaction on this connector
+        # Read active transaction on this connector. A held connector's id may
+        # belong to a transaction that has already ended, so no profile is
+        # bound to it until the charger settles the connector.
         try:
             active_tx_id = int(self._active_tx.get(target_cid, 0) or 0)
         except Exception:
+            active_tx_id = 0
+        if target_cid in self._tx_indeterminate:
             active_tx_id = 0
 
         txp_ok = False
@@ -821,7 +1231,11 @@ class ChargePoint(cp):
 
         If connector_id is provided, only stop the transaction running on that connector.
         """
-        # Resolve which transaction to stop
+        # Resolve which transaction to stop. An id a held connector may still
+        # own is never sent: with duplicate charger-supplied ids the stop could
+        # end another connector's running session, and this is the path the
+        # Charge Control switch takes, since it always names its connector.
+        unsafe = self._unsafe_transaction_ids()
         tx_id = 0
         if connector_id is not None:
             # Per-connector stop: do NOT fall back to other connectors
@@ -838,11 +1252,34 @@ class ChargePoint(cp):
                     n = 0
                 if n == 1 and int(connector_id) in (0, 1):
                     tx_id = int(self.active_transaction_id or 0)
+
+            if int(connector_id) in self._tx_indeterminate or tx_id in unsafe:
+                _LOGGER.warning(
+                    "%s: not stopping connector %s: its transaction state is "
+                    "unresolved until the charger reports its status",
+                    self.id,
+                    connector_id,
+                )
+                await self.notify_ha(
+                    f"Warning: Stop transaction on connector {connector_id} refused: "
+                    "transaction state unresolved"
+                )
+                return False
         else:
-            # Global stop (legacy behavior): stop the known active tx, or any active tx
-            tx_id = int(self.active_transaction_id or 0)
-            if tx_id == 0:
-                tx_id = next((int(v) for v in self._active_tx.values() if v), 0)
+            # Global stop (legacy behaviour): the known active transaction, or
+            # any active one - never an id a held connector may still own.
+            candidates = [
+                int(v)
+                for c, v in self._active_tx.items()
+                if v and c not in self._tx_indeterminate and int(v) not in unsafe
+            ]
+            legacy = int(self.active_transaction_id or 0)
+            if legacy in unsafe:
+                legacy = 0
+            if legacy and (legacy in candidates or not self._active_tx):
+                tx_id = legacy
+            else:
+                tx_id = candidates[0] if candidates else 0
 
         # Nothing to stop - succeed as no-op
         if tx_id == 0:
@@ -1054,8 +1491,18 @@ class ChargePoint(cp):
     def on_meter_values(self, connector_id: int, meter_value: dict, **kwargs):
         """Request handler for MeterValues Calls (multi-connector aware)."""
 
+        self._ensure_tx_store_loaded()
         transaction_id: int = int(kwargs.get(om.transaction_id.name, 0) or 0)
         tx_has_id: bool = transaction_id not in (None, 0)
+        if tx_has_id:
+            # Seeing an id, including on closing values, is enough to keep a
+            # later allocation clear of it; it does not make the id live.
+            self._note_transaction_id(transaction_id)
+        tx_end_context = any(
+            sampled_value.get(om.context) == ReadingContext.transaction_end.value
+            for bucket in meter_value
+            for sampled_value in bucket.get(om.sampled_value.name, [])
+        )
 
         # Restore missing per-connector meter_start / active_transaction_id from HA if possible.
         ms_key = (connector_id, csess.meter_start)
@@ -1083,7 +1530,12 @@ class ChargePoint(cp):
         if self._metrics[tx_key].value is None:
             value = self.get_ha_metric(csess.transaction_id, connector_id)
             if value is None:
-                value = transaction_id if transaction_id else None
+                # A first sighting normally restores a transaction after a
+                # restart. Closing values are different: their id names a
+                # transaction that has already ended and must not revive it.
+                value = (
+                    transaction_id if transaction_id and not tx_end_context else None
+                )
             else:
                 try:
                     value = int(value)
@@ -1096,8 +1548,9 @@ class ChargePoint(cp):
                 except (ValueError, TypeError):
                     value = None
             self._metrics[tx_key].value = value
-            # Track active tx per connector
-            self._active_tx[connector_id] = value
+            # Track active tx per connector, and keep new ids clear of it
+            self._active_tx[connector_id] = int(value or 0)
+            self._note_transaction_id(value)
 
         if connector_id not in self._active_tx:
             try:
@@ -1112,13 +1565,20 @@ class ChargePoint(cp):
         # adopting their id below would revive the session that just ended. A
         # charger says so with a Transaction.End context, but OCPP leaves that
         # field optional, so fall back to the id of the transaction we last saw
-        # stop on this connector.
-        tx_ended: bool = bool(transaction_id) and (
-            transaction_id == int(self._ended_tx.get(connector_id, 0) or 0)
-            or any(
-                sampled_value.get(om.context) == ReadingContext.transaction_end.value
-                for bucket in meter_value
-                for sampled_value in bucket.get(om.sampled_value.name, [])
+        # stop on this connector. The context speaks only for the id it comes
+        # with: closing values for some other transaction, arriving while one
+        # is known on this connector, end nothing here.
+        current_tx = active_tx or recorded_tx
+        tx_ended: bool = (
+            bool(transaction_id)
+            and current_tx
+            in (
+                0,
+                transaction_id,
+            )
+            and (
+                transaction_id == int(self._ended_tx.get(connector_id, 0) or 0)
+                or tx_end_context
             )
         )
 
@@ -1128,6 +1588,12 @@ class ChargePoint(cp):
             self._active_tx[connector_id] = transaction_id
             active_tx = transaction_id
             recorded_tx = transaction_id
+            self._note_transaction_id(transaction_id)
+            # The charger chose this id, so it says nothing about when the
+            # session began; use the persisted start if this is the session
+            # that was running before the restart, else the first sighting.
+            self._ensure_session_start(connector_id, transaction_id)
+            self._schedule_tx_store_save()
             _LOGGER.debug(
                 "Restored transactionId=%s on conn %s from MeterValues.",
                 transaction_id,
@@ -1194,21 +1660,26 @@ class ChargePoint(cp):
         if tx_ended:
             self._zero_flow_measurands(connector_id)
 
-        if tx_has_id and transaction_matches:
-            try:
-                tx_start_epoch = float(self._metrics[tx_key].value)
-            except (TypeError, ValueError):
-                tx_start_epoch = time.time()
-            if tx_start_epoch > 0:
-                self._metrics[session_key].value = round(
-                    (time.time() - tx_start_epoch) / 60
-                )
-                self._metrics[session_key].unit = UnitOfTime.MINUTES
-            else:
-                _LOGGER.debug(
-                    "Skipping session time calc — invalid tx_start_epoch=%s",
-                    tx_start_epoch,
-                )
+        # A sample for the transaction a held connector still has settles it as
+        # running; the closing values of that transaction settle it as over.
+        if connector_id in self._tx_indeterminate and tx_has_id:
+            if tx_ended:
+                # The connector's own transaction is over, which is evidence
+                # of how it ended; an unattributed stop is not claimed here.
+                self._resolve_indeterminate(connector_id, running=False, claim=False)
+            elif transaction_matches:
+                self._resolve_indeterminate(connector_id, running=True)
+
+        # Session time comes from the recorded start, never from the id. The
+        # closing values leave the final figure alone. A held connector only
+        # gets here once the sample above has settled it as running, so its
+        # timer stands still until the charger says something about it.
+        if tx_has_id and transaction_matches and not tx_ended:
+            started_at = self._ensure_session_start(connector_id, transaction_id)
+            self._metrics[session_key].value = max(
+                0, round((time.time() - started_at) / 60)
+            )
+            self._metrics[session_key].unit = UnitOfTime.MINUTES
         self.hass.async_create_task(self.update(self.settings.cpid))
         return call_result.MeterValues()
 
@@ -1223,6 +1694,7 @@ class ChargePoint(cp):
         self.received_boot_notification = True
         _LOGGER.debug("Received boot notification for %s: %s", self.id, kwargs)
 
+        self._ensure_tx_store_loaded()
         self.hass.async_create_task(self.async_update_device_info_v16(kwargs))
         self._register_boot_notification()
         return resp
@@ -1251,6 +1723,15 @@ class ChargePoint(cp):
                 ChargePointStatus.suspended_evse.value,
             ):
                 self._zero_flow_measurands(connector_id)
+
+            # A connector held as unresolved after an unknown StopTransaction
+            # is settled only by a status that proves something: Faulted or
+            # Preparing leave it held rather than end a session that may be
+            # running.
+            if status in _TX_RUNNING_STATUSES:
+                self._resolve_indeterminate(connector_id, running=True)
+            elif status in _TX_ENDED_STATUSES:
+                self._resolve_indeterminate(connector_id, running=False)
 
         self.hass.async_create_task(self.update(self.settings.cpid))
         return call_result.StatusNotification()
@@ -1297,12 +1778,21 @@ class ChargePoint(cp):
     def on_start_transaction(self, connector_id, id_tag, meter_start, **kwargs):
         """Handle a Start Transaction request."""
 
+        self._ensure_tx_store_loaded()
         auth_status = self.get_authorization_status(id_tag)
         if auth_status == AuthorizationStatus.accepted.value:
-            tx_id = int(time.time())
+            tx_id = self._allocate_transaction_id()
             self._ended_tx.pop(connector_id, None)
+            if connector_id in self._tx_indeterminate:
+                # Whatever it held has been superseded; a stop that named it
+                # can no longer be attributed to anyone.
+                self._tx_indeterminate.discard(connector_id)
+                self._invalidate_pending_stops(
+                    connector_id, "started a new transaction"
+                )
             self._active_tx[connector_id] = tx_id
             self.active_transaction_id = tx_id
+            self._set_session_start(connector_id, time.time(), estimated=False)
             self._metrics[(connector_id, cstat.id_tag)].value = id_tag
             self._metrics[(connector_id, cstat.stop_reason)].value = ""
             self._metrics[(connector_id, csess.transaction_id)].value = tx_id
@@ -1318,6 +1808,7 @@ class ChargePoint(cp):
             self._metrics[(connector_id, csess.session_energy)].value = 0.0
             self._metrics[(connector_id, csess.session_energy)].unit = HA_ENERGY_UNIT
 
+            self._schedule_tx_store_save()
             result = call_result.StartTransaction(
                 id_tag_info={om.status: AuthorizationStatus.accepted.value},
                 transaction_id=tx_id,
@@ -1335,41 +1826,59 @@ class ChargePoint(cp):
     def on_stop_transaction(self, meter_stop, timestamp, transaction_id, **kwargs):
         """Stop the current transaction (multi-connector)."""
 
-        # Resolve connector from active tx map
-        conn = next(
-            (c for c, tx in self._active_tx.items() if tx == transaction_id), None
-        )
+        self._ensure_tx_store_loaded()
+        conn = self._resolve_stop_connector(transaction_id)
         if conn is None:
-            _LOGGER.error(
-                "Stop transaction received for unknown transaction id=%i",
-                transaction_id,
-            )
-            conn = 1  # conservative fallback
-
-        # Reset active transaction (global + per-connector)
-        self._ended_tx[conn] = int(transaction_id or 0)
-        self._active_tx[conn] = 0
-        self.active_transaction_id = 0
-        self._metrics[(conn, cstat.id_tag)].value = ""
-        self._metrics[(conn, csess.transaction_id)].value = 0
-        self._metrics[(conn, cstat.stop_reason)].value = kwargs.get(
-            om.reason.name, None
-        )
-
-        ms_key = (conn, csess.meter_start)
-        if (
-            self._metrics[ms_key].value is not None
-            and not self._charger_reports_session_energy
-        ):
-            try:
-                session_kwh = int(meter_stop) / 1000.0 - float(
-                    self._metrics[ms_key].value
+            # Guessing here used to reset connector 1, ending a session that
+            # may still be running and filing another connector's energy
+            # against it. Hold every connector that could own this stop
+            # instead: its timer stops advancing and the next status report
+            # from the charger settles it.
+            live = self._live_connectors()
+            if live:
+                self._tx_indeterminate.update(live)
+                # Keep the stop's payload for whichever of them ended.
+                self._pending_stops.append(
+                    {
+                        "transaction_id": transaction_id,
+                        "meter_stop": meter_stop,
+                        "reason": kwargs.get(om.reason.name, None),
+                        "candidates": set(live),
+                    }
                 )
-            except Exception:
-                session_kwh = 0.0
-            self._metrics[(conn, csess.session_energy)].value = session_kwh
+                _LOGGER.warning(
+                    "%s: StopTransaction for unknown transaction id=%s; cannot "
+                    "tell which of connectors %s it ends, holding their session "
+                    "state until the charger reports their status",
+                    self.id,
+                    transaction_id,
+                    live,
+                )
+            else:
+                _LOGGER.warning(
+                    "%s: StopTransaction for unknown transaction id=%s with no "
+                    "transaction recorded on any connector; nothing to end",
+                    self.id,
+                    transaction_id,
+                )
+            self.hass.async_create_task(self.update(self.settings.cpid))
+            return call_result.StopTransaction(
+                id_tag_info={om.status: AuthorizationStatus.accepted.value}
+            )
+
+        # Reset active transaction (global + per-connector). A stop that names
+        # this connector as a possible owner could have been a malformed
+        # duplicate of this one, so it is discarded rather than left for
+        # another connector to claim.
+        self._invalidate_pending_stops(conn, "received its own StopTransaction")
+        self._clear_transaction_state(
+            conn, transaction_id, kwargs.get(om.reason.name, None)
+        )
+        self.active_transaction_id = 0
+        self._apply_stop_energy(conn, meter_stop)
 
         self._zero_flow_measurands(conn)
+        self._schedule_tx_store_save()
 
         self.hass.async_create_task(self.update(self.settings.cpid))
         return call_result.StopTransaction(

--- a/custom_components/ocpp/switch.py
+++ b/custom_components/ocpp/switch.py
@@ -44,6 +44,9 @@ class OcppSwitchDescription(SwitchEntityDescription):
     default_state: bool = False
     per_connector: bool = False
     single_connector_status_fallback: bool = False
+    # The switch acts on the connector's transaction, so it is unavailable
+    # while that transaction's state is held as unresolved (see ocppv16).
+    transaction_bound: bool = False
 
 
 SWITCHES: Final[list[OcppSwitchDescription]] = [
@@ -60,6 +63,7 @@ SWITCHES: Final[list[OcppSwitchDescription]] = [
             ChargePointStatus.suspended_ev.value,
         ],
         per_connector=True,
+        transaction_bound=True,
     ),
     OcppSwitchDescription(
         key="availability",
@@ -207,6 +211,11 @@ class ChargePointSwitch(SwitchEntity):
         target_conn = (
             self.connector_id if self.entity_description.per_connector else None
         )
+        if (
+            self.entity_description.transaction_bound
+            and self.central_system.is_transaction_indeterminate(self.cpid, target_conn)
+        ):
+            return False
         return bool(self.central_system.get_available(self.cpid, target_conn))
 
     @property

--- a/tests/test_set_charge_rate_v16.py
+++ b/tests/test_set_charge_rate_v16.py
@@ -48,6 +48,7 @@ def cp_v16():
     cp._ocpp_version = "1.6"
     cp.active_transaction_id = 0
     cp._active_tx = {}
+    cp._tx_indeterminate = set()
     cp._metrics = _ConnectorAwareMetrics()
     # set_charge_rate calls these (we’ll monkeypatch per-test):
     # - cp.get_configuration(key)

--- a/tests/test_v16_transaction_identity.py
+++ b/tests/test_v16_transaction_identity.py
@@ -1,0 +1,1227 @@
+"""OCPP 1.6 transaction identity, timing and containment (#2123).
+
+The integration allocates 1.6 transaction ids itself. They used to be
+int(time.time()), which was assumed unique, guessed onto connector 1 when a
+StopTransaction could not be matched, and read back as the session's start
+epoch. Each assumption had a failure mode:
+
+- two connectors starting in the same second shared an id, so a stop for one
+  was applied to whichever came first in the active map;
+- an unknown stop reset connector 1, ending a session that may still have
+  been running there;
+- a charger-supplied id adopted from MeterValues after a restart is not an
+  epoch, so the session timer counted from an arbitrary reference (the second
+  symptom reported in #1938).
+
+These tests drive the server-side handlers directly, the way the charger's
+messages would, without a websocket.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, UTC
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.core import HomeAssistant
+from ocpp.charge_point import ChargePoint as LibChargePoint
+from ocpp.v16.enums import ChargePointStatus, RemoteStartStopStatus
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+from websockets.protocol import State
+
+from custom_components.ocpp import ocppv16
+from custom_components.ocpp.const import (
+    DOMAIN,
+    CentralSystemSettings,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import (
+    ConfigurationKey as ckey,
+    HAChargerSession as csess,
+    OcppMisc as om,
+    Profiles as prof,
+)
+from custom_components.ocpp.ocppv16 import ChargePoint, tx_store_key
+from custom_components.ocpp.switch import SWITCHES, ChargePointSwitch
+
+from .test_charge_point_core import _mk_entry_data
+
+CP_ID = "CP_identity"
+NOW = 1_800_000_000.0  # a fixed "now", far from any id the tests seed
+
+
+def _store_key(entry: MockConfigEntry) -> str:
+    return tx_store_key(entry.entry_id, CP_ID)
+
+
+def _mk_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data=_mk_entry_data())
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _mk_cp(
+    hass: HomeAssistant, *, connectors: int = 2, entry: MockConfigEntry | None = None
+) -> ChargePoint:
+    entry = entry or _mk_entry(hass)
+    # The authorization lookup in StartTransaction reads the integration's
+    # config bucket; there is no CentralSystem here to have created it.
+    hass.data.setdefault(DOMAIN, {})
+    centr = CentralSystemSettings(**entry.data)
+    chg = ChargerSystemSettings(
+        cpid="test_cpid",
+        max_current=32,
+        idle_interval=60,
+        meter_interval=60,
+        monitored_variables="",
+        monitored_variables_autoconfig=False,
+        skip_schema_validation=False,
+        force_smart_charging=False,
+    )
+    conn = SimpleNamespace(state=State.CLOSED, close=lambda: asyncio.sleep(0))
+    cp = ChargePoint(CP_ID, conn, hass, entry, centr, chg)
+    cp.num_connectors = connectors
+    for c in range(1, connectors + 1):
+        cp._init_connector_slots(c)
+    return cp
+
+
+@pytest.fixture
+def frozen_time(monkeypatch):
+    """Pin time.time() as the handlers see it; tests move it explicitly.
+
+    Only the module under test sees the pinned clock: its `time` reference is
+    replaced with a stub, so Home Assistant and the event loop keep real time.
+    """
+    clock = {"now": NOW}
+    monkeypatch.setattr(ocppv16, "time", SimpleNamespace(time=lambda: clock["now"]))
+    return clock
+
+
+def _meter_values(
+    tx_id: int, *, context: str = "Sample.Periodic", value: str = "1000"
+) -> dict:
+    return {
+        "connector_id": 1,
+        "meter_value": [
+            {
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+                # Handlers see the library's snake_case conversion of the
+                # wire payload, not the camelCase the charger sends.
+                "sampled_value": [
+                    {
+                        "measurand": "Energy.Active.Import.Register",
+                        "context": context,
+                        "unit": "Wh",
+                        "value": value,
+                    }
+                ],
+            }
+        ],
+        "transaction_id": tx_id,
+    }
+
+
+async def _settle(hass: HomeAssistant, cp: ChargePoint) -> None:
+    """Let the store load and any scheduled update() tasks run."""
+    cp._ensure_tx_store_loaded()
+    await cp._tx_store_load
+    await hass.async_block_till_done()
+
+
+# --------------------------------------------------------------------------
+# Identity
+# --------------------------------------------------------------------------
+
+
+async def test_simultaneous_starts_get_distinct_ids(hass, frozen_time):
+    """Two connectors starting in the same second must not share an id."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+
+    first = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    second = cp.on_start_transaction(2, "tag-b", 0).transaction_id
+    await hass.async_block_till_done()
+
+    assert first == int(NOW)
+    assert second == first + 1
+    assert cp._active_tx == {1: first, 2: second}
+    assert cp._last_tx_id == second
+
+
+async def test_ids_never_fall_below_the_persisted_last_id(
+    hass, hass_storage, frozen_time
+):
+    """After a restart, allocation continues above the last id handed out.
+
+    The persisted value is ahead of the clock here, as it would be after a
+    burst of same-second starts or a clock that went backwards.
+    """
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {"last_tx_id": int(NOW) + 1000, "connectors": {}},
+    }
+    cp = _mk_cp(hass, entry=entry)
+    await _settle(hass, cp)
+
+    allocated = cp.on_start_transaction(1, "tag", 0).transaction_id
+    await hass.async_block_till_done()
+
+    assert allocated == int(NOW) + 1001
+
+
+async def test_running_session_is_persisted_for_a_restart(
+    hass, hass_storage, frozen_time
+):
+    """StartTransaction records the id and start time; the write is delayed."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    key = cp._tx_store.key
+
+    tx = cp.on_start_transaction(1, "tag", 0).transaction_id
+    assert cp._tx_store_snapshot() == {
+        "last_tx_id": tx,
+        "connectors": {"1": {"tx_id": tx, "started_at": NOW}},
+    }
+    # Nothing is written synchronously from the handler.
+    assert key not in hass_storage
+    async_fire_time_changed(hass, datetime.now(tz=UTC).replace(year=2100))
+    await hass.async_block_till_done()
+    assert hass_storage[key]["data"]["connectors"]["1"]["tx_id"] == tx
+
+
+# --------------------------------------------------------------------------
+# StopTransaction resolution
+# --------------------------------------------------------------------------
+
+
+async def test_known_stop_ends_only_its_connector(hass, frozen_time):
+    """Control: a stop whose id is recorded ends that connector alone."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    second = cp.on_start_transaction(2, "tag-b", 0).transaction_id
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=second)
+    await hass.async_block_till_done()
+
+    assert cp._active_tx == {1: first, 2: 0}
+    assert cp._metrics[(1, csess.transaction_id)].value == first
+    assert cp._metrics[(2, csess.transaction_id)].value == 0
+    assert cp._tx_indeterminate == set()
+
+
+async def test_unknown_stop_resolves_to_the_only_live_connector(hass, frozen_time):
+    """One transaction running: an unrecorded stop id can only be for it."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp._active_tx[2] = 4242  # adopted from the charger, not our allocation
+    cp._metrics[(2, csess.transaction_id)].value = 4242
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=9999)
+    await hass.async_block_till_done()
+
+    assert cp._active_tx[2] == 0
+    assert cp._metrics[(2, csess.transaction_id)].value == 0
+    # Connector 1, the old fallback target, is untouched.
+    assert cp._metrics[(1, csess.transaction_id)].value is None
+    assert cp._tx_indeterminate == set()
+
+
+async def test_unknown_stop_with_two_live_connectors_holds_both(hass, frozen_time):
+    """Ambiguity is contained, not guessed: neither connector is reset."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    second = cp.on_start_transaction(2, "tag-b", 0).transaction_id
+
+    resp = cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=9999)
+    await hass.async_block_till_done()
+
+    assert resp.id_tag_info["status"] == "Accepted"
+    assert cp._active_tx == {1: first, 2: second}
+    assert cp._tx_indeterminate == {1, 2}
+
+    # The charger then reports connector 2 idle and connector 1 charging.
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    cp.on_status_notification(1, "NoError", ChargePointStatus.charging.value)
+    await hass.async_block_till_done()
+
+    assert cp._active_tx == {1: first, 2: 0}
+    assert cp._metrics[(2, csess.transaction_id)].value == 0
+    assert cp._tx_indeterminate == set()
+
+
+async def test_unknown_stop_with_nothing_running_changes_nothing(hass, frozen_time):
+    """No transaction anywhere: the stop is accepted and nothing is reset."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+
+    resp = cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=9999)
+    await hass.async_block_till_done()
+
+    assert resp.id_tag_info["status"] == "Accepted"
+    assert cp._active_tx == {}
+    assert cp._tx_indeterminate == set()
+    assert cp._metrics[(1, csess.transaction_id)].value is None
+
+
+async def test_duplicate_charger_ids_on_two_connectors_are_held(hass, frozen_time):
+    """Charger-supplied ids can collide; a stop for one cannot be attributed."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    for c in (1, 2):
+        cp._active_tx[c] = 700
+        cp._metrics[(c, csess.transaction_id)].value = 700
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=700)
+    await hass.async_block_till_done()
+
+    assert cp._active_tx == {1: 700, 2: 700}
+    assert cp._tx_indeterminate == {1, 2}
+
+
+async def test_held_connector_is_settled_by_its_own_meter_values(hass, frozen_time):
+    """A sample for the held transaction proves it is still running."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    cp.on_start_transaction(2, "tag-b", 0)
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=9999)
+    assert cp._tx_indeterminate == {1, 2}
+
+    cp.on_meter_values(**_meter_values(tx))
+    await hass.async_block_till_done()
+
+    assert cp._tx_indeterminate == {2}
+    assert cp._active_tx[1] == tx
+
+
+# --------------------------------------------------------------------------
+# Session time
+# --------------------------------------------------------------------------
+
+
+async def test_session_time_comes_from_the_recorded_start(hass, frozen_time):
+    """Ten minutes after StartTransaction the timer reads ten minutes."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag", 0).transaction_id
+
+    frozen_time["now"] = NOW + 600
+    cp.on_meter_values(**_meter_values(tx))
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_time)].value == 10
+    assert cp._metrics[(1, csess.session_time)].extra_attr == {}
+
+
+async def test_adopted_transaction_counts_from_first_sighting_and_says_so(
+    hass, frozen_time
+):
+    """A charger id is not an epoch: the timer must not read (now - id)."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+
+    cp.on_meter_values(**_meter_values(4242))
+    frozen_time["now"] = NOW + 300
+    cp.on_meter_values(**_meter_values(4242))
+    await hass.async_block_till_done()
+
+    assert cp._active_tx[1] == 4242
+    assert cp._metrics[(1, csess.session_time)].value == 5
+    assert cp._metrics[(1, csess.session_time)].extra_attr == {
+        "start_time_estimated": True
+    }
+
+
+async def test_adopted_transaction_matching_the_persisted_one_keeps_its_start(
+    hass, hass_storage, frozen_time
+):
+    """The session running before a restart resumes with its real duration."""
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {
+            "last_tx_id": 4242,
+            "connectors": {"1": {"tx_id": 4242, "started_at": NOW - 1800}},
+        },
+    }
+    cp = _mk_cp(hass, entry=entry)
+    await _settle(hass, cp)
+
+    cp.on_meter_values(**_meter_values(4242))
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_time)].value == 30
+    assert cp._metrics[(1, csess.session_time)].extra_attr == {}
+
+
+async def test_session_time_is_never_negative(hass, frozen_time):
+    """A clock that went backwards yields zero, not a negative duration."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag", 0).transaction_id
+
+    frozen_time["now"] = NOW - 3600
+    cp.on_meter_values(**_meter_values(tx))
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_time)].value == 0
+
+
+async def test_closing_values_leave_the_final_session_time(hass, frozen_time):
+    """The Transaction.End sample after a stop must not restart the clock."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag", 0).transaction_id
+    frozen_time["now"] = NOW + 600
+    cp.on_meter_values(**_meter_values(tx))
+    assert cp._metrics[(1, csess.session_time)].value == 10
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=tx)
+    frozen_time["now"] = NOW + 660
+    cp.on_meter_values(**_meter_values(tx, context="Transaction.End"))
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_time)].value == 10
+
+
+async def test_held_connector_timer_resumes_on_its_own_sample(hass, frozen_time):
+    """A held connector's timer stands still until a sample settles it."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    cp.on_start_transaction(2, "tag-b", 0)
+    frozen_time["now"] = NOW + 600
+    cp.on_meter_values(**_meter_values(tx))
+    assert cp._metrics[(1, csess.session_time)].value == 10
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=9999)
+    # Nothing updates the timer while the connector is held. The first sample
+    # for its transaction settles it as running and the timer resumes.
+    frozen_time["now"] = NOW + 1200
+    cp.on_meter_values(**_meter_values(tx))
+    assert cp._metrics[(1, csess.session_time)].value == 20
+    await hass.async_block_till_done()
+
+
+async def test_broken_store_is_tolerated(hass, frozen_time, caplog):
+    """A store that cannot be read must not stop transactions from starting."""
+    cp = _mk_cp(hass)
+
+    async def boom():
+        raise OSError("disk unhappy")
+
+    cp._tx_store.async_load = boom
+    await _settle(hass, cp)
+
+    assert cp.on_start_transaction(1, "tag", 0).transaction_id == int(NOW)
+    assert "could not load transaction state" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Review findings on the first cut
+# --------------------------------------------------------------------------
+
+
+async def test_start_waits_for_the_store_before_the_message_loop(
+    hass, hass_storage, frozen_time, monkeypatch
+):
+    """The first message must see the persisted ceiling, not race the load."""
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {"last_tx_id": int(NOW) + 1000, "connectors": {}},
+    }
+    cp = _mk_cp(hass, entry=entry)
+    seen = {}
+
+    async def first_message_arrives(self):
+        # Stands in for the library's receive loop: the charger's first
+        # message is a StartTransaction.
+        seen["loaded"] = cp._tx_store_load is not None and cp._tx_store_load.done()
+        seen["id"] = cp.on_start_transaction(1, "tag", 0).transaction_id
+
+    async def no_monitor():
+        return None
+
+    monkeypatch.setattr(LibChargePoint, "start", first_message_arrives)
+    monkeypatch.setattr(cp, "monitor_connection", no_monitor)
+
+    await cp.start()
+    await hass.async_block_till_done()
+
+    assert seen == {"loaded": True, "id": int(NOW) + 1001}
+
+
+async def test_a_store_that_loads_late_still_corrects_an_estimated_start(
+    hass, hass_storage, frozen_time
+):
+    """A path that bypasses start() gets its estimate replaced once loaded."""
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {
+            "last_tx_id": 4242,
+            "connectors": {"1": {"tx_id": 4242, "started_at": NOW - 1800}},
+        },
+    }
+    cp = _mk_cp(hass, entry=entry)
+    # Home Assistant starts tasks eagerly and the storage mock never suspends,
+    # so make the load yield once, as real disk I/O does.
+    real_load = cp._tx_store.async_load
+
+    async def slow_load():
+        await asyncio.sleep(0)
+        return await real_load()
+
+    cp._tx_store.async_load = slow_load
+
+    # Adopted before the load has run: the only start known is "now".
+    cp.on_meter_values(**_meter_values(4242))
+    assert cp._metrics[(1, csess.session_time)].extra_attr == {
+        "start_time_estimated": True
+    }
+
+    await cp._tx_store_load
+    frozen_time["now"] = NOW + 60
+    cp.on_meter_values(**_meter_values(4242))
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_time)].value == 31
+    assert cp._metrics[(1, csess.session_time)].extra_attr == {}
+
+
+async def test_an_adopted_id_is_not_handed_out_again(hass, frozen_time):
+    """A charger id adopted from MeterValues is kept clear of allocation."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+
+    cp.on_meter_values(**_meter_values(int(NOW)))
+    assert cp._active_tx[1] == int(NOW)
+
+    second = cp.on_start_transaction(2, "tag", 0).transaction_id
+    await hass.async_block_till_done()
+
+    assert second == int(NOW) + 1
+
+
+async def test_a_restored_id_is_not_handed_out_again(hass, frozen_time, monkeypatch):
+    """An id restored from Home Assistant state is kept clear of allocation."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+
+    def restored(metric, connector_id=None):
+        return int(NOW) if metric == csess.transaction_id else None
+
+    monkeypatch.setattr(cp, "get_ha_metric", restored)
+    cp.on_meter_values(**_meter_values(0))
+    assert cp._active_tx[1] == int(NOW)
+
+    second = cp.on_start_transaction(2, "tag", 0).transaction_id
+    await hass.async_block_till_done()
+
+    assert second == int(NOW) + 1
+
+
+async def _two_held(hass, cp):
+    """Start two transactions and hold both with an unattributable stop."""
+    first = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    second = cp.on_start_transaction(2, "tag-b", 0).transaction_id
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9999, reason="EVDisconnected"
+    )
+    await hass.async_block_till_done()
+    assert cp._tx_indeterminate == {1, 2}
+    return first, second
+
+
+@pytest.mark.parametrize(
+    "status", [ChargePointStatus.faulted.value, ChargePointStatus.preparing.value]
+)
+async def test_ambiguous_statuses_keep_a_held_connector(hass, frozen_time, status):
+    """Faulted and Preparing prove nothing, so the hold stays."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first, second = await _two_held(hass, cp)
+
+    cp.on_status_notification(1, "NoError", status)
+    await hass.async_block_till_done()
+
+    assert cp._tx_indeterminate == {1, 2}
+    assert cp._active_tx == {1: first, 2: second}
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ChargePointStatus.available.value,
+        ChargePointStatus.finishing.value,
+        ChargePointStatus.unavailable.value,
+        ChargePointStatus.reserved.value,
+    ],
+)
+async def test_idle_statuses_end_a_held_connector(hass, frozen_time, status):
+    """A status that proves the connector has no transaction ends its hold."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first, _ = await _two_held(hass, cp)
+
+    cp.on_status_notification(2, "NoError", status)
+    await hass.async_block_till_done()
+
+    assert cp._tx_indeterminate == {1}
+    assert cp._active_tx == {1: first, 2: 0}
+
+
+async def test_global_remote_stop_skips_a_held_connector(
+    hass, frozen_time, monkeypatch
+):
+    """A global stop never targets an id a held connector may not own."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first, second = await _two_held(hass, cp)
+    # Connector 1 proves it is running; connector 2 stays held. The legacy
+    # global field points at connector 2's id, the last one started.
+    cp.on_status_notification(1, "NoError", ChargePointStatus.charging.value)
+    assert cp._tx_indeterminate == {2}
+    assert cp.active_transaction_id == second
+    sent = []
+
+    async def accept(req):
+        sent.append(req)
+        return SimpleNamespace(status=RemoteStartStopStatus.accepted)
+
+    monkeypatch.setattr(cp, "call", accept)
+    assert await cp.stop_transaction() is True
+    await hass.async_block_till_done()
+
+    assert [req.transaction_id for req in sent] == [first]
+
+
+async def test_no_tx_profile_is_bound_to_a_held_connector(
+    hass, frozen_time, monkeypatch
+):
+    """The 1.6 fallback must not bind a profile to an uncertain transaction."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    await _two_held(hass, cp)
+    cp._attr_supported_features = prof.SMART
+    purposes = []
+
+    async def configuration(key):
+        if key == ckey.charging_schedule_allowed_charging_rate_unit:
+            return "Current"
+        return "5"
+
+    async def reject_station_profile(req):
+        purpose = req.cs_charging_profiles[om.charging_profile_purpose]
+        purposes.append(purpose)
+        accepted = purpose != "ChargePointMaxProfile"
+        return SimpleNamespace(status="Accepted" if accepted else "Rejected")
+
+    monkeypatch.setattr(cp, "get_configuration", configuration)
+    monkeypatch.setattr(cp, "call", reject_station_profile)
+
+    await cp.set_charge_rate(limit_amps=10, conn_id=1)
+    await hass.async_block_till_done()
+
+    assert "TxProfile" not in purposes
+    assert "TxDefaultProfile" in purposes
+
+
+async def test_pending_stop_is_applied_to_the_connector_that_ended(hass, frozen_time):
+    """The unattributed stop's meter reading and reason reach the right session."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first, _ = await _two_held(hass, cp)
+    assert cp._pending_stops[0]["meter_stop"] == 5000
+
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(2, csess.session_energy)].value == 5.0
+    assert cp._metrics[(2, "Stop.Reason")].value == "EVDisconnected"
+    assert cp._metrics[(1, csess.session_energy)].value == 0.0
+    assert cp._active_tx == {1: first, 2: 0}
+    assert cp._pending_stops == []
+
+
+def test_store_keys_differ_for_ids_that_slugify_alike():
+    """Chargers of one entry whose ids slugify the same keep separate state."""
+    keys = {tx_store_key("entry", cp_id) for cp_id in ("CP-A", "CP_A", "CP A")}
+
+    assert len(keys) == 3
+    assert all(k.startswith(f"{DOMAIN}.v16_transactions.entry.cp_a_") for k in keys)
+
+
+async def test_an_id_adopted_after_a_stop_is_not_handed_out_again(hass, frozen_time):
+    """The self-heal path (metric zeroed by a stop) also raises the floor.
+
+    After a stop the connector's metric is 0, so a charger id seen in
+    MeterValues is adopted by the self-heal branch rather than the restore
+    branch. If that id is exactly the next one allocation would produce,
+    the next StartTransaction must still not repeat it.
+    """
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first = cp.on_start_transaction(1, "tag-a", 0).transaction_id
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=first)
+    assert cp._metrics[(1, csess.transaction_id)].value == 0
+
+    cp.on_meter_values(**_meter_values(first + 1))
+    assert cp._active_tx[1] == first + 1
+
+    second = cp.on_start_transaction(2, "tag-b", 0).transaction_id
+    await hass.async_block_till_done()
+
+    assert second == first + 2
+
+
+# --------------------------------------------------------------------------
+# Second review: remote stops, concurrent unattributed stops, bad timestamps
+# --------------------------------------------------------------------------
+
+
+async def test_per_connector_remote_stop_refuses_a_held_connector(
+    hass, frozen_time, monkeypatch
+):
+    """The Charge Control path names its connector; a held one is refused."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    await _two_held(hass, cp)
+    sent, notices = [], []
+
+    async def accept(req):
+        sent.append(req)
+        return SimpleNamespace(status=RemoteStartStopStatus.accepted)
+
+    async def note(msg, title="Ocpp integration"):
+        notices.append(msg)
+        return True
+
+    monkeypatch.setattr(cp, "call", accept)
+    monkeypatch.setattr(cp, "notify_ha", note)
+
+    assert await cp.stop_transaction(connector_id=1) is False
+    await hass.async_block_till_done()
+
+    assert sent == []
+    assert notices and "unresolved" in notices[0]
+
+
+async def test_global_remote_stop_skips_an_id_shared_with_a_held_connector(
+    hass, frozen_time, monkeypatch
+):
+    """An unheld connector cannot lend an id a held connector may still own."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    for c in (1, 2):
+        cp._active_tx[c] = 700
+        cp._metrics[(c, csess.transaction_id)].value = 700
+    cp.active_transaction_id = 700
+    cp._tx_indeterminate = {1}
+    sent = []
+
+    async def accept(req):
+        sent.append(req)
+        return SimpleNamespace(status=RemoteStartStopStatus.accepted)
+
+    monkeypatch.setattr(cp, "call", accept)
+
+    assert await cp.stop_transaction() is True  # nothing safe to stop: no-op
+    await hass.async_block_till_done()
+
+    assert sent == []
+
+
+async def test_central_system_reports_a_held_connector(hass):
+    """The switch's availability gate reads the charge point's held set."""
+    from .test_api_paths import _available_central_system
+
+    cs, dummy = _available_central_system(hass)
+    dummy._tx_indeterminate = {1}
+
+    assert cs.is_transaction_indeterminate("ok", 1) is True
+    assert cs.is_transaction_indeterminate("ok", 2) is False
+    assert cs.is_transaction_indeterminate("nope", 1) is False
+
+
+async def test_two_unattributed_stops_are_not_cross_applied(hass, frozen_time):
+    """Neither connector may knowingly receive the other session's final data."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp.on_start_transaction(1, "tag-a", 1000)
+    cp.on_start_transaction(2, "tag-b", 2000)
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9001, reason="Local"
+    )
+    cp.on_stop_transaction(
+        meter_stop=9000, timestamp=None, transaction_id=9002, reason="Remote"
+    )
+    assert cp._tx_indeterminate == {1, 2}
+    assert len(cp._pending_stops) == 2
+
+    cp.on_status_notification(1, "NoError", ChargePointStatus.available.value)
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    for conn in (1, 2):
+        assert cp._active_tx[conn] == 0
+        assert cp._metrics[(conn, csess.session_energy)].value == 0.0
+        assert cp._metrics[(conn, "Stop.Reason")].value is None
+    assert cp._pending_stops == []
+
+
+async def test_sequential_unattributed_stops_each_reach_their_connector(
+    hass, frozen_time
+):
+    """One outstanding stop at a time is attributable and applied."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp.on_start_transaction(1, "tag-a", 1000)
+    cp.on_start_transaction(2, "tag-b", 2000)
+
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9001, reason="Local"
+    )
+    cp.on_status_notification(1, "NoError", ChargePointStatus.available.value)
+    cp.on_stop_transaction(
+        meter_stop=9000, timestamp=None, transaction_id=9002, reason="Remote"
+    )
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_energy)].value == 4.0
+    assert cp._metrics[(1, "Stop.Reason")].value == "Local"
+    assert cp._metrics[(2, csess.session_energy)].value == 7.0
+    assert cp._metrics[(2, "Stop.Reason")].value == "Remote"
+    assert cp._pending_stops == []
+
+
+async def test_a_connector_settled_as_running_gives_up_its_claim(hass, frozen_time):
+    """Once one candidate proves it is running, the stop must be the other's."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp.on_start_transaction(1, "tag-a", 1000)
+    cp.on_start_transaction(2, "tag-b", 2000)
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9001, reason="Local"
+    )
+
+    cp.on_status_notification(1, "NoError", ChargePointStatus.charging.value)
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(2, csess.session_energy)].value == 3.0
+    assert cp._metrics[(2, "Stop.Reason")].value == "Local"
+    assert cp._pending_stops == []
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf"), -5.0])
+async def test_non_finite_persisted_start_falls_back_to_an_estimate(
+    hass, hass_storage, frozen_time, bad
+):
+    """A corrupt timestamp must not make every later MeterValues raise."""
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {
+            "last_tx_id": 4242,
+            "connectors": {"1": {"tx_id": 4242, "started_at": bad}},
+        },
+    }
+    cp = _mk_cp(hass, entry=entry)
+    await _settle(hass, cp)
+    assert cp._persisted_tx == {}
+
+    cp.on_meter_values(**_meter_values(4242))
+    frozen_time["now"] = NOW + 120
+    cp.on_meter_values(**_meter_values(4242))
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_time)].value == 2
+    assert cp._metrics[(1, csess.session_time)].extra_attr == {
+        "start_time_estimated": True
+    }
+
+
+async def test_charge_control_switch_is_unavailable_while_its_connector_is_held(
+    hass,
+):
+    """The entity that remote-stops a connector goes unavailable while held."""
+    from .test_api_paths import _available_central_system
+
+    cs, dummy = _available_central_system(hass)
+    charge_control = next(d for d in SWITCHES if d.key == "charge_control")
+    assert charge_control.transaction_bound is True
+    entity = ChargePointSwitch(cs, "ok", charge_control, connector_id=1)
+
+    assert entity.available is True
+    dummy._tx_indeterminate = {1}
+    assert entity.available is False
+    dummy._tx_indeterminate = {2}
+    assert entity.available is True
+
+
+async def test_a_stop_no_held_connector_can_own_is_discarded(hass, frozen_time):
+    """Once every candidate proves it is running, the stale stop is dropped.
+
+    Left in place it could later be mistaken for a fresh unattributed stop
+    and make a genuine one ambiguous.
+    """
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    await _two_held(hass, cp)
+    assert len(cp._pending_stops) == 1
+
+    cp.on_status_notification(1, "NoError", ChargePointStatus.charging.value)
+    cp.on_status_notification(2, "NoError", ChargePointStatus.charging.value)
+    await hass.async_block_till_done()
+
+    assert cp._tx_indeterminate == set()
+    assert cp._pending_stops == []
+
+
+# --------------------------------------------------------------------------
+# Third review: other evidence of how a candidate ended, and duplicate-id gating
+# --------------------------------------------------------------------------
+
+
+async def test_a_known_stop_on_a_candidate_invalidates_the_pending_stop(
+    hass, frozen_time
+):
+    """A duplicate for the connector that then stopped properly is possible.
+
+    So the other candidate must not receive the unattributed stop.
+    """
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first = cp.on_start_transaction(1, "tag-a", 1000).transaction_id
+    cp.on_start_transaction(2, "tag-b", 2000)
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9999, reason="EVDisconnected"
+    )
+    assert cp._tx_indeterminate == {1, 2}
+
+    cp.on_stop_transaction(
+        meter_stop=3000, timestamp=None, transaction_id=first, reason="Local"
+    )
+    assert cp._pending_stops == []
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(1, csess.session_energy)].value == 2.0
+    assert cp._metrics[(1, "Stop.Reason")].value == "Local"
+    assert cp._metrics[(2, csess.session_energy)].value == 0.0
+    assert cp._metrics[(2, "Stop.Reason")].value is None
+    assert cp._active_tx[2] == 0
+
+
+async def test_a_new_start_on_a_candidate_invalidates_the_pending_stop(
+    hass, frozen_time
+):
+    """A new transaction on a candidate supersedes whatever the stop ended."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp.on_start_transaction(1, "tag-a", 1000)
+    cp.on_start_transaction(2, "tag-b", 2000)
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9999, reason="EVDisconnected"
+    )
+
+    cp.on_start_transaction(1, "tag-c", 1500)
+    assert cp._tx_indeterminate == {2}
+    assert cp._pending_stops == []
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(2, csess.session_energy)].value == 0.0
+    assert cp._metrics[(2, "Stop.Reason")].value is None
+
+
+async def test_closing_values_on_a_candidate_do_not_claim_the_pending_stop(
+    hass, frozen_time
+):
+    """Closing values are evidence of how the connector's transaction ended.
+
+    Unlike a blank idle report, they attribute nothing to it or to the other.
+    """
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first = cp.on_start_transaction(1, "tag-a", 1000).transaction_id
+    cp.on_start_transaction(2, "tag-b", 2000)
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9999, reason="EVDisconnected"
+    )
+
+    cp.on_meter_values(**_meter_values(first, context="Transaction.End"))
+    assert cp._tx_indeterminate == {2}
+    assert cp._pending_stops == []
+    assert cp._metrics[(1, "Stop.Reason")].value is None
+    cp.on_status_notification(2, "NoError", ChargePointStatus.available.value)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(2, csess.session_energy)].value == 0.0
+    assert cp._metrics[(2, "Stop.Reason")].value is None
+
+
+async def test_foreign_closing_values_do_not_settle_a_held_connector(
+    hass, frozen_time, caplog
+):
+    """Closing values for some other transaction prove nothing about this one.
+
+    A Transaction.End context speaks only for the id it carries. A stray or
+    delayed sample for another transaction leaves the held connector held,
+    with its transaction, energy and flow intact and the pending stop in place.
+    """
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    first = cp.on_start_transaction(1, "tag-a", 1000).transaction_id
+    cp.on_start_transaction(2, "tag-b", 2000)
+    cp.on_meter_values(**_meter_values(first, value="3000"))
+    assert cp._metrics[(1, csess.session_energy)].value == 2.0
+    cp._metrics[(1, "Power.Active.Import")].value = 7.0
+    cp.on_stop_transaction(
+        meter_stop=5000, timestamp=None, transaction_id=9999, reason="EVDisconnected"
+    )
+    pending = list(cp._pending_stops)
+
+    cp.on_meter_values(
+        **_meter_values(first + 500, context="Transaction.End", value="9000")
+    )
+    await hass.async_block_till_done()
+
+    assert cp._tx_indeterminate == {1, 2}
+    assert cp._pending_stops == pending
+    assert cp._active_tx[1] == first
+    assert cp._metrics[(1, csess.transaction_id)].value == first
+    assert cp._metrics[(1, csess.session_energy)].value == 2.0
+    assert cp._metrics[(1, "Power.Active.Import")].value == 7.0
+    assert "Unknown transaction detected on conn 1" in caplog.text
+
+
+async def test_closing_values_for_an_unknown_id_are_not_adopted(hass, frozen_time):
+    """After a stop, another transaction's closing values start nothing here."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag", 1000).transaction_id
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=tx)
+
+    cp.on_meter_values(**_meter_values(tx + 500, context="Transaction.End"))
+    await hass.async_block_till_done()
+
+    assert cp._active_tx[1] == 0
+    assert cp._metrics[(1, csess.transaction_id)].value == 0
+
+
+async def test_first_closing_values_after_restart_are_not_adopted(hass, frozen_time):
+    """A first sighting marked Transaction.End is not a live transaction."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    closing_tx = int(NOW)
+
+    cp.on_meter_values(**_meter_values(closing_tx, context="Transaction.End"))
+    await hass.async_block_till_done()
+
+    assert cp._active_tx[1] == 0
+    assert cp._metrics[(1, csess.transaction_id)].value is None
+    assert 1 not in cp._tx_started_at
+    # It is ended, not forgotten: do not allocate the same id immediately.
+    allocated = cp.on_start_transaction(1, "tag", 1000).transaction_id
+    await hass.async_block_till_done()
+    assert allocated == closing_tx + 1
+
+
+async def test_old_ended_id_does_not_settle_a_new_adopted_held_session(
+    hass, frozen_time
+):
+    """The post-stop fallback cannot speak for a newer restored transaction."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    old = cp.on_start_transaction(1, "tag-a", 1000).transaction_id
+    cp.on_stop_transaction(meter_stop=2000, timestamp=None, transaction_id=old)
+
+    adopted = old + 500
+    cp.on_meter_values(**_meter_values(adopted))
+    assert cp._active_tx[1] == adopted
+    cp.on_start_transaction(2, "tag-b", 1000)
+    cp.on_stop_transaction(
+        meter_stop=3000, timestamp=None, transaction_id=9999, reason="Remote"
+    )
+    assert cp._tx_indeterminate == {1, 2}
+    pending = list(cp._pending_stops)
+
+    cp.on_meter_values(**_meter_values(old, context="Transaction.End"))
+    await hass.async_block_till_done()
+
+    assert cp._active_tx[1] == adopted
+    assert cp._metrics[(1, csess.transaction_id)].value == adopted
+    assert cp._tx_indeterminate == {1, 2}
+    assert cp._pending_stops == pending
+
+
+async def test_switch_gating_uses_the_same_unsafe_id_rule_as_the_stop(hass):
+    """A connector sharing its id with a held one cannot be stopped.
+
+    Its Charge Control switch must be unavailable, not merely failing.
+    """
+    from .test_api_paths import _available_central_system
+
+    cs, _ = _available_central_system(hass)
+    cp = _mk_cp(hass)
+    cs.charge_points["CP_OK"] = cp
+    for c in (1, 2):
+        cp._active_tx[c] = 700
+        cp._metrics[(c, csess.transaction_id)].value = 700
+    cp._tx_indeterminate = {1}
+    charge_control = next(d for d in SWITCHES if d.key == "charge_control")
+
+    assert cs.is_transaction_indeterminate("ok", 1) is True
+    assert cs.is_transaction_indeterminate("ok", 2) is True
+    assert (
+        ChargePointSwitch(cs, "ok", charge_control, connector_id=2).available is False
+    )
+
+    cp._active_tx[2] = 701  # its own id: stoppable again
+    cp._metrics[(2, csess.transaction_id)].value = 701
+    assert cs.is_transaction_indeterminate("ok", 2) is False
+
+
+async def test_malformed_store_contents_are_ignored(hass, hass_storage, frozen_time):
+    """A store whose fields are the wrong shape leaves everything at defaults."""
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {"last_tx_id": "not-a-number", "connectors": ["not", "a", "dict"]},
+    }
+    cp = _mk_cp(hass, entry=entry)
+    await _settle(hass, cp)
+
+    assert cp._last_tx_id == 0
+    assert cp._persisted_tx == {}
+    assert cp.on_start_transaction(1, "tag", 0).transaction_id == int(NOW)
+
+
+async def test_malformed_connector_records_are_skipped(hass, hass_storage, frozen_time):
+    """One bad connector record does not cost the good ones."""
+    entry = _mk_entry(hass)
+    key = _store_key(entry)
+    hass_storage[key] = {
+        "version": 1,
+        "key": key,
+        "data": {
+            "last_tx_id": 5,
+            "connectors": {
+                "x": {"tx_id": 1, "started_at": 1.0},
+                "2": {"tx_id": "abc", "started_at": 1.0},
+                "3": {"tx_id": 9},
+                "1": {"tx_id": 700, "started_at": NOW - 60},
+            },
+        },
+    }
+    cp = _mk_cp(hass, entry=entry)
+    await _settle(hass, cp)
+
+    assert cp._persisted_tx == {1: (700, NOW - 60)}
+    assert cp._last_tx_id == 700
+
+
+async def test_a_failing_store_write_does_not_stop_a_start(
+    hass, frozen_time, caplog, monkeypatch
+):
+    """Persistence is best-effort: a broken store never blocks charging."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+
+    def broken(*args, **kwargs):
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(cp._tx_store, "async_delay_save", broken)
+    caplog.set_level(logging.DEBUG, logger="custom_components.ocpp")
+    tx = cp.on_start_transaction(1, "tag", 0).transaction_id
+
+    assert cp._active_tx[1] == tx
+    assert "transaction state not persisted" in caplog.text
+
+
+async def test_non_numeric_ids_are_inert(hass, frozen_time):
+    """A non-numeric id is neither a live transaction nor a floor."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag", 0).transaction_id
+    cp._metrics[(2, csess.transaction_id)].value = "garbage"
+
+    assert cp._live_connectors() == [1]
+    cp._note_transaction_id("garbage")
+    assert cp._last_tx_id == tx
+
+
+async def test_a_stop_is_resolved_by_the_recorded_metric_alone(hass, frozen_time):
+    """After a restart the metric may be all that names the transaction."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp._active_tx.clear()
+    cp._metrics[(2, csess.transaction_id)].value = 555
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=555)
+    await hass.async_block_till_done()
+
+    assert cp._metrics[(2, csess.transaction_id)].value == 0
+    assert cp._tx_indeterminate == set()
+    assert cp._pending_stops == []
+
+
+async def test_an_id_recorded_on_two_connectors_holds_both(hass, frozen_time):
+    """Duplicate ids left behind by an older release cannot be told apart."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    cp._active_tx.clear()
+    for c in (1, 2):
+        cp._metrics[(c, csess.transaction_id)].value = 555
+
+    cp.on_stop_transaction(meter_stop=5000, timestamp=None, transaction_id=555)
+    await hass.async_block_till_done()
+
+    assert cp._tx_indeterminate == {1, 2}
+    assert [p["candidates"] for p in cp._pending_stops] == [{1, 2}]
+
+
+async def test_an_unreadable_meter_stop_records_no_session_energy(hass, frozen_time):
+    """A stop whose reading cannot be parsed still ends the session."""
+    cp = _mk_cp(hass)
+    await _settle(hass, cp)
+    tx = cp.on_start_transaction(1, "tag", 1000).transaction_id
+
+    cp.on_stop_transaction(meter_stop="broken", timestamp=None, transaction_id=tx)
+    await hass.async_block_till_done()
+
+    assert cp._active_tx[1] == 0
+    assert cp._metrics[(1, csess.session_energy)].value == 0.0
+
+
+async def test_a_station_level_control_is_never_gated_by_a_hold(hass):
+    """Only a connector's own switch answers to its hold."""
+    cp = _mk_cp(hass)
+    cp._active_tx[1] = 700
+    cp._tx_indeterminate = {1}
+
+    assert cp.transaction_is_unsafe(1) is True
+    assert cp.transaction_is_unsafe(None) is False


### PR DESCRIPTION
Closes #2123

### Problem

The integration allocates OCPP 1.6 transaction ids itself, as `int(time.time())`, and three things leaned on that:

- Two connectors starting in the same second got the same id, so the StopTransaction for one was applied to whichever connector came first in the active map.
- A StopTransaction whose id matched nothing was applied to connector 1, ending a session that may still have been running there.
- The id doubled as the session's start epoch. An id adopted from a charger's MeterValues after a restart is not an epoch, so the session timer counted from an arbitrary reference (the second symptom in #1938).

### Change

- **Ids are unique per charge point**: `max(int(time.time()), last_id + 1)`. The floor is also raised by any id seen from the charger, restored from HA state or persisted, so a restart cannot hand out an id the charger already knows.
- **The session start is kept separately from the id** and persisted per connector, with the last allocated id, in a small HA `Store` (`ocpp.v16_transactions.<entry>.<charge point>`) that is loaded before the message loop starts. A session whose start had to be estimated after a restart carries `start_time_estimated: true` on the session time sensor.
- **An unknown StopTransaction is never guessed onto a connector.** Resolution goes active map, then recorded metric, then the only connector with a transaction. If that fails, the live connectors are held: their timers stand still, their state is left alone, and the stop is kept pending. A connector settles when the charger says something about it. A Charging/Suspended status or a sample for its transaction settles it as running; Available, Finishing, Unavailable or Reserved settle it as ended, and a plain idle status may then claim the pending stop's meter reading and reason for it. Evidence that its transaction ended by another route (its own StopTransaction, its closing values, a new StartTransaction) discards any stop it could have owned rather than attributing that stop to another connector. Faulted and Preparing leave a connector held.
- **Remote stops stay away from held connectors.** A per-connector stop of a held connector, or of one sharing its id with a held connector, is refused with a notification, and the global stop skips them. The Charge Control switch is unavailable under exactly that rule.
- **Closing values speak only for their own transaction.** A Transaction.End sample ends the connector's transaction only when it carries that transaction's id, or when none is known there; a first sighting marked Transaction.End after a restart is not adopted as a live session; the post-stop id fallback cannot speak for a newer restored transaction. Closing values no longer reset the session timer, and the timer cannot go negative.

### Deliberately not done

- The store is not written atomically, so no fsync on every start and stop. The data is best-effort by design: the loader tolerates a torn or missing file, and a StartTransaction never waits on disk.
- With one pending stop and two held connectors, the stop goes to whichever reports idle first unless something else is learned in between. Two sessions ending inside one status-report window could still be cross-applied. Before this change every such stop went to connector 1.

### Tests

`tests/test_v16_transaction_identity.py` (59 tests) drives the handlers directly with a frozen clock and the `hass_storage` fixture: id allocation and floors, persistence and reconciliation, stop resolution, holds and how each kind of evidence settles them, pending-stop attribution and invalidation, remote-stop refusal, switch availability, and closing-value handling. Existing tests are unchanged apart from one fixture attribute in `test_set_charge_rate_v16.py`. Full suite: 418 tests, all passing in CI.
