### PR TITLE
Keep the session time sensor in minutes through startup, disconnection and reload

### DIFF
--- a/custom_components/ocpp/sensor.py
+++ b/custom_components/ocpp/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import CONF_MONITORED_VARIABLES
+from homeassistant.const import CONF_MONITORED_VARIABLES, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -347,6 +347,11 @@ class ChargePointMetric(RestoreSensor, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the native unit of measurement."""
+        # Session duration is calculated in minutes by both protocol handlers.
+        # Keep its unit even before connection or when restoring offline state.
+        if self.metric == HAChargerSession.session_time:
+            return UnitOfTime.MINUTES
+
         value = self.central_system.get_ha_unit(
             self.cpid, self.metric, self.connector_id
         )

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -126,9 +126,23 @@ charger connects and completes its setup, so reconnecting the charger is
 usually enough. If the charger cannot complete setup, removing the
 integration and adding it back also clears it.
 
-Once the connector entities are recreated, the session sensors regain their
-units and Home Assistant may raise a one-time `units_changed` repair for
-`sensor.<cpid>_time_session`. Choose **"Update the unit of the historic
-statistic values, without converting"** to keep the existing history: the values
-were always minutes, only the unit label was missing while the connector slots
-were uninitialised.
+Session time unit repair
+------------------------
+
+`Time Session` is measured in minutes (`min`). Its unit stays the same during
+startup, disconnection and integration reloads. When the charger is offline,
+the sensor is `unavailable` and retains its unit.
+
+Older versions could lose the unit while live charger metrics were missing,
+including before connector slots were initialised. If the stored statistics
+have a blank unit, Home Assistant raises a `units_changed` warning for
+`sensor.<cpid>_time_session` (or its per-connector equivalent) once the sensor
+has a numeric value, possibly only after the next charging session.
+
+The Repairs entry has no fix button; open **Developer tools → Statistics** to
+apply the repair. Until the historical unit is corrected, Home Assistant does
+not compile new long-term statistics for this sensor. When it proposes changing
+the historical unit **from blank to `min`**, choose **"Update the unit of the
+historic statistic values, without converting"** to retain the history: the
+values were already minutes. Do not change `min` to a blank unit or delete the
+history to work around this issue.

--- a/tests/test_charge_point_v16.py
+++ b/tests/test_charge_point_v16.py
@@ -10,7 +10,7 @@ import time
 from types import SimpleNamespace
 
 import pytest
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_ON, UnitOfTime
 from homeassistant.exceptions import HomeAssistantError
 import websockets
 
@@ -415,9 +415,17 @@ async def test_cms_responses_normal_v16(
         await cp.send_firmware_status()
         await cp.send_data_transfer()
         await cp.send_start_transaction(12345)
+        assert (
+            cs.charge_points[cp_id]._metrics[(1, csess.session_time)].unit
+            == UnitOfTime.MINUTES
+        )
         await cp.send_meter_err_phases()
         await cp.send_meter_line_voltage()
         await cp.send_meter_periodic_data()
+        assert (
+            cs.charge_points[cp_id]._metrics[(1, csess.session_time)].unit
+            == UnitOfTime.MINUTES
+        )
         # add delay to allow meter data to be processed
         await cp.send_stop_transaction(1)
 

--- a/tests/test_session_time_unit.py
+++ b/tests/test_session_time_unit.py
@@ -1,0 +1,155 @@
+"""Session duration must keep its minutes unit without live charger metrics."""
+
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.components.sensor import SensorExtraStoredData, SensorStateClass
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_OK,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfTime,
+)
+from homeassistant.core import State
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache_with_extra_data,
+)
+
+from custom_components.ocpp.chargepoint import _ConnectorAwareMetrics
+from custom_components.ocpp.const import (
+    CONF_CPIDS,
+    CONF_NUM_CONNECTORS,
+    CONF_PORT,
+    DOMAIN,
+)
+from custom_components.ocpp.enums import HAChargerSession
+
+from .const import MOCK_CONFIG_CP_APPEND, MOCK_CONFIG_DATA
+from .lifecycle_asserts import live_entity
+
+
+@pytest.mark.parametrize("num_connectors", [1, 2])
+@pytest.mark.parametrize(
+    ("restored_value", "restored_unit"),
+    [(None, None), (12, UnitOfTime.MINUTES), (12, None), (0, "")],
+    ids=["fresh", "restored-minutes", "restored-no-unit", "restored-zero-empty-unit"],
+)
+async def test_session_time_unit_without_live_metrics(
+    hass, socket_enabled, num_connectors, restored_value, restored_unit
+):
+    """Keep minutes through startup, missing units, disconnection and reload."""
+    cpid = "test_cpid"
+    connector_id = num_connectors if num_connectors > 1 else None
+    suffix = f"_connector_{connector_id}" if connector_id is not None else ""
+    entity_id = f"sensor.{cpid}{suffix}_time_session"
+    if restored_value is not None:
+        mock_restore_cache_with_extra_data(
+            hass,
+            [
+                (
+                    State(
+                        entity_id,
+                        str(restored_value),
+                        {ATTR_UNIT_OF_MEASUREMENT: restored_unit},
+                    ),
+                    SensorExtraStoredData(restored_value, restored_unit).as_dict(),
+                )
+            ],
+        )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG_DATA,
+            CONF_PORT: 0,
+            CONF_CPIDS: [
+                {
+                    "CP_session": {
+                        **MOCK_CONFIG_CP_APPEND,
+                        CONF_NUM_CONNECTORS: num_connectors,
+                    }
+                }
+            ],
+        },
+        version=2,
+        minor_version=2,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    def assert_state(expected=None):
+        """Assert statistics metadata and, when specified, the published value."""
+        state = hass.states.get(entity_id)
+        assert state is not None
+        if expected is not None:
+            assert state.state == expected
+        assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTime.MINUTES
+        assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+    # Before any connection, the entity has no runtime metrics or units.
+    assert_state(STATE_UNAVAILABLE)
+    sensor = live_entity(hass, entity_id, "sensor")
+
+    central = hass.data[DOMAIN][entry.entry_id]
+    charge_point = SimpleNamespace(
+        _metrics=_ConnectorAwareMetrics(),
+        num_connectors=num_connectors,
+        status=STATE_OK,
+    )
+    central.cpids[cpid] = "CP_session"
+    central.charge_points["CP_session"] = charge_point
+
+    # A connection can become available before session metrics are populated.
+    sensor.async_write_ha_state()
+    assert sensor.available
+    assert_state(STATE_UNKNOWN if restored_value is None else None)
+
+    metric = charge_point._metrics[(connector_id or 1, HAChargerSession.session_time)]
+    metric.unit = UnitOfTime.MINUTES
+    for value in (0, 12):
+        metric.value = value
+        sensor.async_write_ha_state()
+        assert_state(str(value))
+
+    # Empty units are normalised to None by the central system. Neither form
+    # may strip the unit from a still-valid session value.
+    for missing_unit in (None, ""):
+        metric.unit = missing_unit
+        sensor.async_write_ha_state()
+        assert_state("12")
+
+    # Losing the backend must publish unavailable, retaining the minutes unit.
+    central.charge_points.clear()
+    sensor.async_write_ha_state()
+    assert_state(STATE_UNAVAILABLE)
+
+    # Reload uses a fresh entity while the charger is offline. Restoring sensor
+    # data must not restore the old unit-loss bug with it.
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+    reloaded = live_entity(hass, entity_id, "sensor")
+    assert reloaded is not sensor
+    assert_state(STATE_UNAVAILABLE)
+
+    # A reconnect gets fresh, uninitialised metrics. Assert unit and availability
+    # without requiring a cached value to be republished before live data arrives.
+    central = hass.data[DOMAIN][entry.entry_id]
+    charge_point._metrics = _ConnectorAwareMetrics()
+    charge_point.status = "init"
+    central.cpids[cpid] = "CP_session"
+    central.charge_points["CP_session"] = charge_point
+    reloaded.async_write_ha_state()
+    assert_state(STATE_UNAVAILABLE)
+    charge_point.status = STATE_OK
+    reloaded.async_write_ha_state()
+    assert reloaded.available
+    assert_state()
+    charge_point._metrics[(connector_id or 1, HAChargerSession.session_time)].value = 0
+    reloaded.async_write_ha_state()
+    assert_state("0")
+
+    central.charge_points.clear()
+    assert await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
Closes #1938

### Problem

`sensor.<cpid>_time_session` is a `measurement` sensor with no device class, so its fallback unit is `None`. `native_unit_of_measurement` returned that fallback whenever the live metric had no unit yet: before the charger connected, while it was offline, and on every restart or reload before a transaction ran. The unit flipped between `min` and blank, and Home Assistant raised a `units_changed` repair each time, as reported in #1938.

### Change

- Both protocol handlers compute `Time.Session` in minutes, so the sensor now reports `min` unconditionally instead of asking the live metric for a unit it may not have yet.
- `docs/debugging.md` explains the one-time statistics repair for history already recorded with a blank unit: apply it from Developer tools → Statistics and keep the values, since they were always minutes.

### Tests

`tests/test_session_time_unit.py` walks a single-connector and a two-connector entry through startup with no metrics, a restored value with and without a unit, a session in progress, a metric that loses its unit, a lost connection, a reload while offline, and a reconnect with fresh metrics, asserting `min` and the measurement state class at every step. `test_cms_responses_normal_v16` also asserts the metric's unit around a transaction.

The second problem discussed in #1938, the session timer counting from a charger-supplied id, is fixed separately in #2128.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session time now consistently displays in minutes, including during startup, offline states, disconnections, and restored sessions.
  - Prevents missing or incorrect units when live charger metrics are unavailable.

- **Documentation**
  - Added instructions for repairing historical session-time statistics without converting or deleting existing history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->