### PR TITLE
One station-wide Maximum Current per charger; remove the per-connector sliders

### DIFF
--- a/custom_components/ocpp/api.py
+++ b/custom_components/ocpp/api.py
@@ -736,13 +736,13 @@ class CentralSystem:
     async def set_max_charge_rate_amps(
         self, id: str, value: float, connector_id: int = 0
     ):
-        """Set the maximum charge rate in amps."""
+        """Set the station maximum in amps; connector_id is retained but unused."""
         # allow id to be either cpid or cp_id
         cp_id = self.cpids.get(id, id)
 
         if cp_id in self.charge_points:
-            return await self.charge_points[cp_id].set_charge_rate(
-                limit_amps=value, conn_id=connector_id
+            return await self.charge_points[cp_id].set_station_charge_rate(
+                limit_amps=value
             )
         return False
 

--- a/custom_components/ocpp/chargepoint.py
+++ b/custom_components/ocpp/chargepoint.py
@@ -422,6 +422,10 @@ class ChargePoint(cp):
         """Clear all charging profiles."""
         pass
 
+    async def set_station_charge_rate(self, limit_amps: int | float) -> bool:
+        """Set the station-wide maximum current without transaction fallbacks."""
+        raise NotImplementedError
+
     async def set_charge_rate(
         self,
         limit_amps: int | float | None = None,

--- a/custom_components/ocpp/number.py
+++ b/custom_components/ocpp/number.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import re
 from typing import Final
 
 from homeassistant.components.number import (
@@ -25,10 +26,8 @@ from .const import (
     CONF_CPID,
     CONF_CPIDS,
     CONF_MAX_CURRENT,
-    CONF_NUM_CONNECTORS,
     DATA_UPDATED,
     DEFAULT_MAX_CURRENT,
-    DEFAULT_NUM_CONNECTORS,
     DOMAIN,
     ICON,
 )
@@ -70,24 +69,23 @@ async def async_setup_entry(hass, entry, async_add_devices):
         cp_id_settings = list(charger.values())[0]
         cpid = cp_id_settings[CONF_CPID]
 
-        num_connectors = 1
-        for item in entry.data.get(CONF_CPIDS, []):
-            for _, cfg in item.items():
-                if cfg.get(CONF_CPID) == cpid:
-                    num_connectors = int(
-                        cfg.get(CONF_NUM_CONNECTORS, DEFAULT_NUM_CONNECTORS)
-                    )
-                    break
-            else:
-                continue
-            break
-
-        if num_connectors > 1:
-            for desc in NUMBERS:
-                uid_flat = ".".join([NUMBER_DOMAIN, DOMAIN, cpid, desc.key])
-                stale_eid = ent_reg.async_get_entity_id(NUMBER_DOMAIN, DOMAIN, uid_flat)
-                if stale_eid:
-                    ent_reg.async_remove(stale_eid)
+        legacy_uid = re.compile(
+            rf"{NUMBER_DOMAIN}\.{DOMAIN}\.{re.escape(cpid)}\.conn\d+\.maximum_current"
+        )
+        for registry_entry in er.async_entries_for_config_entry(
+            ent_reg, entry.entry_id
+        ):
+            if (
+                registry_entry.platform == DOMAIN
+                and registry_entry.domain == NUMBER_DOMAIN
+                and legacy_uid.fullmatch(registry_entry.unique_id)
+            ):
+                _LOGGER.info(
+                    "Removing stale connector-level entity %s; "
+                    "Maximum Current is station-wide on this charger",
+                    registry_entry.entity_id,
+                )
+                ent_reg.async_remove(registry_entry.entity_id)
 
         for desc in NUMBERS:
             if desc.key == "maximum_current":
@@ -100,47 +98,28 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 ent_initial = desc.initial_value
                 ent_max = desc.native_max_value
 
-            if num_connectors > 1:
-                for conn_id in range(1, num_connectors + 1):
-                    entities.append(
-                        ChargePointNumber(
-                            hass=hass,
-                            central_system=central_system,
-                            cpid=cpid,
-                            description=OcppNumberDescription(
-                                key=desc.key,
-                                name=desc.name,
-                                icon=desc.icon,
-                                initial_value=ent_initial,
-                                native_min_value=desc.native_min_value,
-                                native_max_value=ent_max,
-                                native_step=desc.native_step,
-                                native_unit_of_measurement=desc.native_unit_of_measurement,
-                            ),
-                            connector_id=conn_id,
-                            op_connector_id=conn_id,
-                        )
-                    )
-            else:
-                entities.append(
-                    ChargePointNumber(
-                        hass=hass,
-                        central_system=central_system,
-                        cpid=cpid,
-                        description=OcppNumberDescription(
-                            key=desc.key,
-                            name=desc.name,
-                            icon=desc.icon,
-                            initial_value=ent_initial,
-                            native_min_value=desc.native_min_value,
-                            native_max_value=ent_max,
-                            native_step=desc.native_step,
-                            native_unit_of_measurement=desc.native_unit_of_measurement,
-                        ),
-                        connector_id=None,
-                        op_connector_id=0,
-                    )
+            uid_flat = ".".join([NUMBER_DOMAIN, DOMAIN, cpid, desc.key])
+            fresh = ent_reg.async_get_entity_id(NUMBER_DOMAIN, DOMAIN, uid_flat) is None
+            entities.append(
+                ChargePointNumber(
+                    hass=hass,
+                    central_system=central_system,
+                    cpid=cpid,
+                    description=OcppNumberDescription(
+                        key=desc.key,
+                        name=desc.name,
+                        icon=desc.icon,
+                        initial_value=ent_initial,
+                        native_min_value=desc.native_min_value,
+                        native_max_value=ent_max,
+                        native_step=desc.native_step,
+                        native_unit_of_measurement=desc.native_unit_of_measurement,
+                    ),
+                    connector_id=None,
+                    op_connector_id=0,
+                    fresh=fresh,
                 )
+            )
 
     async_add_devices(entities, False)
 
@@ -159,12 +138,14 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
         description: OcppNumberDescription,
         connector_id: int | None = None,
         op_connector_id: int | None = None,
+        fresh: bool = False,
     ):
         """Initialize a Number instance."""
         self.cpid = cpid
         self._hass = hass
         self.central_system = central_system
         self.entity_description = description
+        self._fresh = fresh
         self.connector_id = connector_id
         self._op_connector_id = (
             op_connector_id if op_connector_id is not None else (connector_id or 1)
@@ -213,7 +194,9 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
-        if restored := await self.async_get_last_number_data():
+        # Restore data is keyed by entity id, not unique id. A new station
+        # entity must not inherit an old connector slider's renamed state.
+        if not self._fresh and (restored := await self.async_get_last_number_data()):
             self._attr_native_value = restored.native_value
             # What the previous session last settled on. The charger keeps
             # its charging profile across our restarts, so this is the best
@@ -249,7 +232,7 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
         )
 
     async def async_set_native_value(self, value):
-        """Set new value for max current (station-wide when _op_connector_id==0, otherwise per-connector).
+        """Set the station-wide maximum current.
 
         - Optimistic UI: move the slider immediately so it tracks the drag.
         - On refusal, put it back and raise: a current limit that reads as
@@ -264,9 +247,7 @@ class ChargePointNumber(RestoreNumber, NumberEntity):
         self.async_write_ha_state()
 
         try:
-            ok = await self.central_system.set_max_charge_rate_amps(
-                self.cpid, target, connector_id=self._op_connector_id
-            )
+            ok = await self.central_system.set_max_charge_rate_amps(self.cpid, target)
         except HomeAssistantError:
             # set_charge_rate raises this for a rejected profile, and its
             # message carries the charger's own status_info - the only

--- a/custom_components/ocpp/ocppv16.py
+++ b/custom_components/ocpp/ocppv16.py
@@ -9,6 +9,7 @@ import time
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import UnitOfTime
 from homeassistant.helpers.storage import Store
 from homeassistant.util import slugify
@@ -935,34 +936,13 @@ class ChargePoint(cp):
             return float(_DEFAULT_LIMIT_AMPS)
         return round(watts / denom, 1)
 
-    async def set_charge_rate(
+    async def _resolve_charge_rate(
         self,
-        limit_amps: int | float | None = None,
-        limit_watts: int | float | None = None,
-        conn_id: int = 0,
-        profile: dict | None = None,
-    ) -> bool:
-        """Set charge rate."""
-        if profile is not None:
-            try:
-                req = call.SetChargingProfile(
-                    connector_id=int(conn_id), cs_charging_profiles=profile
-                )
-                resp = await self.call(req)
-                if resp.status == ChargingProfileStatus.accepted:
-                    return True
-                _LOGGER.warning("Custom SetChargingProfile rejected: %s", resp.status)
-            except Exception as ex:
-                _LOGGER.warning("Custom SetChargingProfile failed: %s", ex)
-                await self.notify_ha(
-                    "Warning: Set charging profile failed with response Exception"
-                )
-            return False
-
-        if not (int(self.supported_features or 0) & prof.SMART):
-            _LOGGER.info("Smart charging is not supported by this charger")
-            return False
-
+        limit_amps: int | float | None,
+        limit_watts: int | float | None,
+        conn_id: int,
+    ) -> tuple[str, float, int]:
+        """Resolve units, electrical conversion and stack level for managed limits."""
         # Determine allowed unit (default to Amps if not reported)
         units_resp = await self.get_configuration(
             ckey.charging_schedule_allowed_charging_rate_unit
@@ -1014,6 +994,92 @@ class ChargePoint(cp):
         except Exception:
             stack_level = 1
 
+        return units_value, limit_value, stack_level
+
+    @staticmethod
+    def _station_charge_rate_request(
+        units_value: str, limit_value: float, stack_level: int
+    ) -> call.SetChargingProfile:
+        """Build the shared station ceiling used by the slider and action."""
+        return call.SetChargingProfile(
+            connector_id=0,
+            cs_charging_profiles={
+                om.charging_profile_id: 1000,
+                om.stack_level: stack_level,
+                om.charging_profile_kind: ChargingProfileKindType.relative.value,
+                om.charging_profile_purpose: ChargingProfilePurposeType.charge_point_max_profile.value,
+                om.charging_schedule: {
+                    om.charging_rate_unit: units_value,
+                    om.charging_schedule_period: [
+                        {om.start_period: 0, om.limit: limit_value}
+                    ],
+                },
+            },
+        )
+
+    async def set_station_charge_rate(self, limit_amps: int | float) -> bool:
+        """Set only a station ceiling; transaction defaults cannot replace one."""
+        try:
+            if not (int(self.supported_features or 0) & prof.SMART):
+                raise HomeAssistantError(
+                    "Smart charging is not supported by this charger"
+                )
+            units, limit, stack_level = await self._resolve_charge_rate(
+                limit_amps, None, 0
+            )
+            req = self._station_charge_rate_request(units, limit, stack_level)
+            # _get_specific_response already raises CALLERRORs. Be explicit
+            # here so preserving the charger's reason does not rely on it.
+            resp = await self.call(req, suppress=False)
+            status = resp.status
+        except Exception as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_variables_error",
+                translation_placeholders={"message": str(ex)},
+            ) from ex
+        if status != ChargingProfileStatus.accepted:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_variables_error",
+                translation_placeholders={
+                    "message": f"ChargePointMaxProfile: {status}"
+                },
+            )
+        return True
+
+    async def set_charge_rate(
+        self,
+        limit_amps: int | float | None = None,
+        limit_watts: int | float | None = None,
+        conn_id: int = 0,
+        profile: dict | None = None,
+    ) -> bool:
+        """Set charge rate."""
+        if profile is not None:
+            try:
+                req = call.SetChargingProfile(
+                    connector_id=int(conn_id), cs_charging_profiles=profile
+                )
+                resp = await self.call(req)
+                if resp.status == ChargingProfileStatus.accepted:
+                    return True
+                _LOGGER.warning("Custom SetChargingProfile rejected: %s", resp.status)
+            except Exception as ex:
+                _LOGGER.warning("Custom SetChargingProfile failed: %s", ex)
+                await self.notify_ha(
+                    "Warning: Set charging profile failed with response Exception"
+                )
+            return False
+
+        if not (int(self.supported_features or 0) & prof.SMART):
+            _LOGGER.info("Smart charging is not supported by this charger")
+            return False
+
+        units_value, limit_value, stack_level = await self._resolve_charge_rate(
+            limit_amps, limit_watts, conn_id
+        )
+
         # Helper to build a simple relative schedule with one period
         def _mk_schedule(_units: str, _limit: float) -> dict:
             return {
@@ -1036,17 +1102,8 @@ class ChargePoint(cp):
 
         # Try ChargePointMaxProfile (connectorId = 0)
         try:
-            req = call.SetChargingProfile(
-                connector_id=0,
-                cs_charging_profiles={
-                    om.charging_profile_id: _profile_id(
-                        ChargingProfilePurposeType.charge_point_max_profile.value, 0
-                    ),
-                    om.stack_level: stack_level,
-                    om.charging_profile_kind: ChargingProfileKindType.relative.value,
-                    om.charging_profile_purpose: ChargingProfilePurposeType.charge_point_max_profile.value,
-                    om.charging_schedule: _mk_schedule(units_value, limit_value),
-                },
+            req = self._station_charge_rate_request(
+                units_value, limit_value, stack_level
             )
             resp = await self.call(req)
             if resp.status == ChargingProfileStatus.accepted:

--- a/custom_components/ocpp/ocppv201.py
+++ b/custom_components/ocpp/ocppv201.py
@@ -690,6 +690,10 @@ class ChargePoint(cp):
             ClearChargingProfileStatusEnumType.unknown,
         )
 
+    async def set_station_charge_rate(self, limit_amps: int | float) -> bool:
+        """Use the managed station limit for the Maximum Current entity."""
+        return await self.set_charge_rate(limit_amps=limit_amps, conn_id=0)
+
     async def set_charge_rate(
         self,
         limit_amps: int | None = None,

--- a/docs/Charge_automation.md
+++ b/docs/Charge_automation.md
@@ -17,24 +17,33 @@ This page provides several examples and hints to illustrate some of the many pot
 
 `<cpid>` is the charge point id you configured for your charger. The examples use the entity names of a **single-connector** charger.
 
-If your charger reports more than one connector, those charger-level entities do not exist — the integration creates per-connector entities instead and removes the flat ones. Use the connector that matches the `conn_id` you pass to the action:
+If your charger reports more than one connector, the sensors below are created per connector and their old flat entries are removed. Use the sensor for the connector that matches the `conn_id` you pass to the action. Maximum Current stays on the charger device, with one station-wide slider for every charger. These are default entity ids; any existing user rename of the flat Maximum Current entity is preserved:
 
 | Single connector | Two or more connectors |
 | --- | --- |
 | `sensor.<cpid>_transaction_id` | `sensor.<cpid>_connector_1_transaction_id` |
 | `sensor.<cpid>_current_import` | `sensor.<cpid>_connector_1_current_import` |
-| `number.<cpid>_maximum_current` | `number.<cpid>_connector_1_maximum_current` |
+| `number.<cpid>_maximum_current` | `number.<cpid>_maximum_current` |
 
 ## Adjusting the charge current
 
 When the OCPP integration is added to your Home Assistant, you get a slider to control the maximum charge current named:
 `number.<cpid>_maximum_current`
 
+The slider sets a ceiling for the entire charging station. On **OCPP 1.6** it sends only a `ChargePointMaxProfile` on connector 0. On **OCPP 2.0.1** it sends a `ChargingStationMaxProfile` on EVSE 0; at or above the configured maximum it clears profiles of that purpose instead. On 1.6, setting the slider to its maximum still sends a profile. A refused request is shown as an error and the slider returns to its last confirmed value, or unknown if there is none. There is no transaction-profile fallback in the slider. Chargers that reject the station profile can still use the `ocpp.set_charge_rate` action and its fallback chain, described below. For per-connector session control, use the action's `custom_profile` option as described below.
+
 While using this entity in an automation might seem logical, do not assume it is safe to update at control-loop frequency.
-This entity controls the OCPP ChargePointMaxProfile, which configures the maximum power or current available for the entire charging station.
 OCPP defines the profile's behaviour, but not where a charger stores it. Some charger firmware persists station-wide profiles in non-volatile memory; other firmware does not. If a charger writes every update to EEPROM or flash, a fast control loop can wear that storage. There is no universal safe update rate or lifetime estimate: confirm the implementation and supported update frequency with the charger manufacturer.
 
 ⚠️ **Warning**: Do not use the maximum-current slider as a high-frequency control loop unless the charger manufacturer confirms that repeated profile updates are safe. Debounce ordinary changes, require a meaningful change before sending another profile, and retain the ability to send an immediate safety reduction.
+
+### Maximum Current upgrade notes
+
+This is a breaking change for multi-connector chargers: the old `number.<cpid>_connector_N_maximum_current` entities are removed, including renamed or disabled entries, and replaced by one station-wide master. Update dashboards, scripts and automations that reference the old entities. Existing flat Maximum Current entities keep their registry identity, customisations and restored values. A newly created master starts at the configured maximum without treating a removed entity's value as confirmed; that initial display is not evidence of the charger's current limit.
+
+The slider-side fallback is also removed on **single-connector OCPP 1.6 chargers**. A charger that rejects `ChargePointMaxProfile` now reports an error on slider changes, even if a transaction profile previously worked. The `ocpp.set_charge_rate` action retains its existing behaviour.
+
+The upgrade does not clear stored charging profiles. Moving the master updates only the station maximum; existing transaction or default profiles may continue imposing lower limits. On 1.6, `ocpp.clear_profile` clears **all charging profiles, including custom profiles**. On 2.0.1 it clears **all profiles with purpose `ChargingStationMaxProfile`**, including any custom profiles of that purpose, and leaves transaction/default profiles in place.
 
 ### TxProfile
 
@@ -46,7 +55,7 @@ Essentially, the slider in your GUI maintains control over the absolute maximum 
 
 Before writing a profile by hand it is worth knowing what the built-in action does, because it is not simply a session-scoped limit.
 
-On **OCPP 1.6** it first tries a station-wide `ChargePointMaxProfile` on connector 0, the same profile purpose the slider writes. **If the charger accepts it, that is the end of the call.** Only if the charger *rejects* it does the action fall back to a `TxProfile` bound to the running transaction, plus a `TxDefaultProfile` for later sessions. Which of those happened depends on your charger, and the action reports success either way.
+On **OCPP 1.6** it first tries a station-wide `ChargePointMaxProfile` on connector 0, the same profile purpose the slider writes. **If the charger accepts it, that is the end of the call.** Only if the charger *rejects* it does the action fall back to a `TxProfile` bound to the running transaction, plus a `TxDefaultProfile` on that connector. Which of those happened depends on your charger, and the action reports success either way.
 
 So on a charger that accepts the station-wide profile, calling this on a short interval repeatedly exercises whatever storage path that firmware uses, and the limit can outlive the transaction rather than being session-scoped.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -25,7 +25,7 @@ Measurands (according to OCPP terminology) are actually metrics provided by the 
 
 OCPP integration can automatically detect supported measurands. However, some chargers have faulty firmware that causes the detection mechanism to fail. For such chargers, it is possible to disable automatic measurand detection and manually set the measurands to those supported by the charger. When set manually, selected measurands are not checked for compatibility with the charger and are requested from it. See below for OCPP compliance notes and charger-specific instructions in [supported devices](supported-devices).
 
-For chargers with multiple connectors (outlets), the OCPP integration will create one device per connector, named `charger Connector 1`, `charger Connector 2` etc. All measurands and other entities (buttons, numbers, switches, diagnostics sensors) that are connector-specific per the OCPP standard will be found on these devices.
+For chargers with multiple connectors (outlets), the OCPP integration will create one device per connector, named `charger Connector 1`, `charger Connector 2` etc. All measurands and other entities (buttons, numbers, switches, diagnostics sensors) that are connector-specific per the OCPP standard will be found on these devices. Maximum Current is station-wide: every charger has one slider on the charger device, with default entity id `number.<cpid>_maximum_current`, regardless of its connector count. See the Maximum Current upgrade notes in the [charge automation guide](Charge_automation) for changes to existing entities and charger compatibility.
 
 ## Removing a charge point
 
@@ -92,7 +92,7 @@ If your integration shows extra attributes on the connector status sensor like a
 
 * `Charge Control`
 * `Availability` (must be set to ON before EV is plugged in)
-* `Maximum Current` (sets maximum charging current available)
+* `Maximum Current` (sets the station-wide maximum charging current available)
 * `Reset`
 
 ## Useful Entities for ABB Terra AC
@@ -122,7 +122,7 @@ If your integration shows extra attributes on the connector status sensor like a
 
 * `Charge Control`
 * `Availability` (OFF when something causes a problem or during a reboot etc)
-* `Maximum Current` (sets maximum charging current available)
+* `Maximum Current` (sets the station-wide maximum charging current available)
 * `Reset`
 
 ## Useful Entities and Workarounds for United Chargers Grizzl-E
@@ -147,7 +147,7 @@ The Grizzl-E updates these metrics every 30s during charging sessions:
 
 * `Charge Control` (User switches to ON to start charging session, once charger is in Preparing state. Can be automated in HA - see this [comment in Issue #442](https://github.com/lbbrhzn/ocpp/issues/442#issuecomment-1295865797) for details)
 * `Availability` (ON when charger is idle. OFF during active charging session, or when something causes a problem)
-* `Maximum Current` (sets maximum charging current available. Reverts to value set by charger's internal DIP switch following reboots; tweak slider to reload)
+* `Maximum Current` (sets the station-wide maximum charging current available. Reverts to value set by charger's internal DIP switch following reboots; tweak slider to reload)
 
 ## Useful Entities for Vestel EVC-04 Wallboxes
 
@@ -168,7 +168,7 @@ The Grizzl-E updates these metrics every 30s during charging sessions:
 
 * `Charge Control`
 * `Availability` (must be set to ON before EV is plugged in)
-* `Maximum Current` (sets maximum charging current available)
+* `Maximum Current` (sets the station-wide maximum charging current available)
 * `Reset`
 
 ## Useful Entities for Rolec EVO

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -40,6 +40,11 @@ class DummyCP:
         # service call sinks
         self.calls = []
 
+    async def set_station_charge_rate(self, **kw):
+        """Record the station-only number route."""
+        self.calls.append(("set_station_charge_rate", kw))
+        return True
+
     # ---- services the API calls into ----
     async def set_charge_rate(self, **kw):
         """Set charge rate."""
@@ -385,7 +390,7 @@ async def test_setters_when_missing_and_present(hass):
     # present -> routes and returns True
     cp = _install_dummy_cp(cs)
     assert await cs.set_max_charge_rate_amps("test_cpid", 16.0, connector_id=2) is True
-    assert ("set_charge_rate", {"limit_amps": 16.0, "conn_id": 2}) in cp.calls
+    assert cp.calls == [("set_station_charge_rate", {"limit_amps": 16.0})]
 
     # set_charger_state branches
     await cs.set_charger_state(

--- a/tests/test_flat_maximum_current.py
+++ b/tests/test_flat_maximum_current.py
@@ -1,0 +1,457 @@
+"""A Maximum Current entity controls one station ceiling, regardless of connectors."""
+
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.components.number import NumberExtraStoredData
+from homeassistant.const import STATE_OK, UnitOfElectricCurrent
+from homeassistant.core import State
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from ocpp.messages import CallError
+from ocpp.v16.enums import Measurand
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache_with_extra_data,
+)
+
+from custom_components.ocpp.const import (
+    CONF_CPIDS,
+    CONF_MAX_CURRENT,
+    CONF_NUM_CONNECTORS,
+    CONF_PORT,
+    DOMAIN,
+    ChargerSystemSettings,
+)
+from custom_components.ocpp.enums import ConfigurationKey, Profiles
+from custom_components.ocpp.ocppv16 import ChargePoint as ChargePoint16
+from custom_components.ocpp.ocppv201 import ChargePoint as ChargePoint201
+
+from .const import MOCK_CONFIG_CP_APPEND, MOCK_CONFIG_DATA
+from .lifecycle_asserts import live_entity
+
+
+@pytest.fixture
+def flat_entry(hass):
+    """Register a charger before platform setup so tests can seed its registry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG_DATA,
+            CONF_PORT: 0,
+            CONF_CPIDS: [
+                {
+                    "CP_flat": {
+                        **MOCK_CONFIG_CP_APPEND,
+                        CONF_MAX_CURRENT: 48,
+                        CONF_NUM_CONNECTORS: 2,
+                    }
+                }
+            ],
+        },
+        version=2,
+        minor_version=2,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+async def setup_flat(hass, bypass_get_data, flat_entry):
+    """Start the real integration and clean up any attached protocol object."""
+
+    async def setup():
+        assert await hass.config_entries.async_setup(flat_entry.entry_id)
+        await hass.async_block_till_done()
+        return hass.data[DOMAIN][flat_entry.entry_id]
+
+    yield setup
+    central = hass.data.get(DOMAIN, {}).get(flat_entry.entry_id)
+    if central is not None:
+        central.charge_points.clear()
+        assert await hass.config_entries.async_unload(flat_entry.entry_id)
+
+
+def _settings(entry):
+    return entry.data[CONF_CPIDS][0]["CP_flat"]
+
+
+def _configure(hass, entry, **changes):
+    data = {**entry.data, CONF_CPIDS: [{"CP_flat": {**_settings(entry), **changes}}]}
+    hass.config_entries.async_update_entry(entry, data=data)
+
+
+def _register(hass, entry, uid, **kwargs):
+    return er.async_get(hass).async_get_or_create(
+        "number", DOMAIN, uid, config_entry=entry, **kwargs
+    )
+
+
+def _restore(hass, entity_id, value):
+    data = NumberExtraStoredData(48, 0, 1, UnitOfElectricCurrent.AMPERE, value)
+    mock_restore_cache_with_extra_data(
+        hass, [(State(entity_id, str(value)), data.as_dict())]
+    )
+
+
+def _attach_protocol(hass, entry, central, protocol="1.6"):
+    connection = SimpleNamespace(subprotocol=f"ocpp{protocol}")
+    cls = ChargePoint16 if protocol == "1.6" else ChargePoint201
+    cp = cls(
+        "CP_flat",
+        connection,
+        hass,
+        entry,
+        central.settings,
+        ChargerSystemSettings(**_settings(entry)),
+    )
+    cp.status = STATE_OK
+    cp.num_connectors = 2
+    cp._attr_supported_features = Profiles.SMART
+    central.cpids["test_cpid"] = "CP_flat"
+    central.charge_points["CP_flat"] = cp
+    return cp
+
+
+def _number(hass):
+    return live_entity(hass, "number.test_cpid_maximum_current", "number")
+
+
+@pytest.mark.parametrize("connectors", [1, 2])
+async def test_one_master_on_station_device(hass, flat_entry, setup_flat, connectors):
+    """Single and multi-connector chargers expose the same configured master."""
+    _configure(hass, flat_entry, num_connectors=connectors)
+    central = await setup_flat()
+    registry = er.async_get(hass)
+    numbers = [
+        e
+        for e in er.async_entries_for_config_entry(registry, flat_entry.entry_id)
+        if e.domain == "number"
+    ]
+    assert len(numbers) == 1
+    assert numbers[0].unique_id == "number.ocpp.test_cpid.maximum_current"
+    entity = _number(hass)
+    device = dr.async_get(hass).async_get(numbers[0].device_id)
+    assert (DOMAIN, "test_cpid") in device.identifiers
+    assert entity.connector_id is None
+    assert entity._op_connector_id == 0
+    assert entity.native_value == entity.native_max_value == 48
+    assert entity.native_min_value == 0
+    assert entity.native_step == 1
+    assert entity._confirmed_value is None
+    assert not entity.available
+    cp = _attach_protocol(hass, flat_entry, central)
+    assert entity.available
+    cp._attr_supported_features = Profiles.NONE
+    assert not entity.available
+    cp._attr_supported_features = Profiles.SMART
+    cp.status = "init"
+    assert not entity.available
+
+
+@pytest.mark.parametrize("connectors", [1, 2])
+async def test_cleanup_only_legacy_numbers_for_this_charger(
+    hass, flat_entry, setup_flat, caplog, connectors
+):
+    """Clean all stale indices, names and disabled entries without overmatching."""
+    _configure(hass, flat_entry, cpid="test.cpid", num_connectors=connectors)
+    caplog.set_level(logging.INFO, logger="custom_components.ocpp")
+    registry = er.async_get(hass)
+    removed = [
+        _register(
+            hass,
+            flat_entry,
+            f"number.ocpp.test.cpid.conn{n}.maximum_current",
+            suggested_object_id=f"custom_slider_{n}",
+            disabled_by=er.RegistryEntryDisabler.USER if n == 2 else None,
+        )
+        for n in (1, 2, 3, 40)
+    ]
+    foreign_entry = MockConfigEntry(domain=DOMAIN)
+    foreign_entry.add_to_hass(hass)
+    kept = [
+        _register(hass, flat_entry, "number.ocpp.testXcpid.conn1.maximum_current"),
+        _register(
+            hass, flat_entry, "number.ocpp.test.cpid_other.conn1.maximum_current"
+        ),
+        _register(hass, flat_entry, "number.ocpp.test.cpid.conn1.another_number"),
+        _register(
+            hass, flat_entry, "number.ocpp.test.cpid.conn1.maximum_current.extra"
+        ),
+        _register(hass, foreign_entry, "number.ocpp.test.cpid.conn5.maximum_current"),
+        registry.async_get_or_create(
+            "number",
+            "other",
+            "number.ocpp.test.cpid.conn6.maximum_current",
+            config_entry=flat_entry,
+        ),
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "number.ocpp.test.cpid.conn7.maximum_current",
+            config_entry=flat_entry,
+        ),
+    ]
+    await setup_flat()
+    for entry in removed:
+        assert registry.async_get(entry.entity_id) is None
+        assert (
+            sum(
+                f"Removing stale connector-level entity {entry.entity_id};" in r.message
+                for r in caplog.records
+            )
+            == 1
+        )
+    for entry in kept:
+        assert registry.async_get(entry.entity_id) == entry
+
+
+async def test_existing_master_survives_connector_reconfiguration(
+    hass, flat_entry, setup_flat
+):
+    """Keep a renamed flat registry entry, its state and settings through 1 -> 2."""
+    _configure(hass, flat_entry, num_connectors=1)
+    existing = _register(
+        hass,
+        flat_entry,
+        "number.ocpp.test_cpid.maximum_current",
+        suggested_object_id="custom_station_limit",
+    )
+    existing = er.async_get(hass).async_update_entity(
+        existing.entity_id, name="Site ceiling"
+    )
+    _restore(hass, existing.entity_id, 17)
+    await setup_flat()
+    entity = live_entity(hass, existing.entity_id, "number")
+    assert entity.native_value == entity._confirmed_value == 17
+    assert await hass.config_entries.async_unload(flat_entry.entry_id)
+    _configure(hass, flat_entry, num_connectors=2)
+    await setup_flat()
+    reloaded = live_entity(hass, existing.entity_id, "number")
+    assert reloaded is not entity
+    assert reloaded.native_value == reloaded._confirmed_value == 17
+    registry_entry = er.async_get(hass).async_get(existing.entity_id)
+    assert registry_entry.id == existing.id
+    assert registry_entry.name == "Site ceiling"
+
+
+@pytest.mark.parametrize("renamed_connector", [False, True])
+async def test_new_master_ignores_old_restore_data(
+    hass, flat_entry, setup_flat, renamed_connector
+):
+    """Historical flat state and a renamed connector must never seed confirmation."""
+    eid = "number.test_cpid_maximum_current"
+    if renamed_connector:
+        old = _register(
+            hass,
+            flat_entry,
+            "number.ocpp.test_cpid.conn1.maximum_current",
+            suggested_object_id="test_cpid_maximum_current",
+        )
+        assert old.entity_id == eid
+    _restore(hass, eid, 9)
+    central = await setup_flat()
+    entity = _number(hass)
+    assert entity.native_value == 48
+    assert entity._confirmed_value is None
+    cp = _attach_protocol(hass, flat_entry, central)
+    cp.call = AsyncMock(return_value=SimpleNamespace(status="Accepted"))
+    cp.get_configuration = AsyncMock(return_value="Current")
+    await entity.async_set_native_value(18)
+    central.charge_points.clear()
+    assert await hass.config_entries.async_reload(flat_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _number(hass).native_value == _number(hass)._confirmed_value == 18
+
+
+@pytest.fixture
+async def slider16(hass, flat_entry, setup_flat):
+    """Attach a real 1.6 protocol object behind the real number and API."""
+    central = await setup_flat()
+    cp = _attach_protocol(hass, flat_entry, central)
+    cp._active_tx = {1: 111, 2: 222}
+
+    async def configuration(key):
+        return (
+            "Current"
+            if key == ConfigurationKey.charging_schedule_allowed_charging_rate_unit
+            else "3"
+        )
+
+    cp.get_configuration = AsyncMock(side_effect=configuration)
+    cp.call = AsyncMock(return_value=SimpleNamespace(status="Accepted"))
+    return _number(hass), cp, central
+
+
+async def test_slider16_sends_only_station_ceiling(slider16):
+    """Acceptance sends one station profile, including when set to the maximum."""
+    entity, cp, _ = slider16
+    for limit in (16, 48):
+        cp.call.reset_mock()
+        await entity.async_set_native_value(limit)
+        cp.call.assert_awaited_once()
+        req = cp.call.call_args.args[0]
+        assert cp.call.call_args.kwargs == {"suppress": False}
+        assert req.connector_id == 0
+        assert req.cs_charging_profiles == {
+            "chargingProfileId": 1000,
+            "stackLevel": 3,
+            "chargingProfilePurpose": "ChargePointMaxProfile",
+            "chargingProfileKind": "Relative",
+            "chargingSchedule": {
+                "chargingRateUnit": "A",
+                "chargingSchedulePeriod": [{"startPeriod": 0, "limit": float(limit)}],
+            },
+        }
+        assert entity.native_value == entity._confirmed_value == limit
+
+
+@pytest.mark.parametrize(
+    "failure", ["Rejected", "NotSupported", TimeoutError("no reply")]
+)
+@pytest.mark.parametrize("confirmed", [None, 24])
+async def test_slider16_refusal_reverts_without_fallback(slider16, failure, confirmed):
+    """Refusals preserve the last confirmed value and reason with active transactions."""
+    entity, cp, _ = slider16
+    entity._confirmed_value = confirmed
+    if isinstance(failure, Exception):
+        cp.call.side_effect = failure
+    else:
+        cp.call.return_value = SimpleNamespace(status=failure)
+    with pytest.raises(HomeAssistantError) as exc:
+        await entity.async_set_native_value(16)
+    assert str(failure) in str(exc.value.translation_placeholders["message"])
+    assert entity.native_value == entity._confirmed_value == confirmed
+    cp.call.assert_awaited_once()
+    assert (
+        cp.call.call_args.args[0].cs_charging_profiles["chargingProfilePurpose"]
+        == "ChargePointMaxProfile"
+    )
+
+
+async def test_slider16_callerror_through_library(slider16):
+    """Route a real CALLERROR through the OCPP queue and preserve the charger's reason."""
+    entity, cp, _ = slider16
+    sent = []
+
+    async def send(frame):
+        message = json.loads(frame)
+        sent.append(message)
+        response = CallError(
+            message[1], "NotSupported", "station profile unsupported", {}
+        )
+        await cp.route_message(response.to_json())
+
+    cp._connection.send = send
+    cp.call = AsyncMock(wraps=ChargePoint16.call.__get__(cp))
+    with pytest.raises(HomeAssistantError) as exc:
+        await asyncio.wait_for(entity.async_set_native_value(16), timeout=2)
+    assert "NotSupported" in exc.value.translation_placeholders["message"]
+    assert (
+        "station profile unsupported" in exc.value.translation_placeholders["message"]
+    )
+    assert len(sent) == 1
+    assert sent[0][2] == "SetChargingProfile"
+    assert cp.call.call_args.kwargs == {"suppress": False}
+    assert entity.native_value is None
+
+
+async def test_slider16_watt_only_conversion(slider16):
+    """The station route retains the action's measured three-phase watt conversion."""
+    entity, cp, _ = slider16
+    cp.get_configuration = AsyncMock(side_effect=["Power", "3"])
+    metric = cp._metrics[(1, Measurand.voltage.value)]
+    metric.value = 240
+    metric.extra_attr = {"L1": 240, "L2": 240, "L3": 240}
+    await entity.async_set_native_value(16)
+    schedule = cp.call.call_args.args[0].cs_charging_profiles["chargingSchedule"]
+    assert schedule["chargingRateUnit"] == "W"
+    assert schedule["chargingSchedulePeriod"] == [{"startPeriod": 0, "limit": 11520}]
+
+
+async def test_station_without_smart_charging_sends_nothing(slider16):
+    """The backend also guards unsupported chargers when called directly."""
+    entity, cp, _ = slider16
+    cp._attr_supported_features = Profiles.NONE
+    with pytest.raises(HomeAssistantError, match="Smart charging"):
+        await entity.async_set_native_value(16)
+    cp.call.assert_not_awaited()
+    cp.get_configuration.assert_not_awaited()
+    assert entity.native_value is None
+
+
+@pytest.mark.parametrize("connector", [None, 0, 2])
+async def test_service_keeps_connector_fallbacks(slider16, connector):
+    """Omitted, zero and explicit action connectors still use the full legacy chain."""
+    _, cp, central = slider16
+    cp.call.side_effect = [
+        SimpleNamespace(status=s) for s in ("Rejected", "Accepted", "Accepted")
+    ]
+    data = {"devid": "test_cpid", "limit_amps": 16}
+    if connector is not None:
+        data["conn_id"] = connector
+    await central.handle_set_charge_rate(SimpleNamespace(data=data))
+    target = connector or 1
+    requests = [c.args[0] for c in cp.call.call_args_list]
+    assert [
+        (r.connector_id, r.cs_charging_profiles["chargingProfilePurpose"])
+        for r in requests
+    ] == [
+        (0, "ChargePointMaxProfile"),
+        (target, "TxProfile"),
+        (target, "TxDefaultProfile"),
+    ]
+    assert requests[1].cs_charging_profiles["transactionId"] == cp._active_tx[target]
+    assert "transactionId" not in requests[2].cs_charging_profiles
+    assert [r.cs_charging_profiles["chargingProfileId"] for r in requests] == [
+        1000,
+        3000 + target,
+        2000 + target,
+    ]
+
+
+@pytest.mark.parametrize(
+    "limit,status",
+    [
+        (16, "Accepted"),
+        (16, "Rejected"),
+        (48, "Accepted"),
+        (48, "Rejected"),
+        (48, "Unknown"),
+    ],
+)
+async def test_slider201_uses_existing_station_path(
+    hass, flat_entry, setup_flat, limit, status
+):
+    """The new hook retains EVSE 0, the configured clear threshold and refusals."""
+    central = await setup_flat()
+    cp = _attach_protocol(hass, flat_entry, central, "2.0.1")
+    cp.call = AsyncMock(
+        return_value=SimpleNamespace(status=status, status_info="charger reason")
+    )
+    entity = _number(hass)
+    entity._confirmed_value = 24
+    if status == "Rejected":
+        with pytest.raises(HomeAssistantError):
+            await entity.async_set_native_value(limit)
+        assert entity.native_value == 24
+    else:
+        await entity.async_set_native_value(limit)
+        assert entity.native_value == limit
+    cp.call.assert_awaited_once()
+    req = cp.call.call_args.args[0]
+    if limit < 48:
+        assert req.evse_id == 0
+        assert (
+            req.charging_profile["charging_profile_purpose"]
+            == "ChargingStationMaxProfile"
+        )
+    else:
+        assert type(req).__name__ == "ClearChargingProfile"
+        assert req.charging_profile_criteria == {
+            "charging_profile_purpose": "ChargingStationMaxProfile"
+        }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,7 +39,7 @@ from .lifecycle_asserts import (
 # Both single- and multi-connector mocks configure cpid "test_cpid_9001"
 # with at least one connector, so this entity exists in each lifecycle
 # test and its identity across a reload is the load-bearing assertion.
-MAX_CURRENT_EID = "number.test_cpid_9001_connector_1_maximum_current"
+MAX_CURRENT_EID = "number.test_cpid_9001_maximum_current"
 
 
 # We can pass fixtures as defined in conftest.py to tell pytest to use the fixture
@@ -356,7 +356,7 @@ async def test_remove_config_entry_device_removes_charge_point(
     # The surviving sibling's entity is the reload probe: it must be a
     # fresh object after the update-listener reload, while the removed
     # charge point's entity must be gone.
-    sibling_eid = "number.test_cpid_9002_connector_1_maximum_current"
+    sibling_eid = "number.test_cpid_9002_maximum_current"
     entity_before = live_entity(hass, sibling_eid, "number")
 
     assert await async_remove_config_entry_device(hass, config_entry, victim)

--- a/tests/test_reload_offline_charger.py
+++ b/tests/test_reload_offline_charger.py
@@ -81,7 +81,7 @@ async def test_reload_with_charger_offline_keeps_every_platform(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert_platforms_hold(hass, entry.entry_id)
-    eid = "number.test_cpid_9001_connector_1_maximum_current"
+    eid = "number.test_cpid_9001_maximum_current"
     entity_before = live_entity(hass, eid, "number")
     assert entity_before is not None
 
@@ -115,7 +115,7 @@ async def test_a_second_offline_reload_is_also_clean(hass, bypass_websockets, ca
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    eid = "number.test_cpid_9001_connector_1_maximum_current"
+    eid = "number.test_cpid_9001_maximum_current"
     entity_start = live_entity(hass, eid, "number")
 
     assert await hass.config_entries.async_reload(entry.entry_id)

--- a/tests/test_set_charge_rate_v16.py
+++ b/tests/test_set_charge_rate_v16.py
@@ -98,6 +98,43 @@ async def test_custom_profile_path_exception_triggers_notify_and_returns_false(
 
 
 @pytest.mark.asyncio
+async def test_custom_profile_rejected_status_returns_false_without_notify(
+    cp_v16, monkeypatch, caplog
+):
+    """A custom profile the charger answers Rejected returns False and logs, without a notification."""
+    notices = []
+
+    async def fake_notify(msg, title="Ocpp integration"):
+        notices.append(msg)
+        return True
+
+    async def fake_call(_req):
+        return SimpleNamespace(status=ChargingProfileStatus.rejected.value)
+
+    async def fake_get_conf(_key):
+        pytest.fail("get_configuration should not be called for custom profile")
+
+    monkeypatch.setattr(cp_v16, "notify_ha", fake_notify)
+    monkeypatch.setattr(cp_v16, "call", fake_call)
+    monkeypatch.setattr(cp_v16, "get_configuration", fake_get_conf)
+
+    profile = {
+        "chargingProfileId": 123,
+        "stackLevel": 1,
+        "chargingProfileKind": ChargingProfileKindType.relative.value,
+        "chargingProfilePurpose": ChargingProfilePurposeType.charge_point_max_profile.value,
+        "chargingSchedule": {
+            "chargingRateUnit": ChargingRateUnitType.amps.value,
+            "chargingSchedulePeriod": [{"startPeriod": 0, "limit": 16}],
+        },
+    }
+
+    assert await cp_v16.set_charge_rate(profile=profile, conn_id=2) is False
+    assert notices == []
+    assert "Custom SetChargingProfile rejected: Rejected" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_smart_charging_not_supported_returns_false_no_notify(
     cp_v16, monkeypatch
 ):


### PR DESCRIPTION
Closes #2110

### Problem

On a charger with more than one connector the integration created one `Maximum Current` slider per connector, and every one of them wrote the same station-wide profile: `ChargePointMaxProfile` on connector 0 for OCPP 1.6, `ChargingStationMaxProfile` on EVSE 0 for 2.0.1. The slider moved last set the limit for the whole station while the others displayed values the charger was not applying. On 1.6 the shared path also fell back to a `TxProfile` and `TxDefaultProfile` on one connector when the station profile was rejected, so what a slider did depended on the charger's answer.

### Change

- **One `Maximum Current` per charger**, on the charger device, whatever the connector count. The multi-connector branch of the number platform is gone; the single remaining path is the one single-connector chargers already used.
- **Legacy connector sliders are removed at setup.** Registry entries are matched by config entry, integration, number domain and the exact legacy unique id for the charger being set up, so renamed and disabled entries go too, and other chargers' entries are untouched. An existing flat entry keeps its registry identity, customisations and restored value. A newly created master starts at the configured maximum without treating a removed connector slider's state as confirmed, since restore data is keyed by entity id.
- **The slider sends only a station-wide profile.** A new `set_station_charge_rate` hook sits on the base charge point: on 1.6 it sends a single `ChargePointMaxProfile` on connector 0 and reports any other status, CALLERROR or transport failure as an error, after which the slider reverts to its last confirmed value; on 2.0.1 it is the existing managed station path. There is no transaction-profile fallback in the slider, because a `TxDefaultProfile` is a per-transaction default on each connector rather than a shared ceiling, and a `TxProfile` binds one connector.
- **The `ocpp.set_charge_rate` action is unchanged**, including its 1.6 fallback chain on the connector it names.

### Breaking change

@drc38 this one wants the `breaking` label for the release notes; I can't apply labels here.

- On multi-connector chargers `number.<cpid>_connector_N_maximum_current` entities are removed and replaced by one `number.<cpid>_maximum_current`. Dashboards, scripts and automations that reference the old entities need updating.
- The slider-side fallback is removed on all 1.6 chargers, single-connector ones included. A charger that rejects `ChargePointMaxProfile` now shows an error on slider changes; the action keeps the fallback for it.
- The upgrade does not clear profiles stored on the charger. Moving the master updates only the station maximum; existing transaction or default profiles may keep imposing lower limits. `docs/Charge_automation.md` gains upgrade notes covering this, including what `ocpp.clear_profile` clears on each protocol.

### Tests

`tests/test_flat_maximum_current.py` drives the real platform, API and protocol objects: one master on the station device for one and two connectors; cleanup of stale, out-of-range, renamed and disabled legacy entries with a dotted charger id, leaving near-miss unique ids, other chargers, other platforms and other domains alone; a renamed flat entry surviving a one-to-two reconfiguration with its state; a new master ignoring restore data left by a historical flat entity or a renamed connector slider; the 1.6 slider sending exactly one station profile, including at the maximum; Rejected, NotSupported and transport failures reverting without any transaction-profile request while transactions run on both connectors; a real CALLERROR routed back through the OCPP message queue; watt-only conversion through the slider route; the action's fallback chain for an omitted, zero and explicit `conn_id`; and the 2.0.1 set, clear and refusal paths through the new hook. Existing lifecycle tests move to the flat entity id. Full suite passes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Maximum Current is now a single station-wide control, regardless of the number of connectors.
  - The control uses the charger-level entity `number.<cpid>_maximum_current`.
  - Station-wide current limits are supported for OCPP 1.6 and OCPP 2.0.1 chargers.
  - Clearer handling is provided when a charger refuses or reports an error while applying a limit.

- **Documentation**
  - Updated guidance explains the new entity naming, station-wide behavior, profile handling, and upgrade considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->